### PR TITLE
refactor: Replace unsafe PodcastIndexPodcast type assertions with PodcastSearchResult DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Episode detail page now returns 404 instead of 500 for invalid/missing PodcastIndex episode IDs (#52)
 - Preview deployments no longer get 500 errors from schema drift — `drizzle-kit push` now runs in the Vercel build targeting the correct Neon branch
 
+### Refactored
+- Replaced unsafe `as PodcastIndexPodcast` type assertions in search route with `PodcastSearchResult` DTO (#72)
+
 ### Removed
 - GitHub Actions Neon branch workflow (`.github/workflows/neon-branch.yml`) — replaced by `vercel-build` script to eliminate dual Neon branch problem
 

--- a/src/app/(app)/discover/page.tsx
+++ b/src/app/(app)/discover/page.tsx
@@ -6,12 +6,12 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { SearchResults } from "@/components/podcasts/search-results";
 import { RssFeedForm } from "@/components/podcasts/rss-feed-form";
-import type { PodcastIndexPodcast } from "@/lib/podcastindex";
+import type { PodcastSearchResult } from "@/lib/podcastindex";
 
 export default function DiscoverPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
-  const [podcasts, setPodcasts] = useState<PodcastIndexPodcast[]>([]);
+  const [podcasts, setPodcasts] = useState<PodcastSearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/app/api/podcasts/search/route.ts
+++ b/src/app/api/podcasts/search/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   searchPodcasts,
   searchByPerson,
-  type PodcastIndexPodcast,
+  type PodcastSearchResult,
 } from "@/lib/podcastindex";
 import { searchLocalPodcasts } from "@/lib/podcast-search";
 
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
         searchLocalPodcasts(query),
       ]);
 
-    const merged: PodcastIndexPodcast[] = [];
+    const merged: PodcastSearchResult[] = [];
     const seenIds = new Set<string>();
 
     // Layer 1a: byterm results (primary)
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
           title: info.title,
           image: info.feedImage,
           artwork: info.feedImage,
-        } as PodcastIndexPodcast);
+        });
       });
     }
 
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest) {
             id: numericId,
             title: local.title,
             author: local.publisher ?? "",
-          } as PodcastIndexPodcast);
+          });
         }
       }
     }

--- a/src/components/podcasts/podcast-card.tsx
+++ b/src/components/podcasts/podcast-card.tsx
@@ -4,13 +4,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { PodcastIndexPodcast } from "@/lib/podcastindex";
+import type { PodcastSearchResult } from "@/lib/podcastindex";
 
 interface PodcastCardProps {
-  podcast: PodcastIndexPodcast;
+  podcast: PodcastSearchResult;
 }
 
 export function PodcastCard({ podcast }: PodcastCardProps) {
+  const imageUrl = podcast.artwork || podcast.image;
   const categories = podcast.categories
     ? Object.values(podcast.categories).slice(0, 3)
     : [];
@@ -21,9 +22,9 @@ export function PodcastCard({ podcast }: PodcastCardProps) {
         <CardContent className="p-4">
           <div className="flex gap-4">
             <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-lg bg-muted">
-              {podcast.artwork || podcast.image ? (
+              {imageUrl ? (
                 <Image
-                  src={podcast.artwork || podcast.image}
+                  src={imageUrl}
                   alt={podcast.title}
                   fill
                   className="object-cover"
@@ -72,7 +73,7 @@ export function PodcastCard({ podcast }: PodcastCardProps) {
                     ))}
                   </div>
                 )}
-                {podcast.episodeCount > 0 && (
+                {podcast.episodeCount != null && podcast.episodeCount > 0 && (
                   <span className="text-xs text-muted-foreground">
                     {podcast.episodeCount} episodes
                   </span>

--- a/src/components/podcasts/search-results.tsx
+++ b/src/components/podcasts/search-results.tsx
@@ -2,10 +2,10 @@
 
 import { PodcastCard } from "./podcast-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { PodcastIndexPodcast } from "@/lib/podcastindex";
+import type { PodcastSearchResult } from "@/lib/podcastindex";
 
 interface SearchResultsProps {
-  podcasts: PodcastIndexPodcast[];
+  podcasts: PodcastSearchResult[];
   isLoading: boolean;
   error: string | null;
   query: string;

--- a/src/lib/podcastindex.ts
+++ b/src/lib/podcastindex.ts
@@ -47,6 +47,26 @@ export interface PodcastIndexPodcast {
   newestItemPubdate: number;
 }
 
+/**
+ * Lightweight DTO for podcast search results. Covers the union of fields
+ * populated by byterm (full), byperson (partial), and local fuzzy (partial)
+ * search layers — only the fields the search UI actually reads.
+ *
+ * PodcastIndexPodcast is structurally assignable to this type, so full
+ * API results can be used without conversion.
+ */
+export interface PodcastSearchResult {
+  id: number;
+  title: string;
+  author?: string;
+  ownerName?: string;
+  image?: string;
+  artwork?: string;
+  description?: string;
+  categories?: Record<string, string>;
+  episodeCount?: number;
+}
+
 export interface PodcastIndexEpisode {
   id: number | string;
   title: string;


### PR DESCRIPTION
## Summary

Closes #72

- Defined a `PodcastSearchResult` interface in `src/lib/podcastindex.ts` with only the 9 fields the search UI actually reads (`id`, `title`, `author?`, `ownerName?`, `image?`, `artwork?`, `description?`, `categories?`, `episodeCount?`)
- Removed both `as PodcastIndexPodcast` type assertions from the search route — partial objects from byperson and local fuzzy layers now satisfy the type without casts
- Updated `PodcastCard`, `SearchResults`, and `DiscoverPage` to use the new type
- Fixed two strict-mode type errors in `PodcastCard` exposed by the optional fields (`Image` src narrowing, `episodeCount` nullability guard)

`PodcastIndexPodcast` remains structurally assignable to `PodcastSearchResult`, so existing consumers (recommendations, dashboard, tests, stories) work without changes.

## Test plan

- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — 252/252 tests pass (including `podcast-card.test.tsx` and `podcasts-search.test.ts`)
- [x] `bun run build` — production build succeeds with no type errors
- [x] No `as PodcastIndexPodcast` casts remain in `src/app/api/podcasts/search/route.ts`
- [x] `PodcastCard` test still passes with full `PodcastIndexPodcast` mock (structural typing)
- [ ] Manual: search for a podcast on `/discover` and verify results render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)