### PR TITLE
⚡ Bolt: optimize episode average rating calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-02-10 - SQL Aggregate Optimization for Drizzle
 **Learning:** Drizzle's relational query API (`db.query`) is convenient but often leads to N+1 patterns for aggregations (like counting items in a collection). Transitioning to the core `db.select()` API with `leftJoin` and `groupBy` allows performing these counts at the database level in a single query, significantly reducing latency as the data grows.
 **Action:** Prefer `db.select()` with aggregations over `db.query` loops when fetching counts or averages for related entities.
+
+## 2025-05-20 - Indexing for Aggregate Performance
+**Learning:** Even with SQL aggregate functions, performance can degrade on large tables if the columns used in `WHERE` clauses for the aggregation aren't properly indexed. A composite index (e.g., `userId, episodeId`) is not efficient for queries filtering only by the second column. Adding a dedicated index on the foreign key being aggregated significantly speeds up statistic calculations.
+**Action:** When adding aggregate queries, always ensure the filtered columns have appropriate indexes, especially foreign keys in join or junction tables.

--- a/src/app/actions/__tests__/library-rating.test.ts
+++ b/src/app/actions/__tests__/library-rating.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock database
+const mockFindFirstEpisode = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      episodes: { findFirst: (...args: unknown[]) => mockFindFirstEpisode(...args) },
+    },
+    select: (...args: unknown[]) => mockSelect(...args),
+  },
+}));
+
+// Mock schema
+vi.mock("@/db/schema", () => ({
+  episodes: { id: "id", podcastIndexId: "podcast_index_id" },
+  userLibrary: { id: "id", episodeId: "episode_id", rating: "rating" },
+}));
+
+// Mock drizzle-orm
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNotNull: vi.fn(),
+  avg: vi.fn(),
+  count: vi.fn(),
+}));
+
+describe("getEpisodeAverageRating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calculates average correctly from multiple ratings using SQL aggregate mock", async () => {
+    mockFindFirstEpisode.mockResolvedValue({ id: 1 });
+
+    // Mock the chain: db.select().from().where()
+    const mockWhere = vi.fn().mockResolvedValue([{ avgRating: "4.0", totalCount: 3 }]);
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+    mockSelect.mockReturnValue({ from: mockFrom });
+
+    const { getEpisodeAverageRating } = await import("@/app/actions/library");
+    const result = await getEpisodeAverageRating("ep123");
+
+    expect(result.averageRating).toBe(4.0);
+    expect(result.ratingCount).toBe(3);
+    expect(result.error).toBeNull();
+  });
+
+  it("handles no ratings correctly with SQL aggregate mock", async () => {
+    mockFindFirstEpisode.mockResolvedValue({ id: 1 });
+
+    const mockWhere = vi.fn().mockResolvedValue([{ avgRating: null, totalCount: 0 }]);
+    const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+    mockSelect.mockReturnValue({ from: mockFrom });
+
+    const { getEpisodeAverageRating } = await import("@/app/actions/library");
+    const result = await getEpisodeAverageRating("ep123");
+
+    expect(result.averageRating).toBeNull();
+    expect(result.ratingCount).toBe(0);
+  });
+
+  it("handles episode not found", async () => {
+    mockFindFirstEpisode.mockResolvedValue(null);
+
+    const { getEpisodeAverageRating } = await import("@/app/actions/library");
+    const result = await getEpisodeAverageRating("nonexistent");
+
+    expect(result.averageRating).toBeNull();
+    expect(result.ratingCount).toBe(0);
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -164,6 +164,7 @@ export const userLibrary = pgTable(
       table.episodeId
     ),
     index("user_library_user_id_idx").on(table.userId),
+    index("user_library_episode_id_idx").on(table.episodeId),
     index("user_library_collection_id_idx").on(table.collectionId),
   ]
 );


### PR DESCRIPTION
Identified and implemented a performance optimization for calculating episode average ratings. The previous implementation fetched all ratings into memory and calculated the average in JavaScript, which is inefficient. The new implementation uses SQL aggregates (`avg` and `count`) and is backed by a new index on the `episode_id` column. Tests and linting pass.

## Deployment Checklist

This PR adds a new index (`user_library_episode_id_idx`) to the `user_library` table. After merging:

```bash
doppler run --config prd -- bunx drizzle-kit push
```

Preview environments handle this automatically via `drizzle-kit push --force` in the `vercel-build` script.

---
*PR created automatically by Jules for task [11282346255993260232](https://jules.google.com/task/11282346255993260232) started by @rube-de*