### PR TITLE
chore: add dlc plugin to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,7 +58,8 @@
     "doc-tools@cc-skills": true,
     "project-manager@rube-cc-skills": true,
     "jules-review@rube-cc-skills": true,
-    "council@rube-cc-skills": true
+    "council@rube-cc-skills": true,
+    "dlc@rube-cc-skills": true
   },
   "sandbox": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- Adds the `dlc@rube-cc-skills` plugin to `.claude/settings.json`

## Test plan
- [x] Lint passes
- [x] All 261 tests pass
- [x] Plugin installs and loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled new plugin capabilities to expand application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->