### PR TITLE
feat: Add AssemblyAI transcription client library

### DIFF
--- a/src/lib/__tests__/assemblyai.test.ts
+++ b/src/lib/__tests__/assemblyai.test.ts
@@ -58,6 +58,23 @@ describe("submitTranscription", () => {
       submitTranscription("https://example.com/audio.mp3")
     ).rejects.toThrow("AssemblyAI API error: 401 - Unauthorized");
   });
+
+  it("throws when response is missing transcript ID", async () => {
+    vi.stubEnv("ASSEMBLYAI_API_KEY", "test-api-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: "queued" }),
+      })
+    );
+
+    await expect(
+      submitTranscription("https://example.com/audio.mp3")
+    ).rejects.toThrow(
+      "AssemblyAI API error: submit response did not include a transcript ID"
+    );
+  });
 });
 
 describe("getTranscriptionStatus", () => {
@@ -135,6 +152,21 @@ describe("getTranscriptionStatus", () => {
 
     await expect(getTranscriptionStatus("bad-id")).rejects.toThrow(
       "AssemblyAI API error: 404 - Not found"
+    );
+  });
+
+  it("throws on malformed response missing id or status", async () => {
+    vi.stubEnv("ASSEMBLYAI_API_KEY", "test-api-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: "some text" }),
+      })
+    );
+
+    await expect(getTranscriptionStatus("transcript-123")).rejects.toThrow(
+      "AssemblyAI API error: invalid response from status check"
     );
   });
 });

--- a/src/lib/assemblyai.ts
+++ b/src/lib/assemblyai.ts
@@ -56,7 +56,12 @@ export async function submitTranscription(audioUrl: string): Promise<string> {
   }
 
   const data = await response.json();
-  return data.id as string;
+  if (typeof data?.id !== "string" || !data.id) {
+    throw new Error(
+      "AssemblyAI API error: submit response did not include a transcript ID"
+    );
+  }
+  return data.id;
 }
 
 // Get the current status of a transcription
@@ -76,9 +81,14 @@ export async function getTranscriptionStatus(
   }
 
   const data = await response.json();
+  if (typeof data?.id !== "string" || typeof data?.status !== "string") {
+    throw new Error(
+      "AssemblyAI API error: invalid response from status check"
+    );
+  }
   return {
     id: data.id,
-    status: data.status,
+    status: data.status as TranscriptionStatus,
     text: data.text ?? null,
     error: data.error ?? null,
   };


### PR DESCRIPTION
## Summary

- Add `src/lib/assemblyai.ts` — server-side client for AssemblyAI's transcription REST API
- Exports `submitTranscription`, `getTranscriptionStatus`, and `transcribeAudio` (high-level submit + poll)
- Uses direct `fetch` calls following existing `podcastindex.ts` / `openrouter.ts` patterns (runtime env var access, typed responses)
- Exponential backoff polling (5s initial, 1.5x factor, 30s cap, 30min max wait)
- Add 10 unit tests in `src/lib/__tests__/assemblyai.test.ts` with mocked API calls

Closes #14

## Test plan

- [x] `npm run lint` — zero warnings/errors
- [x] `npm run test` — 116 tests pass (10 new for assemblyai)
- [x] `npm run build` — production build succeeds
- [ ] Verify `submitTranscription` sends correct POST to `/v2/transcript` with `audio_url`
- [ ] Verify `getTranscriptionStatus` polls GET `/v2/transcript/{id}` correctly
- [ ] Verify `transcribeAudio` handles completed, error, and timeout cases
- [ ] Verify API key is read at runtime (not module load time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)