### PR TITLE
refactor: consolidate getEpisodeAverageRating into single JOIN query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - GitHub Actions Neon branch workflow (`.github/workflows/neon-branch.yml`) — replaced by `vercel-build` script to eliminate dual Neon branch problem
 
 ### Changed
+- Consolidated `getEpisodeAverageRating` into a single JOIN query, reducing database round-trips from 2 to 1
 - Optimized dashboard stats retrieval by using SQL `COUNT(*)` aggregation instead of in-memory counting, significantly reducing memory and network overhead (#71)
 - Optimized collections sidebar loading by eliminating N+1 database queries in `getUserCollections` (single SQL aggregation via LEFT JOIN + GROUP BY)
 - PodcastIndex API authentication headers are now stabilized to 30-second windows, enabling Next.js `fetch` caching and reducing redundant network requests


### PR DESCRIPTION
## Summary

- Replaced two sequential queries in `getEpisodeAverageRating` with a single `innerJoin` query, reducing database round-trips from 2 to 1
- Changed `count(userLibrary.id)` to `count(userLibrary.rating)` for better semantic correctness
- Updated unit test mocks to match the new single-query chain (`select → from → innerJoin → where`)

## Test plan

- [x] All 3 unit tests in `library-rating.test.ts` pass (correct average, no ratings, episode not found)
- [x] Full test suite passes (301/301)
- [x] ESLint clean
- [x] Production build succeeds
- [x] Only `getEpisodeAverageRating` function modified — no changes to other functions in `library.ts`

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the episode average rating calculation process to enhance overall application responsiveness and efficiency

* **Code Refactoring**
  * Streamlined the implementation of rating retrieval functionality to improve system performance while preserving all existing user-facing capabilities

* **Testing Updates**
  * Updated the test suite to validate the optimized rating retrieval implementation and ensure continued accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->