### PR TITLE
chore: clean up Neon preview branches on PR close

### DIFF
--- a/.github/workflows/neon-cleanup.yml
+++ b/.github/workflows/neon-cleanup.yml
@@ -1,0 +1,15 @@
+name: Clean up Neon preview branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: calm-sound-10354246
+          branch: preview/${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - CI workflow simplified to quality checks only (lint, test, Storybook); Vercel handles builds and deploys
 
 ### Added
+- GitHub Actions workflow to delete Neon preview branches on PR close, preventing branch accumulation on the free plan
 - Fuzzy podcast search with typo tolerance, host name matching, and local MiniSearch index (#55)
 - Trigger.dev dry-run validation step in CI for PR builds (#25)
 - Scheduled feed polling via Trigger.dev (every 2h) with manual refresh server action (#24)


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that deletes the Neon preview database branch when a PR is closed/merged
- Uses the official `neondatabase/delete-branch-action@v3` targeting `preview/<branch-name>` (the naming convention used by the Neon-Vercel integration)
- Prevents Neon branch accumulation that can exceed the free-tier 10-branch limit

## Context
The Neon-Vercel integration creates a preview database branch per PR but doesn't reliably clean them up on merge. Vercel's preview deployment retention setting is too blunt — it would also delete deployments for still-open PRs. This workflow targets only closed PRs.

## Test plan
- [ ] Merge a PR and verify the corresponding Neon preview branch is deleted in the Neon Console
- [ ] Confirm `NEON_API_KEY` secret is set in the GitHub repo

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated cleanup of Neon preview branches when pull requests are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->