### PR TITLE
feat: Add Neon branch-per-PR workflow

### DIFF
--- a/.github/workflows/neon-branch.yml
+++ b/.github/workflows/neon-branch.yml
@@ -22,7 +22,7 @@ jobs:
     name: Create Neon Branch
     outputs:
       db_url: ${{ steps.create_neon_branch.outputs.db_url }}
-      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
+      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
     needs: setup
     if: |
       github.event_name == 'pull_request' && (
@@ -58,7 +58,7 @@ jobs:
       - name: Run migrations
         run: npx drizzle-kit push
         env:
-          DATABASE_URL: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
+          DATABASE_URL: ${{ steps.create_neon_branch.outputs.db_url_pooled }}
 
   delete_neon_branch:
     name: Delete Neon Branch


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that creates a preview Neon database branch for each PR
- Runs `drizzle-kit push` against the branch so schema migrations are tested automatically
- Branches auto-expire after 2 weeks and are deleted when the PR closes
- Uses `NEON_API_KEY` secret and `NEON_PROJECT_ID` variable already configured in the repo

## Test plan

- [ ] Open a PR and verify the Neon branch is created in the console
- [ ] Verify migrations run against the preview branch
- [ ] Close the PR and verify the Neon branch is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)