### PR TITLE
chore: Add project-manager plugin to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,8 @@
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
     "devops-tools@cc-skills": true,
-    "doc-tools@cc-skills": true
+    "doc-tools@cc-skills": true,
+    "project-manager@rube-cc-skills": true
   },
   "sandbox": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- Added `project-manager@rube-cc-skills` plugin to `.claude/settings.json`

## Test plan
- [x] Lint passes
- [x] Tests pass (210/210)
- [x] Plugin loads after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)