### PR TITLE
fix: persist discover search query in URL to survive back navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Discover page search query now persists in URL (`?q=`) — back navigation, bookmarks, and shared links restore search state (#85)
 - SSRF vulnerability in podcast RSS subscription — validates URLs before fetching (#77)
 - Authenticated users are now redirected from landing page to dashboard after login (#50)
 - Episode detail page now returns 404 instead of 500 for invalid/missing PodcastIndex episode IDs (#52)

--- a/src/app/(app)/discover/__tests__/discover-content.test.tsx
+++ b/src/app/(app)/discover/__tests__/discover-content.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DiscoverContent } from "../discover-content";
+
+// Mock next/navigation with controllable searchParams
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/discover",
+}));
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("DiscoverContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ podcasts: [] }),
+    });
+  });
+
+  it("renders with empty state when no URL params", () => {
+    render(<DiscoverContent />);
+
+    expect(
+      screen.getByPlaceholderText("Search podcasts...")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+  });
+
+  it("auto-fetches when URL has q param", async () => {
+    mockSearchParams = new URLSearchParams("q=lex");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        podcasts: [
+          {
+            id: 1,
+            title: "Lex Fridman Podcast",
+            author: "Lex Fridman",
+            image: "",
+            description: "Test",
+            url: "https://example.com",
+            categories: {},
+          },
+        ],
+      }),
+    });
+
+    render(<DiscoverContent />);
+
+    expect(screen.getByDisplayValue("lex")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/podcasts/search?q=lex&max=20"
+      );
+    });
+  });
+
+  it("updates URL on search submission", async () => {
+    const user = userEvent.setup();
+    render(<DiscoverContent />);
+
+    await user.type(
+      screen.getByPlaceholderText("Search podcasts..."),
+      "technology"
+    );
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/discover?q=technology"
+    );
+  });
+
+  it("strips URL params when submitting empty query", async () => {
+    const user = userEvent.setup();
+    mockSearchParams = new URLSearchParams("q=something");
+    render(<DiscoverContent />);
+
+    await user.clear(screen.getByPlaceholderText("Search podcasts..."));
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(mockReplace).toHaveBeenCalledWith("/discover");
+  });
+
+  it("displays error when fetch fails", async () => {
+    mockSearchParams = new URLSearchParams("q=failing");
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Service unavailable" }),
+    });
+
+    render(<DiscoverContent />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+
+  it("trims whitespace from query before updating URL", async () => {
+    const user = userEvent.setup();
+    render(<DiscoverContent />);
+
+    await user.type(
+      screen.getByPlaceholderText("Search podcasts..."),
+      "  lex fridman  "
+    );
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/discover?q=lex%20fridman"
+    );
+  });
+
+  it("does not fetch when URL has no q param", () => {
+    render(<DiscoverContent />);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/discover/__tests__/discover-content.test.tsx
+++ b/src/app/(app)/discover/__tests__/discover-content.test.tsx
@@ -109,7 +109,7 @@ describe("DiscoverContent", () => {
     render(<DiscoverContent />);
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled();
+      expect(screen.getByText("Service unavailable")).toBeInTheDocument();
     });
   });
 

--- a/src/app/(app)/discover/discover-content.tsx
+++ b/src/app/(app)/discover/discover-content.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { SearchResults } from "@/components/podcasts/search-results";
+import { RssFeedForm } from "@/components/podcasts/rss-feed-form";
+import type { PodcastSearchResult } from "@/lib/podcastindex";
+
+export function DiscoverContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const urlQuery = searchParams.get("q") ?? "";
+
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const [podcasts, setPodcasts] = useState<PodcastSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setPodcasts([]);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/podcasts/search?q=${encodeURIComponent(query)}&max=20`
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to search podcasts");
+      }
+
+      const data = await response.json();
+      setPodcasts(data.podcasts || []);
+    } catch (err) {
+      console.error("Search error:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to search podcasts"
+      );
+      setPodcasts([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setSearchQuery(urlQuery);
+    if (urlQuery) {
+      handleSearch(urlQuery);
+    } else {
+      setPodcasts([]);
+      setError(null);
+    }
+  }, [urlQuery, handleSearch]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = searchQuery.trim();
+    router.replace(
+      trimmed ? `/discover?q=${encodeURIComponent(trimmed)}` : "/discover"
+    );
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search podcasts..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? "Searching..." : "Search"}
+        </Button>
+      </form>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-background px-2 text-muted-foreground">
+            or add by RSS feed
+          </span>
+        </div>
+      </div>
+
+      <RssFeedForm />
+
+      <SearchResults
+        podcasts={podcasts}
+        isLoading={isLoading}
+        error={error}
+        query={urlQuery}
+      />
+    </>
+  );
+}

--- a/src/app/(app)/discover/discover-content.tsx
+++ b/src/app/(app)/discover/discover-content.tsx
@@ -54,12 +54,7 @@ export function DiscoverContent() {
 
   useEffect(() => {
     setSearchQuery(urlQuery);
-    if (urlQuery) {
-      handleSearch(urlQuery);
-    } else {
-      setPodcasts([]);
-      setError(null);
-    }
+    handleSearch(urlQuery);
   }, [urlQuery, handleSearch]);
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/app/(app)/discover/page.tsx
+++ b/src/app/(app)/discover/page.tsx
@@ -1,58 +1,21 @@
-"use client";
+import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DiscoverContent } from "./discover-content";
 
-import { useState, useCallback } from "react";
-import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { SearchResults } from "@/components/podcasts/search-results";
-import { RssFeedForm } from "@/components/podcasts/rss-feed-form";
-import type { PodcastSearchResult } from "@/lib/podcastindex";
+function DiscoverPageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-2">
+        <Skeleton className="h-10 flex-1" />
+        <Skeleton className="h-10 w-24" />
+      </div>
+      <Skeleton className="h-4 w-48 mx-auto" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+}
 
 export default function DiscoverPage() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [submittedQuery, setSubmittedQuery] = useState("");
-  const [podcasts, setPodcasts] = useState<PodcastSearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSearch = useCallback(async (query: string) => {
-    if (!query.trim()) {
-      setPodcasts([]);
-      setSubmittedQuery("");
-      setError(null);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-    setSubmittedQuery(query);
-
-    try {
-      const response = await fetch(
-        `/api/podcasts/search?q=${encodeURIComponent(query)}&max=20`
-      );
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Failed to search podcasts");
-      }
-
-      const data = await response.json();
-      setPodcasts(data.podcasts || []);
-    } catch (err) {
-      console.error("Search error:", err);
-      setError(err instanceof Error ? err.message : "Failed to search podcasts");
-      setPodcasts([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    handleSearch(searchQuery);
-  };
-
   return (
     <div className="space-y-6">
       <div>
@@ -62,41 +25,9 @@ export default function DiscoverPage() {
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="flex gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search podcasts..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-          />
-        </div>
-        <Button type="submit" disabled={isLoading}>
-          {isLoading ? "Searching..." : "Search"}
-        </Button>
-      </form>
-
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t" />
-        </div>
-        <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">
-            or add by RSS feed
-          </span>
-        </div>
-      </div>
-
-      <RssFeedForm />
-
-      <SearchResults
-        podcasts={podcasts}
-        isLoading={isLoading}
-        error={error}
-        query={submittedQuery}
-      />
+      <Suspense fallback={<DiscoverPageSkeleton />}>
+        <DiscoverContent />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Persist the discover page search query in URL search params (`?q=`) so back navigation, bookmarks, and shared links restore the search state
- Split the discover page into a server-component Suspense wrapper (`page.tsx`) and a client `DiscoverContent` component that reads/writes URL via `useSearchParams` + `router.replace`
- Eliminated `submittedQuery` state — the URL `q` param is now the single source of truth for the submitted query
- Added 7 unit tests covering empty state, URL-driven auto-fetch, form submission, URL update, empty query cleanup, error handling, and whitespace trimming

## Test plan

- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — 294/294 tests pass (7 new for DiscoverContent)
- [x] `bun run build` — successful
- [ ] `VERIFY:` After searching, URL updates to `/discover?q={searchTerm}`
- [ ] `VERIFY:` Back navigation restores search term and auto-fetches results
- [ ] `VERIFY:` Direct visit to `/discover?q=lex` triggers search on page load
- [ ] `VERIFY:` Empty search clears `?q=` param
- [ ] `VERIFY:` URL updates use `router.replace` (no history pollution)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Discover page loading with a skeleton while content loads.

* **Bug Fixes**
  * Search queries on the Discover page now persist in the URL, enabling bookmarks, shared links, and back navigation to restore your search state.

* **Tests**
  * Added comprehensive test coverage for Discover page search behavior, URL handling, and error/loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->