### PR TITLE
fix: Redirect authenticated users from landing page to dashboard (#50)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,8 @@ Secrets are managed via **Doppler** (not `.env` files). Run `doppler setup` afte
 
 Available environment variables:
 - `CLERK_SECRET_KEY` — Clerk backend auth
+- `CLERK_SIGN_IN_FORCE_REDIRECT_URL` — Post-sign-in redirect URL (e.g. `/dashboard`)
+- `CLERK_SIGN_UP_FORCE_REDIRECT_URL` — Post-sign-up redirect URL (e.g. `/dashboard`)
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — Clerk frontend auth
 - `DATABASE_URL` — Neon Postgres connection string
 - `OPENROUTER_API_KEY` — OpenRouter AI API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Authenticated users are now redirected from landing page to dashboard after login (#50)
+
 ### Changed
 - Rate limiting upgraded from in-memory to distributed (Postgres-backed) for serverless compatibility
 - CI workflow simplified to quality checks only (lint, test, Storybook); Vercel handles builds and deploys

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -65,6 +65,8 @@ Most `package.json` scripts are wrapped with `doppler run --`, which injects env
 | `NEXT_PUBLIC_APP_URL` | Public | Application URL (inlined at build time) |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Public | Clerk publishable key (inlined at build time) |
 | `CLERK_SECRET_KEY` | Server | Clerk secret key |
+| `CLERK_SIGN_IN_FORCE_REDIRECT_URL` | Server | URL to redirect to after sign-in (e.g. `/dashboard`) |
+| `CLERK_SIGN_UP_FORCE_REDIRECT_URL` | Server | URL to redirect to after sign-up (e.g. `/dashboard`) |
 | `TRIGGER_SECRET_KEY` | Server | Trigger.dev secret key (background jobs) |
 | `ASSEMBLYAI_API_KEY` | Server | AssemblyAI transcription API key |
 

--- a/src/app/__tests__/middleware.test.ts
+++ b/src/app/__tests__/middleware.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextFetchEvent } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+
+type MiddlewareCallback = (auth: unknown, req: NextRequest) => Promise<unknown>;
+
+function createClerkMock(userId: string | null, mockProtect?: ReturnType<typeof vi.fn>) {
+  return {
+    clerkMiddleware: (cb: MiddlewareCallback) => {
+      return async (req: NextRequest) => {
+        const protect = mockProtect ?? vi.fn();
+        const authFn = Object.assign(vi.fn().mockResolvedValue({ userId }), { protect });
+        return cb(authFn, req);
+      };
+    },
+    createRouteMatcher: (patterns: string[]) => {
+      return (req: NextRequest) => {
+        return patterns.some((pattern) => {
+          const regex = new RegExp(`^${pattern.replace("(.*)", ".*")}$`);
+          return regex.test(req.nextUrl.pathname);
+        });
+      };
+    },
+  };
+}
+
+// Our mock doesn't use the event, so a stub satisfies the type
+const stubEvent = {} as NextFetchEvent;
+
+describe("middleware", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("redirects authenticated users from / to /dashboard", async () => {
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock("user_123"));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/");
+    const response = await middleware(req, stubEvent);
+
+    expect(response).toBeInstanceOf(NextResponse);
+    expect((response as NextResponse).headers.get("location")).toBe(
+      "http://localhost:3000/dashboard"
+    );
+  });
+
+  it("does not redirect unauthenticated users from /", async () => {
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/");
+    const response = await middleware(req, stubEvent);
+
+    if (response instanceof NextResponse) {
+      expect(response.headers.get("location")).not.toBe(
+        "http://localhost:3000/dashboard"
+      );
+    }
+  });
+
+  it("does not redirect authenticated users from other routes", async () => {
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock("user_123"));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/dashboard");
+    const response = await middleware(req, stubEvent);
+
+    if (response instanceof NextResponse) {
+      expect(response.headers.get("location")).not.toBe(
+        "http://localhost:3000/dashboard"
+      );
+    }
+  });
+
+  it("calls auth.protect() for protected routes", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/dashboard");
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).toHaveBeenCalled();
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -8,6 +9,13 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, req) => {
+  const { userId } = await auth();
+
+  // Redirect authenticated users from landing page to dashboard
+  if (userId && req.nextUrl.pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+
   if (!isPublicRoute(req)) {
     await auth.protect();
   }


### PR DESCRIPTION
## Summary
- Authenticated users visiting `/` are now redirected to `/dashboard` via Clerk middleware
- Added `CLERK_SIGN_IN_FORCE_REDIRECT_URL` and `CLERK_SIGN_UP_FORCE_REDIRECT_URL` Doppler env vars to redirect after Clerk sign-in/sign-up flows
- Added 4 middleware unit tests covering redirect, no-redirect, and route protection scenarios
- Updated docs (AGENTS.md, secrets-management.md) to document new env vars

Closes #50

## Test plan
- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — 208 tests pass (24 files), including 4 new middleware tests
- [x] `bunx tsc --noEmit` — zero TypeScript errors
- [x] `bun run build` — production build succeeds
- [ ] Manual: sign in → verify redirect to `/dashboard`
- [ ] Manual: visit `/` while authenticated → verify redirect to `/dashboard`
- [ ] Manual: visit `/dashboard` while authenticated → no redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)