### PR TITLE
chore: Add jules-review and council plugins to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,7 +56,9 @@
     "claude-md-management@claude-plugins-official": true,
     "devops-tools@cc-skills": true,
     "doc-tools@cc-skills": true,
-    "project-manager@rube-cc-skills": true
+    "project-manager@rube-cc-skills": true,
+    "jules-review@rube-cc-skills": true,
+    "council@rube-cc-skills": true
   },
   "sandbox": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- Enables `jules-review` plugin for reviewing Jules (Google AI agent) pull requests using AI council
- Enables `council` plugin for external AI council consultation for thorough reviews and consensus-driven decisions

These plugins enhance code review capabilities by providing access to external AI perspectives (Gemini, Codex, Qwen, GLM-4.7) when explicitly requested.

## Test plan
- [x] Verified settings.json syntax is valid JSON
- [x] Lint and tests pass
- [x] Plugins are properly formatted in the enabled skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)