### PR TITLE
feat: add persistent in-app audio player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,15 @@ src/
     └── helpers/              # Shared helpers for trigger tasks
 ```
 
+## Architecture Decision Records
+
+ADRs are stored in `docs/adr/`. Read them before designing changes that touch the same areas:
+
+- [ADR-001: Distributed Rate Limiting](docs/adr/001-distributed-rate-limiting.md)
+- [ADR-002: Preview Database Migrations](docs/adr/002-preview-database-migrations.md)
+- [ADR-003: Scheduled Feed Polling](docs/adr/003-scheduled-feed-polling.md)
+- [ADR-004: Audio Player State Management](docs/adr/004-audio-player-state-management.md)
+
 ## Architecture patterns
 
 - **App Router with route groups:** `(auth)` for sign-in/sign-up, `(app)` for authenticated pages with shared sidebar layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - CI workflow simplified to quality checks only (lint, test, Storybook); Vercel handles builds and deploys
 
 ### Added
+- Persistent in-app audio player with play/pause, seek, skip ±15s, playback speed, volume, and OS media controls via Media Session API (#93)
 - GitHub Actions workflow to delete Neon preview branches on PR close, preventing branch accumulation on the free plan
 - Fuzzy podcast search with typo tolerance, host name matching, and local MiniSearch index (#55)
 - Trigger.dev dry-run validation step in CI for PR builds (#25)

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@trigger.dev/react-hooks": "^4.3.3",
         "@trigger.dev/sdk": "^4.3.3",
@@ -414,6 +415,8 @@
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
 
     "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
+
+    "@radix-ui/react-slider": ["@radix-ui/react-slider@1.3.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 

--- a/docs/adr/004-audio-player-state-management.md
+++ b/docs/adr/004-audio-player-state-management.md
@@ -1,0 +1,69 @@
+# ADR-004: Use React Context for Global Audio Player State
+
+**Status:** Proposed
+**Date:** 2026-02-13
+**Issue:** [#93](https://github.com/Chalet-Labs/contentgenie/issues/93)
+
+## Context
+
+Issue #93 adds a persistent in-app audio player that stays visible across all `(app)` routes while audio is playing. The player needs global state shared between the episode page (triggers playback), the player bar (displays controls), and sub-components (seek bar, playback speed, volume). The state includes:
+
+- Current episode metadata (id, title, podcast name, artwork URL, audio URL)
+- Playback state (isPlaying, isBuffering, hasError)
+- Timing (currentTime, duration, buffered) — updated ~4x/sec during playback
+- User preferences (playbackSpeed, volume) — persisted in localStorage
+
+The `<audio>` HTML element must live in a React ref that survives navigation between pages. The state management solution must colocate the audio ref with the state and provide stable action dispatchers to avoid unnecessary re-renders.
+
+## Options Considered
+
+### Option A: React Context with triple split (chosen)
+
+Three nested contexts in a single provider component:
+
+1. **AudioPlayerAPIContext** — stable action dispatchers (`playEpisode`, `togglePlay`, `seek`, `skipForward`, `skipBack`, `setPlaybackSpeed`, `setVolume`, `closePlayer`). Value is `useMemo(() => actions, [])` — the actions close over `audioRef.current` lazily, so their identity never changes. Consumers that only call actions never re-render.
+2. **AudioPlayerStateContext** — playback state (`currentEpisode`, `isPlaying`, `isVisible`, `playbackSpeed`, `volume`, `duration`, `isBuffering`, `hasError`, `errorMessage`). Managed via `useReducer`. Re-renders only on user-initiated actions (play, pause, episode switch, speed change).
+3. **AudioPlayerProgressContext** — high-frequency timing (`currentTime`, `buffered`). Updated via `useState` on every `timeupdate` event (~4x/sec). Only consumed by the seek bar component.
+
+- **Pros:** Zero new dependencies. Natural colocation of `<audio>` ref with state. Triple split eliminates unnecessary re-renders — the episode page listen button reads State + API but not Progress; the seek bar reads Progress + API but not the full State. Matches the existing `ThemeProvider` pattern (`src/components/theme-provider.tsx`). Well-understood pattern in the React ecosystem.
+- **Cons:** Three contexts in one file adds complexity vs. a single-context solution. The triple split requires consumers to know which hook to call (`useAudioPlayer`, `useAudioPlayerProgress`, `useAudioPlayerAPI`). If audio state grows significantly (queue, playlist, history), the reducer could become unwieldy.
+
+### Option B: Zustand
+
+A lightweight external store with built-in selectors for fine-grained re-render control.
+
+- **Pros:** Built-in selector pattern (`useStore(state => state.currentTime)`) avoids the triple-context split entirely. Simpler API for consumers — one hook with selectors. Smaller boilerplate than Context + useReducer. Middleware for localStorage persistence (`persist`).
+- **Cons:** Adds a new dependency to a project with zero state management libraries. The `<audio>` ref must be managed separately (Zustand stores are plain objects, not React components). The ref would live in a module-level variable or a parallel Context, splitting the concern that Option A keeps unified. Overkill for ~5 consumer components.
+
+### Option C: Jotai
+
+Atomic state management with derived atoms for computed values.
+
+- **Pros:** Fine-grained reactivity — each piece of state is an atom, consumers only subscribe to atoms they read. No provider needed (provider-less mode). Excellent TypeScript support.
+- **Cons:** New dependency. Unfamiliar API for contributors who know React Context but not Jotai. The `<audio>` ref management is awkward — atoms hold serializable state, not DOM refs. Same ref-splitting issue as Zustand. Atomic model is a better fit for complex interconnected state (form builders, editors), not a linear audio player.
+
+### Option D: Single React Context (no split)
+
+One context with all state and actions in a single value.
+
+- **Pros:** Simplest implementation. One hook for everything.
+- **Cons:** Every `timeupdate` (~4x/sec) re-renders all consumers — the episode page listen button, the player bar title, the close button, the speed selector, and the volume slider all re-render 4 times per second during playback. This is the exact performance problem the PM flagged during review.
+
+## Decision
+
+**Option A** — React Context with triple split (API / State / Progress).
+
+## Rationale
+
+- **Zero new dependencies.** The project has no state management library today. Adding Zustand or Jotai for a single feature sets a precedent that future features should also use external state libraries, fragmenting state management across the codebase. React Context is built-in and sufficient.
+- **Ref colocation.** The `<audio>` element lives as a `useRef` inside the `AudioPlayerProvider` component. The provider renders a hidden `<audio>` element in the DOM, attaches event listeners, and dispatches state updates. All audio lifecycle management is in one place. External stores (Zustand, Jotai) cannot own a DOM ref — they would need a parallel mechanism.
+- **Performance is addressed.** The triple split ensures that high-frequency `timeupdate` events only re-render the seek bar (via `AudioPlayerProgressContext`). Stable state and stable actions are in separate contexts, so components pick exactly the reactivity they need.
+- **Bounded complexity.** The audio player has ~8 state fields and ~8 actions. This fits comfortably in a single `useReducer`. The issue explicitly scopes out playlist/queue functionality, so the state is unlikely to grow significantly in this iteration.
+- **Matches existing patterns.** `ThemeProvider` in `src/components/theme-provider.tsx` wraps `next-themes`'s provider and is consumed via `useTheme()`. The audio player follows the same provider-in-layout, hook-for-consumers pattern.
+
+## Consequences
+
+- The `src/contexts/` directory is created (first context in the project outside of third-party providers).
+- Contributors must choose the right hook: `useAudioPlayer()` for state, `useAudioPlayerAPI()` for actions, `useAudioPlayerProgress()` for timing. This is documented in the module's JSDoc comments.
+- If a second global state need arises (e.g., notification center, download manager), the team should evaluate whether React Context is still sufficient or if a shared state library (Zustand) is warranted. This ADR does not set a permanent policy — it documents the decision for this feature.
+- Helper modules `src/lib/media-session.ts` and `src/lib/player-preferences.ts` are extracted from the provider to keep the context file focused on state management.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@trigger.dev/react-hooks": "^4.3.3",
     "@trigger.dev/sdk": "^4.3.3",

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,22 +1,9 @@
-import { Header } from "@/components/layout/header"
-import { Sidebar } from "@/components/layout/sidebar"
+import { AppShell } from "@/components/layout/app-shell"
 
 export default function AppLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <div className="flex">
-        <Sidebar />
-        <main className="flex-1 overflow-auto p-4 sm:p-6">
-          <div className="mx-auto max-w-6xl">
-            {children}
-          </div>
-        </main>
-      </div>
-    </div>
-  )
+  return <AppShell>{children}</AppShell>
 }

--- a/src/components/audio-player/__tests__/playback-speed.test.tsx
+++ b/src/components/audio-player/__tests__/playback-speed.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PlaybackSpeed } from "@/components/audio-player/playback-speed"
+
+const mockState = {
+  playbackSpeed: 1,
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: true,
+  duration: 0,
+  volume: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+const mockAPI = {
+  playEpisode: vi.fn(),
+  togglePlay: vi.fn(),
+  seek: vi.fn(),
+  skipForward: vi.fn(),
+  skipBack: vi.fn(),
+  setVolume: vi.fn(),
+  setPlaybackSpeed: vi.fn(),
+  closePlayer: vi.fn(),
+}
+
+vi.mock("@/contexts/audio-player-context", () => ({
+  useAudioPlayerState: () => mockState,
+  useAudioPlayerAPI: () => mockAPI,
+}))
+
+describe("PlaybackSpeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState.playbackSpeed = 1
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("displays current speed", () => {
+    render(<PlaybackSpeed />)
+    expect(screen.getByText("1x")).toBeInTheDocument()
+  })
+
+  it("displays 1.5x when speed is 1.5", () => {
+    mockState.playbackSpeed = 1.5
+    render(<PlaybackSpeed />)
+    expect(screen.getByText("1.5x")).toBeInTheDocument()
+  })
+
+  it("cycles from 1x to 1.25x on click", async () => {
+    const user = userEvent.setup()
+    render(<PlaybackSpeed />)
+
+    await user.click(screen.getByRole("button"))
+    expect(mockAPI.setPlaybackSpeed).toHaveBeenCalledWith(1.25)
+  })
+
+  it("cycles from 1.25x to 1.5x on click", async () => {
+    mockState.playbackSpeed = 1.25
+    const user = userEvent.setup()
+    render(<PlaybackSpeed />)
+
+    await user.click(screen.getByRole("button"))
+    expect(mockAPI.setPlaybackSpeed).toHaveBeenCalledWith(1.5)
+  })
+
+  it("cycles from 1.5x to 2x on click", async () => {
+    mockState.playbackSpeed = 1.5
+    const user = userEvent.setup()
+    render(<PlaybackSpeed />)
+
+    await user.click(screen.getByRole("button"))
+    expect(mockAPI.setPlaybackSpeed).toHaveBeenCalledWith(2)
+  })
+
+  it("cycles from 2x back to 1x on click", async () => {
+    mockState.playbackSpeed = 2
+    const user = userEvent.setup()
+    render(<PlaybackSpeed />)
+
+    await user.click(screen.getByRole("button"))
+    expect(mockAPI.setPlaybackSpeed).toHaveBeenCalledWith(1)
+  })
+
+  it("has descriptive aria-label", () => {
+    render(<PlaybackSpeed />)
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "Playback speed 1x, click to change"
+    )
+  })
+})

--- a/src/components/audio-player/__tests__/player-bar.test.tsx
+++ b/src/components/audio-player/__tests__/player-bar.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PlayerBar } from "@/components/audio-player/player-bar"
+
+// Radix Slider uses ResizeObserver which jsdom doesn't provide
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+
+// --- Mock the context hooks ---
+const mockState = {
+  currentEpisode: null as {
+    id: string
+    title: string
+    podcastTitle: string
+    audioUrl: string
+    artwork?: string
+    duration?: number
+  } | null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 300,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null as string | null,
+}
+
+const mockAPI = {
+  playEpisode: vi.fn(),
+  togglePlay: vi.fn(),
+  seek: vi.fn(),
+  skipForward: vi.fn(),
+  skipBack: vi.fn(),
+  setVolume: vi.fn(),
+  setPlaybackSpeed: vi.fn(),
+  closePlayer: vi.fn(),
+}
+
+const mockProgress = {
+  currentTime: 45,
+  buffered: 120,
+}
+
+vi.mock("@/contexts/audio-player-context", () => ({
+  useAudioPlayerState: () => mockState,
+  useAudioPlayerAPI: () => mockAPI,
+  useAudioPlayerProgress: () => mockProgress,
+}))
+
+const testEpisode = {
+  id: "ep-1",
+  title: "A Test Episode Title",
+  podcastTitle: "My Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 300,
+}
+
+describe("PlayerBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.assign(mockState, {
+      currentEpisode: null,
+      isPlaying: false,
+      isBuffering: false,
+      isVisible: false,
+      duration: 300,
+      volume: 1,
+      playbackSpeed: 1,
+      hasError: false,
+      errorMessage: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders nothing when not visible", () => {
+    const { container } = render(<PlayerBar />)
+    expect(container.innerHTML).toBe("")
+  })
+
+  it("renders nothing when no episode loaded", () => {
+    mockState.isVisible = true
+    const { container } = render(<PlayerBar />)
+    expect(container.innerHTML).toBe("")
+  })
+
+  it("renders player bar when visible with episode", () => {
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    expect(screen.getByRole("region", { name: "Audio player" })).toBeInTheDocument()
+    expect(screen.getAllByText(testEpisode.title).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(testEpisode.podcastTitle).length).toBeGreaterThan(0)
+  })
+
+  it("shows play button when paused", () => {
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    mockState.isPlaying = false
+    render(<PlayerBar />)
+
+    const playButtons = screen.getAllByRole("button", { name: "Play" })
+    expect(playButtons.length).toBeGreaterThan(0)
+  })
+
+  it("shows pause button when playing", () => {
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    mockState.isPlaying = true
+    render(<PlayerBar />)
+
+    const pauseButtons = screen.getAllByRole("button", { name: "Pause" })
+    expect(pauseButtons.length).toBeGreaterThan(0)
+  })
+
+  it("calls togglePlay when play/pause is clicked", async () => {
+    const user = userEvent.setup()
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    const playButtons = screen.getAllByRole("button", { name: "Play" })
+    await user.click(playButtons[0])
+    expect(mockAPI.togglePlay).toHaveBeenCalled()
+  })
+
+  it("calls skipBack when skip back is clicked", async () => {
+    const user = userEvent.setup()
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    const skipBackButtons = screen.getAllByRole("button", { name: "Skip back 15 seconds" })
+    await user.click(skipBackButtons[0])
+    expect(mockAPI.skipBack).toHaveBeenCalled()
+  })
+
+  it("calls skipForward when skip forward is clicked", async () => {
+    const user = userEvent.setup()
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    const skipForwardButtons = screen.getAllByRole("button", { name: "Skip forward 15 seconds" })
+    await user.click(skipForwardButtons[0])
+    expect(mockAPI.skipForward).toHaveBeenCalled()
+  })
+
+  it("calls closePlayer when close is clicked", async () => {
+    const user = userEvent.setup()
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    const closeButtons = screen.getAllByRole("button", { name: "Close player" })
+    await user.click(closeButtons[0])
+    expect(mockAPI.closePlayer).toHaveBeenCalled()
+  })
+
+  it("has aria-label on the player region", () => {
+    mockState.isVisible = true
+    mockState.currentEpisode = testEpisode
+    render(<PlayerBar />)
+
+    expect(screen.getByRole("region")).toHaveAttribute("aria-label", "Audio player")
+  })
+
+  it("shows title attribute for long episode titles", () => {
+    mockState.isVisible = true
+    mockState.currentEpisode = {
+      ...testEpisode,
+      title: "A Very Long Episode Title That Should Be Truncated In The UI",
+    }
+    render(<PlayerBar />)
+
+    const titleElements = screen.getAllByTitle(
+      "A Very Long Episode Title That Should Be Truncated In The UI"
+    )
+    expect(titleElements.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/audio-player/__tests__/seek-bar.test.tsx
+++ b/src/components/audio-player/__tests__/seek-bar.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { SeekBar } from "@/components/audio-player/seek-bar"
+
+// Radix Slider uses ResizeObserver which jsdom doesn't provide
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+
+const mockState = {
+  duration: 300,
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: true,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+const mockProgress = {
+  currentTime: 65,
+  buffered: 150,
+}
+
+const mockAPI = {
+  playEpisode: vi.fn(),
+  togglePlay: vi.fn(),
+  seek: vi.fn(),
+  skipForward: vi.fn(),
+  skipBack: vi.fn(),
+  setVolume: vi.fn(),
+  setPlaybackSpeed: vi.fn(),
+  closePlayer: vi.fn(),
+}
+
+vi.mock("@/contexts/audio-player-context", () => ({
+  useAudioPlayerState: () => mockState,
+  useAudioPlayerProgress: () => mockProgress,
+  useAudioPlayerAPI: () => mockAPI,
+}))
+
+describe("SeekBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockProgress.currentTime = 65
+    mockProgress.buffered = 150
+    mockState.duration = 300
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("displays formatted current time", () => {
+    render(<SeekBar />)
+    // 65 seconds = 1:05
+    expect(screen.getByText("1:05")).toBeInTheDocument()
+  })
+
+  it("displays formatted duration", () => {
+    render(<SeekBar />)
+    // 300 seconds = 5:00
+    expect(screen.getByText("5:00")).toBeInTheDocument()
+  })
+
+  it("renders a slider", () => {
+    render(<SeekBar />)
+    expect(screen.getByRole("slider")).toBeInTheDocument()
+  })
+
+  it("shows 0:00 when currentTime is 0", () => {
+    mockProgress.currentTime = 0
+    render(<SeekBar />)
+    expect(screen.getByText("0:00")).toBeInTheDocument()
+  })
+
+  it("renders buffered range indicator", () => {
+    const { container } = render(<SeekBar />)
+    // buffered = 150 / 300 = 50%
+    const bufferedDiv = container.querySelector("[style]")
+    expect(bufferedDiv).toBeTruthy()
+    expect(bufferedDiv?.getAttribute("style")).toContain("50%")
+  })
+})

--- a/src/components/audio-player/__tests__/volume-control.test.tsx
+++ b/src/components/audio-player/__tests__/volume-control.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { VolumeControl } from "@/components/audio-player/volume-control"
+
+// Radix Slider uses ResizeObserver which jsdom doesn't provide
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+
+const mockState = {
+  volume: 0.8,
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: true,
+  duration: 0,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+const mockAPI = {
+  playEpisode: vi.fn(),
+  togglePlay: vi.fn(),
+  seek: vi.fn(),
+  skipForward: vi.fn(),
+  skipBack: vi.fn(),
+  setVolume: vi.fn(),
+  setPlaybackSpeed: vi.fn(),
+  closePlayer: vi.fn(),
+}
+
+vi.mock("@/contexts/audio-player-context", () => ({
+  useAudioPlayerState: () => mockState,
+  useAudioPlayerAPI: () => mockAPI,
+}))
+
+describe("VolumeControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState.volume = 0.8
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders mute button with Mute aria-label when not muted", () => {
+    render(<VolumeControl />)
+    expect(screen.getByRole("button", { name: "Mute" })).toBeInTheDocument()
+  })
+
+  it("renders unmute button with Unmute aria-label when muted", () => {
+    mockState.volume = 0
+    render(<VolumeControl />)
+    expect(screen.getByRole("button", { name: "Unmute" })).toBeInTheDocument()
+  })
+
+  it("mutes on click (sets volume to 0)", async () => {
+    const user = userEvent.setup()
+    render(<VolumeControl />)
+
+    await user.click(screen.getByRole("button", { name: "Mute" }))
+    expect(mockAPI.setVolume).toHaveBeenCalledWith(0)
+  })
+
+  it("unmutes on click (restores previous volume)", async () => {
+    // First mute, then unmute
+    mockState.volume = 0
+    const user = userEvent.setup()
+    render(<VolumeControl />)
+
+    await user.click(screen.getByRole("button", { name: "Unmute" }))
+    // Should restore to 1 (default previousVolume)
+    expect(mockAPI.setVolume).toHaveBeenCalledWith(1)
+  })
+
+  it("renders a volume slider", () => {
+    render(<VolumeControl />)
+    expect(screen.getByRole("slider")).toBeInTheDocument()
+  })
+
+  it("has hidden md:flex class for desktop-only visibility", () => {
+    const { container } = render(<VolumeControl />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain("hidden")
+    expect(wrapper.className).toContain("md:flex")
+  })
+})

--- a/src/components/audio-player/playback-speed.stories.tsx
+++ b/src/components/audio-player/playback-speed.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import type { ReactNode } from "react"
+import {
+  AudioPlayerAPIContext,
+  AudioPlayerStateContext,
+  AudioPlayerProgressContext,
+  type AudioPlayerState,
+  type AudioPlayerAPI,
+} from "@/contexts/audio-player-context"
+import { PlaybackSpeed } from "./playback-speed"
+
+const noopAPI: AudioPlayerAPI = {
+  playEpisode: () => {},
+  togglePlay: () => {},
+  seek: () => {},
+  skipForward: () => {},
+  skipBack: () => {},
+  setVolume: () => {},
+  setPlaybackSpeed: () => {},
+  closePlayer: () => {},
+}
+
+const baseState: AudioPlayerState = {
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 0,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+function MockProvider({
+  state,
+  children,
+}: {
+  state: AudioPlayerState
+  children: ReactNode
+}) {
+  return (
+    <AudioPlayerAPIContext.Provider value={noopAPI}>
+      <AudioPlayerStateContext.Provider value={state}>
+        <AudioPlayerProgressContext.Provider
+          value={{ currentTime: 0, buffered: 0 }}
+        >
+          {children}
+        </AudioPlayerProgressContext.Provider>
+      </AudioPlayerStateContext.Provider>
+    </AudioPlayerAPIContext.Provider>
+  )
+}
+
+const meta: Meta<typeof PlaybackSpeed> = {
+  title: "AudioPlayer/PlaybackSpeed",
+  component: PlaybackSpeed,
+}
+
+export default meta
+type Story = StoryObj<typeof PlaybackSpeed>
+
+export const Speed1x: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, playbackSpeed: 1 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Speed125x: Story = {
+  name: "Speed 1.25x",
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, playbackSpeed: 1.25 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Speed15x: Story = {
+  name: "Speed 1.5x",
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, playbackSpeed: 1.5 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Speed2x: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, playbackSpeed: 2 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}

--- a/src/components/audio-player/playback-speed.tsx
+++ b/src/components/audio-player/playback-speed.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useCallback } from "react"
+import { Button } from "@/components/ui/button"
+import { useAudioPlayerState, useAudioPlayerAPI } from "@/contexts/audio-player-context"
+import { SPEED_OPTIONS } from "@/lib/player-preferences"
+
+export function PlaybackSpeed() {
+  const { playbackSpeed } = useAudioPlayerState()
+  const { setPlaybackSpeed } = useAudioPlayerAPI()
+
+  const cycleSpeed = useCallback(() => {
+    const currentIndex = (SPEED_OPTIONS as readonly number[]).indexOf(playbackSpeed)
+    // If current speed is not in SPEED_OPTIONS (e.g. stale localStorage), reset to 1x
+    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % SPEED_OPTIONS.length
+    setPlaybackSpeed(SPEED_OPTIONS[nextIndex])
+  }, [playbackSpeed, setPlaybackSpeed])
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={cycleSpeed}
+      aria-label={`Playback speed ${playbackSpeed}x, click to change`}
+      className="min-w-[3.5rem] px-2 text-xs font-semibold tabular-nums"
+    >
+      {playbackSpeed}x
+    </Button>
+  )
+}

--- a/src/components/audio-player/player-bar.stories.tsx
+++ b/src/components/audio-player/player-bar.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import type { ReactNode } from "react"
+import {
+  AudioPlayerAPIContext,
+  AudioPlayerStateContext,
+  AudioPlayerProgressContext,
+  type AudioPlayerState,
+  type AudioPlayerProgress,
+  type AudioPlayerAPI,
+} from "@/contexts/audio-player-context"
+import { PlayerBar } from "./player-bar"
+
+const noopAPI: AudioPlayerAPI = {
+  playEpisode: () => {},
+  togglePlay: () => {},
+  seek: () => {},
+  skipForward: () => {},
+  skipBack: () => {},
+  setVolume: () => {},
+  setPlaybackSpeed: () => {},
+  closePlayer: () => {},
+}
+
+const defaultProgress: AudioPlayerProgress = {
+  currentTime: 45,
+  buffered: 120,
+}
+
+const baseState: AudioPlayerState = {
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 0,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+const testEpisode = {
+  id: "ep-1",
+  title: "How to Build Better Products",
+  podcastTitle: "Design Matters",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://picsum.photos/seed/podcast/300/300",
+  duration: 2400,
+}
+
+const longTitleEpisode = {
+  id: "ep-2",
+  title: "The Extremely Long Episode Title That Should Be Truncated Because It Exceeds The Available Width In The Player Bar Component",
+  podcastTitle: "My Very Long Podcast Name That Also Needs Truncation",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://picsum.photos/seed/podcast2/300/300",
+  duration: 5400,
+}
+
+function MockProvider({
+  state,
+  progress = defaultProgress,
+  children,
+}: {
+  state: AudioPlayerState
+  progress?: AudioPlayerProgress
+  children: ReactNode
+}) {
+  return (
+    <AudioPlayerAPIContext.Provider value={noopAPI}>
+      <AudioPlayerStateContext.Provider value={state}>
+        <AudioPlayerProgressContext.Provider value={progress}>
+          {children}
+        </AudioPlayerProgressContext.Provider>
+      </AudioPlayerStateContext.Provider>
+    </AudioPlayerAPIContext.Provider>
+  )
+}
+
+const meta: Meta<typeof PlayerBar> = {
+  title: "AudioPlayer/PlayerBar",
+  component: PlayerBar,
+  parameters: {
+    layout: "fullscreen",
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof PlayerBar>
+
+export const Hidden: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={baseState}>
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Playing: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{
+          ...baseState,
+          currentEpisode: testEpisode,
+          isPlaying: true,
+          isVisible: true,
+          duration: 2400,
+        }}
+        progress={{ currentTime: 340, buffered: 800 }}
+      >
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Paused: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{
+          ...baseState,
+          currentEpisode: testEpisode,
+          isPlaying: false,
+          isVisible: true,
+          duration: 2400,
+        }}
+        progress={{ currentTime: 340, buffered: 800 }}
+      >
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const LongTitle: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{
+          ...baseState,
+          currentEpisode: longTitleEpisode,
+          isPlaying: true,
+          isVisible: true,
+          duration: 5400,
+        }}
+        progress={{ currentTime: 1200, buffered: 2000 }}
+      >
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Buffering: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{
+          ...baseState,
+          currentEpisode: testEpisode,
+          isPlaying: true,
+          isBuffering: true,
+          isVisible: true,
+          duration: 2400,
+        }}
+        progress={{ currentTime: 45, buffered: 50 }}
+      >
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const MobileViewport: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    chromatic: { viewports: [375] },
+  },
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{
+          ...baseState,
+          currentEpisode: testEpisode,
+          isPlaying: true,
+          isVisible: true,
+          duration: 2400,
+        }}
+        progress={{ currentTime: 340, buffered: 800 }}
+      >
+        <div className="min-h-[200px]">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}

--- a/src/components/audio-player/player-bar.tsx
+++ b/src/components/audio-player/player-bar.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import Image from "next/image"
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  X,
+  Loader2,
+  Rss,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  useAudioPlayerState,
+  useAudioPlayerAPI,
+} from "@/contexts/audio-player-context"
+import { SeekBar } from "@/components/audio-player/seek-bar"
+import { PlaybackSpeed } from "@/components/audio-player/playback-speed"
+import { VolumeControl } from "@/components/audio-player/volume-control"
+
+export function PlayerBar() {
+  const { currentEpisode, isPlaying, isBuffering, isVisible } =
+    useAudioPlayerState()
+  const { togglePlay, skipBack, skipForward, closePlayer } =
+    useAudioPlayerAPI()
+
+  if (!isVisible || !currentEpisode) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Audio player"
+      className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background/95 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60"
+    >
+      {/* Desktop layout (md+): single row */}
+      <div className="hidden h-[72px] items-center gap-4 px-4 md:flex">
+        {/* Track info (left) */}
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded bg-muted">
+            {currentEpisode.artwork ? (
+              <Image
+                src={currentEpisode.artwork}
+                alt=""
+                fill
+                className="object-cover"
+                sizes="48px"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                <Rss className="h-5 w-5" />
+              </div>
+            )}
+          </div>
+          <div className="min-w-0">
+            <p
+              className="truncate text-sm font-medium"
+              title={currentEpisode.title}
+            >
+              {currentEpisode.title}
+            </p>
+            <p
+              className="truncate text-xs text-muted-foreground"
+              title={currentEpisode.podcastTitle}
+            >
+              {currentEpisode.podcastTitle}
+            </p>
+          </div>
+        </div>
+
+        {/* Controls (center) */}
+        <div className="flex w-full max-w-xl flex-col items-center gap-1">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => skipBack()}
+              aria-label="Skip back 15 seconds"
+              className="h-8 w-8"
+            >
+              <SkipBack className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="default"
+              size="icon"
+              onClick={togglePlay}
+              aria-label={isPlaying ? "Pause" : "Play"}
+              className="h-9 w-9"
+            >
+              {isBuffering ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : isPlaying ? (
+                <Pause className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => skipForward()}
+              aria-label="Skip forward 15 seconds"
+              className="h-8 w-8"
+            >
+              <SkipForward className="h-4 w-4" />
+            </Button>
+          </div>
+          <SeekBar />
+        </div>
+
+        {/* Volume/Speed/Close (right) */}
+        <div className="flex flex-1 items-center justify-end gap-2">
+          <PlaybackSpeed />
+          <VolumeControl />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={closePlayer}
+            aria-label="Close player"
+            className="h-8 w-8"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Mobile layout (<md): two rows */}
+      <div className="flex flex-col md:hidden">
+        {/* Top row: info + play/pause + close */}
+        <div className="flex items-center gap-3 px-3 py-2">
+          <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded bg-muted">
+            {currentEpisode.artwork ? (
+              <Image
+                src={currentEpisode.artwork}
+                alt=""
+                fill
+                className="object-cover"
+                sizes="40px"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                <Rss className="h-4 w-4" />
+              </div>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p
+              className="truncate text-sm font-medium"
+              title={currentEpisode.title}
+            >
+              {currentEpisode.title}
+            </p>
+            <p
+              className="truncate text-xs text-muted-foreground"
+              title={currentEpisode.podcastTitle}
+            >
+              {currentEpisode.podcastTitle}
+            </p>
+          </div>
+          <Button
+            variant="default"
+            size="icon"
+            onClick={togglePlay}
+            aria-label={isPlaying ? "Pause" : "Play"}
+            className="h-8 w-8 shrink-0"
+          >
+            {isBuffering ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : isPlaying ? (
+              <Pause className="h-4 w-4" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={closePlayer}
+            aria-label="Close player"
+            className="h-8 w-8 shrink-0"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Bottom row: skip + seek + speed */}
+        <div className="flex items-center gap-2 px-3 pb-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => skipBack()}
+            aria-label="Skip back 15 seconds"
+            className="h-7 w-7 shrink-0"
+          >
+            <SkipBack className="h-3.5 w-3.5" />
+          </Button>
+          <div className="flex-1">
+            <SeekBar />
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => skipForward()}
+            aria-label="Skip forward 15 seconds"
+            className="h-7 w-7 shrink-0"
+          >
+            <SkipForward className="h-3.5 w-3.5" />
+          </Button>
+          <PlaybackSpeed />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/audio-player/seek-bar.stories.tsx
+++ b/src/components/audio-player/seek-bar.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import type { ReactNode } from "react"
+import {
+  AudioPlayerAPIContext,
+  AudioPlayerStateContext,
+  AudioPlayerProgressContext,
+  type AudioPlayerState,
+  type AudioPlayerProgress,
+  type AudioPlayerAPI,
+} from "@/contexts/audio-player-context"
+import { SeekBar } from "./seek-bar"
+
+const noopAPI: AudioPlayerAPI = {
+  playEpisode: () => {},
+  togglePlay: () => {},
+  seek: () => {},
+  skipForward: () => {},
+  skipBack: () => {},
+  setVolume: () => {},
+  setPlaybackSpeed: () => {},
+  closePlayer: () => {},
+}
+
+const baseState: AudioPlayerState = {
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 0,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+function MockProvider({
+  state,
+  progress,
+  children,
+}: {
+  state: AudioPlayerState
+  progress: AudioPlayerProgress
+  children: ReactNode
+}) {
+  return (
+    <AudioPlayerAPIContext.Provider value={noopAPI}>
+      <AudioPlayerStateContext.Provider value={state}>
+        <AudioPlayerProgressContext.Provider value={progress}>
+          {children}
+        </AudioPlayerProgressContext.Provider>
+      </AudioPlayerStateContext.Provider>
+    </AudioPlayerAPIContext.Provider>
+  )
+}
+
+const meta: Meta<typeof SeekBar> = {
+  title: "AudioPlayer/SeekBar",
+  component: SeekBar,
+}
+
+export default meta
+type Story = StoryObj<typeof SeekBar>
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{ ...baseState, duration: 300 }}
+        progress={{ currentTime: 45, buffered: 120 }}
+      >
+        <div className="mx-auto max-w-lg p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const NearEnd: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{ ...baseState, duration: 300 }}
+        progress={{ currentTime: 285, buffered: 300 }}
+      >
+        <div className="mx-auto max-w-lg p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const LongEpisode: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{ ...baseState, duration: 7200 }}
+        progress={{ currentTime: 3600, buffered: 4500 }}
+      >
+        <div className="mx-auto max-w-lg p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const BufferedRange: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{ ...baseState, duration: 600 }}
+        progress={{ currentTime: 30, buffered: 450 }}
+      >
+        <div className="mx-auto max-w-lg p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const ZeroDuration: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider
+        state={{ ...baseState, duration: 0 }}
+        progress={{ currentTime: 0, buffered: 0 }}
+      >
+        <div className="mx-auto max-w-lg p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}

--- a/src/components/audio-player/seek-bar.tsx
+++ b/src/components/audio-player/seek-bar.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useCallback } from "react"
+import { Slider } from "@/components/ui/slider"
+import { useAudioPlayerProgress, useAudioPlayerAPI, useAudioPlayerState } from "@/contexts/audio-player-context"
+
+function formatTime(seconds: number): string {
+  if (!seconds || !isFinite(seconds)) return "0:00"
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}
+
+export function SeekBar() {
+  const { currentTime, buffered } = useAudioPlayerProgress()
+  const { duration } = useAudioPlayerState()
+  const { seek } = useAudioPlayerAPI()
+
+  const handleSeek = useCallback(
+    (value: number[]) => {
+      seek(value[0])
+    },
+    [seek]
+  )
+
+  const bufferedPercent = duration > 0 ? (buffered / duration) * 100 : 0
+
+  return (
+    <div className="flex w-full items-center gap-2">
+      <span className="w-10 text-right text-xs tabular-nums text-muted-foreground">
+        {formatTime(currentTime)}
+      </span>
+      <div className="relative flex-1">
+        {/* Buffered range background */}
+        <div className="pointer-events-none absolute inset-0 flex items-center">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-primary/20">
+            <div
+              className="h-full bg-primary/40 transition-all"
+              style={{ width: `${bufferedPercent}%` }}
+            />
+          </div>
+        </div>
+        <Slider
+          aria-label="Seek"
+          min={0}
+          max={duration || 100}
+          step={1}
+          value={[currentTime]}
+          onValueChange={handleSeek}
+        />
+      </div>
+      <span className="w-10 text-xs tabular-nums text-muted-foreground">
+        {formatTime(duration)}
+      </span>
+    </div>
+  )
+}

--- a/src/components/audio-player/volume-control.stories.tsx
+++ b/src/components/audio-player/volume-control.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import type { ReactNode } from "react"
+import {
+  AudioPlayerAPIContext,
+  AudioPlayerStateContext,
+  AudioPlayerProgressContext,
+  type AudioPlayerState,
+  type AudioPlayerAPI,
+} from "@/contexts/audio-player-context"
+import { VolumeControl } from "./volume-control"
+
+const noopAPI: AudioPlayerAPI = {
+  playEpisode: () => {},
+  togglePlay: () => {},
+  seek: () => {},
+  skipForward: () => {},
+  skipBack: () => {},
+  setVolume: () => {},
+  setPlaybackSpeed: () => {},
+  closePlayer: () => {},
+}
+
+const baseState: AudioPlayerState = {
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 0,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+function MockProvider({
+  state,
+  children,
+}: {
+  state: AudioPlayerState
+  children: ReactNode
+}) {
+  return (
+    <AudioPlayerAPIContext.Provider value={noopAPI}>
+      <AudioPlayerStateContext.Provider value={state}>
+        <AudioPlayerProgressContext.Provider
+          value={{ currentTime: 0, buffered: 0 }}
+        >
+          {children}
+        </AudioPlayerProgressContext.Provider>
+      </AudioPlayerStateContext.Provider>
+    </AudioPlayerAPIContext.Provider>
+  )
+}
+
+const meta: Meta<typeof VolumeControl> = {
+  title: "AudioPlayer/VolumeControl",
+  component: VolumeControl,
+}
+
+export default meta
+type Story = StoryObj<typeof VolumeControl>
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, volume: 1 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const Muted: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, volume: 0 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const HalfVolume: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, volume: 0.5 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}
+
+export const MaxVolume: Story = {
+  decorators: [
+    (Story) => (
+      <MockProvider state={{ ...baseState, volume: 1 }}>
+        <div className="p-4">
+          <Story />
+        </div>
+      </MockProvider>
+    ),
+  ],
+}

--- a/src/components/audio-player/volume-control.tsx
+++ b/src/components/audio-player/volume-control.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+import { Volume2, VolumeX } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Slider } from "@/components/ui/slider"
+import { useAudioPlayerState, useAudioPlayerAPI } from "@/contexts/audio-player-context"
+
+export function VolumeControl() {
+  const { volume } = useAudioPlayerState()
+  const { setVolume } = useAudioPlayerAPI()
+  const previousVolumeRef = useRef(1)
+
+  const handleVolumeChange = useCallback(
+    (value: number[]) => {
+      setVolume(value[0])
+    },
+    [setVolume]
+  )
+
+  const toggleMute = useCallback(() => {
+    if (volume > 0) {
+      previousVolumeRef.current = volume
+      setVolume(0)
+    } else {
+      setVolume(previousVolumeRef.current || 1)
+    }
+  }, [volume, setVolume])
+
+  const isMuted = volume === 0
+
+  return (
+    <div className="hidden items-center gap-2 md:flex">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleMute}
+        aria-label={isMuted ? "Unmute" : "Mute"}
+        className="h-8 w-8"
+      >
+        {isMuted ? (
+          <VolumeX className="h-4 w-4" />
+        ) : (
+          <Volume2 className="h-4 w-4" />
+        )}
+      </Button>
+      <Slider
+        aria-label="Volume"
+        min={0}
+        max={1}
+        step={0.01}
+        value={[volume]}
+        onValueChange={handleVolumeChange}
+        className="w-24"
+      />
+    </div>
+  )
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { AudioPlayerProvider, useAudioPlayerState } from "@/contexts/audio-player-context"
+import { Header } from "@/components/layout/header"
+import { Sidebar } from "@/components/layout/sidebar"
+import { PlayerBar } from "@/components/audio-player/player-bar"
+
+function AppShellInner({ children }: { children: React.ReactNode }) {
+  const { isVisible } = useAudioPlayerState()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <div className="flex">
+        <Sidebar />
+        <main className={`flex-1 overflow-auto p-4 sm:p-6 ${isVisible ? "pb-24 md:pb-[104px]" : ""}`}>
+          <div className="mx-auto max-w-6xl">
+            {children}
+          </div>
+        </main>
+      </div>
+      <PlayerBar />
+    </div>
+  )
+}
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <AudioPlayerProvider>
+      <AppShellInner>{children}</AppShellInner>
+    </AudioPlayerProvider>
+  )
+}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  AudioPlayerProvider,
+  useAudioPlayerAPI,
+  useAudioPlayerState,
+  useAudioPlayerProgress,
+  type AudioEpisode,
+} from "@/contexts/audio-player-context"
+
+// Mock media-session helpers
+vi.mock("@/lib/media-session", () => ({
+  updateMediaSessionMetadata: vi.fn(),
+  setupMediaSessionHandlers: vi.fn(),
+  updateMediaSessionPosition: vi.fn(),
+  clearMediaSession: vi.fn(),
+}))
+
+// Mock player-preferences helpers
+const mockLoadPrefs = vi.fn().mockReturnValue({ volume: 0.8, playbackSpeed: 1.5 })
+const mockSavePrefs = vi.fn()
+vi.mock("@/lib/player-preferences", () => ({
+  loadPlayerPreferences: (...args: unknown[]) => mockLoadPrefs(...args),
+  savePlayerPreferences: (...args: unknown[]) => mockSavePrefs(...args),
+}))
+
+// --- Mock HTMLMediaElement prototype ---
+// jsdom doesn't implement play/load/pause, so we stub them globally
+const playMock = vi.fn().mockResolvedValue(undefined)
+const pauseMock = vi.fn()
+const loadMock = vi.fn()
+
+// Track event listeners on audio elements
+const audioListeners: Record<string, EventListener[]> = {}
+
+function getAudioElement(): HTMLAudioElement | null {
+  return document.querySelector("audio")
+}
+
+function fireAudioEvent(eventName: string) {
+  const audio = getAudioElement()
+  if (audio) {
+    audio.dispatchEvent(new Event(eventName))
+  }
+}
+
+beforeEach(() => {
+  // Stub HTMLMediaElement methods
+  HTMLMediaElement.prototype.play = playMock
+  HTMLMediaElement.prototype.pause = pauseMock
+  HTMLMediaElement.prototype.load = loadMock
+
+  // Provide a buffered TimeRanges stub
+  Object.defineProperty(HTMLMediaElement.prototype, "buffered", {
+    configurable: true,
+    get() {
+      return {
+        length: 1,
+        start: () => 0,
+        end: () => 150,
+      }
+    },
+  })
+})
+
+const mockEpisode: AudioEpisode = {
+  id: "ep-123",
+  title: "Test Episode",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 600,
+}
+
+// Test consumer component
+function TestConsumer() {
+  const state = useAudioPlayerState()
+  const api = useAudioPlayerAPI()
+  const progress = useAudioPlayerProgress()
+
+  return (
+    <div>
+      <span data-testid="isPlaying">{String(state.isPlaying)}</span>
+      <span data-testid="isVisible">{String(state.isVisible)}</span>
+      <span data-testid="isBuffering">{String(state.isBuffering)}</span>
+      <span data-testid="volume">{state.volume}</span>
+      <span data-testid="playbackSpeed">{state.playbackSpeed}</span>
+      <span data-testid="hasError">{String(state.hasError)}</span>
+      <span data-testid="errorMessage">{state.errorMessage ?? ""}</span>
+      <span data-testid="duration">{state.duration}</span>
+      <span data-testid="currentTime">{progress.currentTime}</span>
+      <span data-testid="buffered">{progress.buffered}</span>
+      <span data-testid="episodeTitle">{state.currentEpisode?.title ?? ""}</span>
+      <button onClick={() => api.playEpisode(mockEpisode)}>Play Episode</button>
+      <button onClick={api.togglePlay}>Toggle Play</button>
+      <button onClick={() => api.seek(120)}>Seek 120</button>
+      <button onClick={() => api.skipForward()}>Skip Forward</button>
+      <button onClick={() => api.skipBack()}>Skip Back</button>
+      <button onClick={() => api.setVolume(0.5)}>Set Volume</button>
+      <button onClick={() => api.setPlaybackSpeed(2)}>Set Speed</button>
+      <button onClick={api.closePlayer}>Close</button>
+    </div>
+  )
+}
+
+describe("AudioPlayerProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    playMock.mockResolvedValue(undefined)
+    mockLoadPrefs.mockReturnValue({ volume: 0.8, playbackSpeed: 1.5 })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("provides default state from localStorage preferences", () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("false")
+    expect(screen.getByTestId("isVisible")).toHaveTextContent("false")
+    expect(screen.getByTestId("volume")).toHaveTextContent("0.8")
+    expect(screen.getByTestId("playbackSpeed")).toHaveTextContent("1.5")
+    expect(screen.getByTestId("hasError")).toHaveTextContent("false")
+  })
+
+  it("plays an episode and updates state", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+
+    expect(screen.getByTestId("episodeTitle")).toHaveTextContent(mockEpisode.title)
+    expect(screen.getByTestId("isVisible")).toHaveTextContent("true")
+    expect(playMock).toHaveBeenCalled()
+  })
+
+  it("toggles play/pause", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Play episode first
+    await user.click(screen.getByText("Play Episode"))
+
+    // Simulate audio playing
+    const audio = getAudioElement()!
+    Object.defineProperty(audio, "paused", { value: false, configurable: true })
+    await user.click(screen.getByText("Toggle Play"))
+    expect(pauseMock).toHaveBeenCalled()
+
+    // Now paused — toggle should play
+    Object.defineProperty(audio, "paused", { value: true, configurable: true })
+    await user.click(screen.getByText("Toggle Play"))
+    // play called: once from playEpisode + once from togglePlay
+    expect(playMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("seeks to a specific time", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+
+    const audio = getAudioElement()!
+    Object.defineProperty(audio, "duration", { value: 600, configurable: true })
+    await user.click(screen.getByText("Seek 120"))
+    expect(audio.currentTime).toBe(120)
+  })
+
+  it("skips forward by 15 seconds", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    audio.currentTime = 100
+    Object.defineProperty(audio, "duration", { value: 600, configurable: true })
+    await user.click(screen.getByText("Skip Forward"))
+    expect(audio.currentTime).toBe(115)
+  })
+
+  it("skips back by 15 seconds", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    audio.currentTime = 100
+    await user.click(screen.getByText("Skip Back"))
+    expect(audio.currentTime).toBe(85)
+  })
+
+  it("does not skip back below zero", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    audio.currentTime = 5
+    await user.click(screen.getByText("Skip Back"))
+    expect(audio.currentTime).toBe(0)
+  })
+
+  it("sets volume and persists to localStorage", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Set Volume"))
+    expect(screen.getByTestId("volume")).toHaveTextContent("0.5")
+    expect(mockSavePrefs).toHaveBeenCalledWith({ volume: 0.5 })
+  })
+
+  it("sets playback speed and persists to localStorage", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Set Speed"))
+    expect(screen.getByTestId("playbackSpeed")).toHaveTextContent("2")
+    expect(mockSavePrefs).toHaveBeenCalledWith({ playbackSpeed: 2 })
+  })
+
+  it("closes player and resets state", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    expect(screen.getByTestId("isVisible")).toHaveTextContent("true")
+
+    await user.click(screen.getByText("Close"))
+    expect(screen.getByTestId("isVisible")).toHaveTextContent("false")
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("false")
+    expect(screen.getByTestId("episodeTitle")).toHaveTextContent("")
+    expect(pauseMock).toHaveBeenCalled()
+  })
+
+  it("dispatches playing/pause from audio events", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+
+    // Simulate 'playing' event
+    act(() => fireAudioEvent("playing"))
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("true")
+    expect(screen.getByTestId("isBuffering")).toHaveTextContent("false")
+
+    // Simulate 'pause' event
+    act(() => fireAudioEvent("pause"))
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("false")
+  })
+
+  it("dispatches buffering state from waiting event", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    act(() => fireAudioEvent("waiting"))
+    expect(screen.getByTestId("isBuffering")).toHaveTextContent("true")
+  })
+
+  it("dispatches error state from error event", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    Object.defineProperty(audio, "error", {
+      value: { code: 2 }, // MEDIA_ERR_NETWORK
+      configurable: true,
+    })
+    act(() => fireAudioEvent("error"))
+    expect(screen.getByTestId("hasError")).toHaveTextContent("true")
+    expect(screen.getByTestId("errorMessage")).toHaveTextContent(
+      "A network error occurred while loading audio."
+    )
+  })
+
+  it("updates duration from durationchange event", async () => {
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    Object.defineProperty(audio, "duration", { value: 1200, configurable: true })
+    act(() => fireAudioEvent("durationchange"))
+    expect(screen.getByTestId("duration")).toHaveTextContent("1200")
+  })
+
+  it("sets up Media Session handlers on mount", async () => {
+    const { setupMediaSessionHandlers } = await import("@/lib/media-session")
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+    expect(setupMediaSessionHandlers).toHaveBeenCalled()
+  })
+
+  it("renders hidden audio element and aria-live region", () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    expect(document.querySelector("audio")).toBeTruthy()
+    expect(screen.getByRole("status")).toBeInTheDocument()
+  })
+
+  it("handles autoplay blocked (play rejection)", async () => {
+    playMock.mockRejectedValueOnce(new DOMException("NotAllowedError"))
+    const user = userEvent.setup()
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+    // Should set isPlaying to false after rejection
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("false")
+  })
+})
+
+describe("hooks throw outside provider", () => {
+  // Suppress React error boundary console errors
+  const originalError = console.error
+  beforeEach(() => {
+    console.error = vi.fn()
+  })
+  afterEach(() => {
+    console.error = originalError
+  })
+
+  it("useAudioPlayerAPI throws without provider", () => {
+    function BadConsumer() {
+      useAudioPlayerAPI()
+      return null
+    }
+    expect(() => render(<BadConsumer />)).toThrow(
+      "useAudioPlayerAPI must be used within AudioPlayerProvider"
+    )
+  })
+
+  it("useAudioPlayerState throws without provider", () => {
+    function BadConsumer() {
+      useAudioPlayerState()
+      return null
+    }
+    expect(() => render(<BadConsumer />)).toThrow(
+      "useAudioPlayerState must be used within AudioPlayerProvider"
+    )
+  })
+
+  it("useAudioPlayerProgress throws without provider", () => {
+    function BadConsumer() {
+      useAudioPlayerProgress()
+      return null
+    }
+    expect(() => render(<BadConsumer />)).toThrow(
+      "useAudioPlayerProgress must be used within AudioPlayerProvider"
+    )
+  })
+})

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -1,0 +1,500 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react"
+import { toast } from "sonner"
+import {
+  updateMediaSessionMetadata,
+  setupMediaSessionHandlers,
+  updateMediaSessionPosition,
+  clearMediaSession,
+} from "@/lib/media-session"
+import {
+  loadPlayerPreferences,
+  savePlayerPreferences,
+} from "@/lib/player-preferences"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AudioEpisode {
+  id: string
+  title: string
+  podcastTitle: string
+  audioUrl: string
+  artwork?: string
+  duration?: number
+}
+
+export interface AudioPlayerState {
+  currentEpisode: AudioEpisode | null
+  isPlaying: boolean
+  isBuffering: boolean
+  isVisible: boolean
+  duration: number
+  volume: number
+  playbackSpeed: number
+  hasError: boolean
+  errorMessage: string | null
+}
+
+export interface AudioPlayerProgress {
+  currentTime: number
+  buffered: number
+}
+
+export interface AudioPlayerAPI {
+  playEpisode: (episode: AudioEpisode) => void
+  togglePlay: () => void
+  seek: (time: number) => void
+  skipForward: (seconds?: number) => void
+  skipBack: (seconds?: number) => void
+  setVolume: (volume: number) => void
+  setPlaybackSpeed: (speed: number) => void
+  closePlayer: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+type Action =
+  | { type: "PLAY_EPISODE"; episode: AudioEpisode }
+  | { type: "SET_PLAYING"; isPlaying: boolean }
+  | { type: "SET_BUFFERING"; isBuffering: boolean }
+  | { type: "SET_DURATION"; duration: number }
+  | { type: "SET_VOLUME"; volume: number }
+  | { type: "SET_PLAYBACK_SPEED"; speed: number }
+  | { type: "SET_ERROR"; message: string }
+  | { type: "CLEAR_ERROR" }
+  | { type: "CLOSE" }
+
+function reducer(state: AudioPlayerState, action: Action): AudioPlayerState {
+  switch (action.type) {
+    case "PLAY_EPISODE":
+      return {
+        ...state,
+        currentEpisode: action.episode,
+        isPlaying: true,
+        isBuffering: true,
+        isVisible: true,
+        hasError: false,
+        errorMessage: null,
+        duration: action.episode.duration ?? 0,
+      }
+    case "SET_PLAYING":
+      return { ...state, isPlaying: action.isPlaying }
+    case "SET_BUFFERING":
+      return { ...state, isBuffering: action.isBuffering }
+    case "SET_DURATION":
+      return { ...state, duration: action.duration }
+    case "SET_VOLUME":
+      return { ...state, volume: action.volume }
+    case "SET_PLAYBACK_SPEED":
+      return { ...state, playbackSpeed: action.speed }
+    case "SET_ERROR":
+      return {
+        ...state,
+        hasError: true,
+        errorMessage: action.message,
+        isPlaying: false,
+        isBuffering: false,
+      }
+    case "CLEAR_ERROR":
+      return { ...state, hasError: false, errorMessage: null }
+    case "CLOSE":
+      return {
+        ...state,
+        currentEpisode: null,
+        isPlaying: false,
+        isBuffering: false,
+        isVisible: false,
+        hasError: false,
+        errorMessage: null,
+        duration: 0,
+      }
+    default:
+      return state
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+// MediaError.code constants (numeric values per spec, avoids runtime reference issues)
+const MEDIA_ERR_ABORTED = 1
+const MEDIA_ERR_NETWORK = 2
+const MEDIA_ERR_DECODE = 3
+const MEDIA_ERR_SRC_NOT_SUPPORTED = 4
+
+function getMediaErrorMessage(code: number): string {
+  switch (code) {
+    case MEDIA_ERR_ABORTED:
+      return "Playback was aborted."
+    case MEDIA_ERR_NETWORK:
+      return "A network error occurred while loading audio."
+    case MEDIA_ERR_DECODE:
+      return "The audio file could not be decoded."
+    case MEDIA_ERR_SRC_NOT_SUPPORTED:
+      return "This audio format is not supported."
+    default:
+      return "An unknown playback error occurred."
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contexts
+// ---------------------------------------------------------------------------
+
+export const AudioPlayerAPIContext = createContext<AudioPlayerAPI | null>(null)
+export const AudioPlayerStateContext = createContext<AudioPlayerState | null>(null)
+export const AudioPlayerProgressContext = createContext<AudioPlayerProgress | null>(null)
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+const SKIP_SECONDS = 15
+const STALL_TIMEOUT_MS = 10_000
+
+const initialState: AudioPlayerState = {
+  currentEpisode: null,
+  isPlaying: false,
+  isBuffering: false,
+  isVisible: false,
+  duration: 0,
+  volume: 1,
+  playbackSpeed: 1,
+  hasError: false,
+  errorMessage: null,
+}
+
+export function AudioPlayerProvider({ children }: { children: ReactNode }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const ariaTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const progressRef = useRef<AudioPlayerProgress>({ currentTime: 0, buffered: 0 })
+  const [progress, setProgress] = useReducer(
+    (_prev: AudioPlayerProgress, next: AudioPlayerProgress) => next,
+    { currentTime: 0, buffered: 0 }
+  )
+
+  // Announce time for screen readers (debounced 15s)
+  const [ariaAnnouncement, setAriaAnnouncement] = useReducer(
+    (_prev: string, next: string) => next,
+    ""
+  )
+
+  // ---- Load preferences on mount ----
+  useEffect(() => {
+    const prefs = loadPlayerPreferences()
+    dispatch({ type: "SET_VOLUME", volume: prefs.volume })
+    dispatch({ type: "SET_PLAYBACK_SPEED", speed: prefs.playbackSpeed })
+  }, [])
+
+  // ---- Sync volume & speed to audio element ----
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.volume = state.volume
+  }, [state.volume])
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.playbackRate = state.playbackSpeed
+  }, [state.playbackSpeed])
+
+  // ---- Stall timeout ----
+  const clearStallTimer = useCallback(() => {
+    if (stallTimerRef.current) {
+      clearTimeout(stallTimerRef.current)
+      stallTimerRef.current = null
+    }
+  }, [])
+
+  const startStallTimer = useCallback(() => {
+    clearStallTimer()
+    stallTimerRef.current = setTimeout(() => {
+      toast.error("Audio stalled", {
+        description: "The audio stream appears to have stalled. Try seeking or reloading.",
+      })
+    }, STALL_TIMEOUT_MS)
+  }, [clearStallTimer])
+
+  // ---- API (stable reference) ----
+  const api = useMemo<AudioPlayerAPI>(
+    () => ({
+      playEpisode: (episode: AudioEpisode) => {
+        const audio = audioRef.current
+        if (!audio) return
+        dispatch({ type: "PLAY_EPISODE", episode })
+        audio.src = episode.audioUrl
+        audio.load()
+        audio.play().catch(() => {
+          // Autoplay blocked — user will see "play" button
+          dispatch({ type: "SET_PLAYING", isPlaying: false })
+        })
+        updateMediaSessionMetadata({
+          title: episode.title,
+          artist: episode.podcastTitle,
+          artwork: episode.artwork,
+        })
+      },
+
+      togglePlay: () => {
+        const audio = audioRef.current
+        if (!audio || !audio.src) return
+        if (audio.paused) {
+          audio.play().catch(() => {
+            dispatch({ type: "SET_PLAYING", isPlaying: false })
+          })
+        } else {
+          audio.pause()
+        }
+      },
+
+      seek: (time: number) => {
+        const audio = audioRef.current
+        if (!audio) return
+        audio.currentTime = Math.max(0, Math.min(time, audio.duration || 0))
+      },
+
+      skipForward: (seconds = SKIP_SECONDS) => {
+        const audio = audioRef.current
+        if (!audio) return
+        audio.currentTime = Math.min(
+          audio.currentTime + seconds,
+          audio.duration || 0
+        )
+      },
+
+      skipBack: (seconds = SKIP_SECONDS) => {
+        const audio = audioRef.current
+        if (!audio) return
+        audio.currentTime = Math.max(audio.currentTime - seconds, 0)
+      },
+
+      setVolume: (volume: number) => {
+        const clamped = Math.max(0, Math.min(1, volume))
+        dispatch({ type: "SET_VOLUME", volume: clamped })
+        savePlayerPreferences({ volume: clamped })
+      },
+
+      setPlaybackSpeed: (speed: number) => {
+        dispatch({ type: "SET_PLAYBACK_SPEED", speed })
+        savePlayerPreferences({ playbackSpeed: speed })
+      },
+
+      closePlayer: () => {
+        const audio = audioRef.current
+        if (audio) {
+          audio.pause()
+          audio.removeAttribute("src")
+          audio.load()
+        }
+        dispatch({ type: "CLOSE" })
+        setProgress({ currentTime: 0, buffered: 0 })
+        clearMediaSession()
+        clearStallTimer()
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally stable: actions close over refs
+    []
+  )
+
+  // ---- Media Session handlers ----
+  useEffect(() => {
+    setupMediaSessionHandlers({
+      onPlay: api.togglePlay,
+      onPause: api.togglePlay,
+      onSeekBackward: () => api.skipBack(),
+      onSeekForward: () => api.skipForward(),
+      onStop: api.closePlayer,
+    })
+    return () => clearMediaSession()
+  }, [api])
+
+  // ---- Audio event listeners ----
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+
+    const onTimeUpdate = () => {
+      const next: AudioPlayerProgress = {
+        currentTime: audio.currentTime,
+        buffered:
+          audio.buffered.length > 0
+            ? audio.buffered.end(audio.buffered.length - 1)
+            : 0,
+      }
+      progressRef.current = next
+      setProgress(next)
+
+      updateMediaSessionPosition(
+        audio.currentTime,
+        audio.duration || 0,
+        audio.playbackRate
+      )
+
+      // Debounced ARIA announcement (every 15s)
+      if (!ariaTimerRef.current) {
+        ariaTimerRef.current = setTimeout(() => {
+          const mins = Math.floor(audio.currentTime / 60)
+          const secs = Math.floor(audio.currentTime % 60)
+          setAriaAnnouncement(`${mins} minutes ${secs} seconds`)
+          ariaTimerRef.current = null
+        }, 15_000)
+      }
+    }
+
+    const onProgress = () => {
+      const next: AudioPlayerProgress = {
+        currentTime: progressRef.current.currentTime,
+        buffered:
+          audio.buffered.length > 0
+            ? audio.buffered.end(audio.buffered.length - 1)
+            : 0,
+      }
+      progressRef.current = next
+      setProgress(next)
+    }
+
+    const onDurationChange = () => {
+      dispatch({ type: "SET_DURATION", duration: audio.duration || 0 })
+    }
+
+    const onPlaying = () => {
+      dispatch({ type: "SET_PLAYING", isPlaying: true })
+      dispatch({ type: "SET_BUFFERING", isBuffering: false })
+      dispatch({ type: "CLEAR_ERROR" })
+      clearStallTimer()
+    }
+
+    const onPause = () => {
+      dispatch({ type: "SET_PLAYING", isPlaying: false })
+      clearStallTimer()
+    }
+
+    const onWaiting = () => {
+      dispatch({ type: "SET_BUFFERING", isBuffering: true })
+      startStallTimer()
+    }
+
+    const onStalled = () => {
+      dispatch({ type: "SET_BUFFERING", isBuffering: true })
+      startStallTimer()
+    }
+
+    const onEnded = () => {
+      dispatch({ type: "SET_PLAYING", isPlaying: false })
+      clearStallTimer()
+    }
+
+    const onError = () => {
+      const errorCode = audio.error?.code ?? 0
+      const message = getMediaErrorMessage(errorCode)
+      dispatch({ type: "SET_ERROR", message })
+      toast.error("Playback error", { description: message })
+      clearStallTimer()
+    }
+
+    audio.addEventListener("timeupdate", onTimeUpdate)
+    audio.addEventListener("progress", onProgress)
+    audio.addEventListener("durationchange", onDurationChange)
+    audio.addEventListener("playing", onPlaying)
+    audio.addEventListener("pause", onPause)
+    audio.addEventListener("waiting", onWaiting)
+    audio.addEventListener("stalled", onStalled)
+    audio.addEventListener("ended", onEnded)
+    audio.addEventListener("error", onError)
+
+    return () => {
+      audio.removeEventListener("timeupdate", onTimeUpdate)
+      audio.removeEventListener("progress", onProgress)
+      audio.removeEventListener("durationchange", onDurationChange)
+      audio.removeEventListener("playing", onPlaying)
+      audio.removeEventListener("pause", onPause)
+      audio.removeEventListener("waiting", onWaiting)
+      audio.removeEventListener("stalled", onStalled)
+      audio.removeEventListener("ended", onEnded)
+      audio.removeEventListener("error", onError)
+      clearStallTimer()
+      if (ariaTimerRef.current) {
+        clearTimeout(ariaTimerRef.current)
+      }
+    }
+  }, [clearStallTimer, startStallTimer])
+
+  return (
+    <AudioPlayerAPIContext.Provider value={api}>
+      <AudioPlayerStateContext.Provider value={state}>
+        <AudioPlayerProgressContext.Provider value={progress}>
+          {children}
+          {/* Hidden audio element */}
+          <audio ref={audioRef} preload="metadata" />
+          {/* Screen reader time announcements */}
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {ariaAnnouncement}
+          </div>
+        </AudioPlayerProgressContext.Provider>
+      </AudioPlayerStateContext.Provider>
+    </AudioPlayerAPIContext.Provider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useAudioPlayerAPI(): AudioPlayerAPI {
+  const ctx = useContext(AudioPlayerAPIContext)
+  if (!ctx) {
+    throw new Error("useAudioPlayerAPI must be used within AudioPlayerProvider")
+  }
+  return ctx
+}
+
+export function useAudioPlayerState(): AudioPlayerState {
+  const ctx = useContext(AudioPlayerStateContext)
+  if (!ctx) {
+    throw new Error("useAudioPlayerState must be used within AudioPlayerProvider")
+  }
+  return ctx
+}
+
+export function useAudioPlayerProgress(): AudioPlayerProgress {
+  const ctx = useContext(AudioPlayerProgressContext)
+  if (!ctx) {
+    throw new Error(
+      "useAudioPlayerProgress must be used within AudioPlayerProvider"
+    )
+  }
+  return ctx
+}
+
+/** Convenience hook combining state + API (not progress — to avoid high-frequency re-renders). */
+export function useAudioPlayer() {
+  return {
+    ...useAudioPlayerState(),
+    ...useAudioPlayerAPI(),
+  }
+}

--- a/src/lib/media-session.ts
+++ b/src/lib/media-session.ts
@@ -1,0 +1,69 @@
+export interface MediaSessionTrack {
+  title: string
+  artist: string
+  artwork?: string
+}
+
+export function updateMediaSessionMetadata(track: MediaSessionTrack): void {
+  if (typeof navigator === "undefined" || !("mediaSession" in navigator)) return
+
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title: track.title,
+    artist: track.artist,
+    artwork: track.artwork
+      ? [
+          { src: track.artwork, sizes: "96x96", type: "image/png" },
+          { src: track.artwork, sizes: "128x128", type: "image/png" },
+          { src: track.artwork, sizes: "192x192", type: "image/png" },
+          { src: track.artwork, sizes: "256x256", type: "image/png" },
+          { src: track.artwork, sizes: "384x384", type: "image/png" },
+          { src: track.artwork, sizes: "512x512", type: "image/png" },
+        ]
+      : [],
+  })
+}
+
+export function setupMediaSessionHandlers(handlers: {
+  onPlay: () => void
+  onPause: () => void
+  onSeekBackward: () => void
+  onSeekForward: () => void
+  onStop: () => void
+}): void {
+  if (typeof navigator === "undefined" || !("mediaSession" in navigator)) return
+
+  navigator.mediaSession.setActionHandler("play", handlers.onPlay)
+  navigator.mediaSession.setActionHandler("pause", handlers.onPause)
+  navigator.mediaSession.setActionHandler("seekbackward", handlers.onSeekBackward)
+  navigator.mediaSession.setActionHandler("seekforward", handlers.onSeekForward)
+  navigator.mediaSession.setActionHandler("stop", handlers.onStop)
+}
+
+export function updateMediaSessionPosition(
+  position: number,
+  duration: number,
+  playbackRate: number
+): void {
+  if (typeof navigator === "undefined" || !("mediaSession" in navigator)) return
+
+  try {
+    navigator.mediaSession.setPositionState({
+      duration: Math.max(0, duration),
+      playbackRate,
+      position: Math.max(0, Math.min(position, duration)),
+    })
+  } catch {
+    // setPositionState can throw if values are invalid
+  }
+}
+
+export function clearMediaSession(): void {
+  if (typeof navigator === "undefined" || !("mediaSession" in navigator)) return
+
+  navigator.mediaSession.metadata = null
+  navigator.mediaSession.setActionHandler("play", null)
+  navigator.mediaSession.setActionHandler("pause", null)
+  navigator.mediaSession.setActionHandler("seekbackward", null)
+  navigator.mediaSession.setActionHandler("seekforward", null)
+  navigator.mediaSession.setActionHandler("stop", null)
+}

--- a/src/lib/player-preferences.ts
+++ b/src/lib/player-preferences.ts
@@ -1,0 +1,50 @@
+const STORAGE_KEY = "contentgenie-player-preferences"
+
+export const SPEED_OPTIONS = [1, 1.25, 1.5, 2] as const
+export type SpeedOption = (typeof SPEED_OPTIONS)[number]
+
+export interface PlayerPreferences {
+  volume: number
+  playbackSpeed: number
+}
+
+const DEFAULT_PREFERENCES: PlayerPreferences = {
+  volume: 1,
+  playbackSpeed: 1,
+}
+
+export function loadPlayerPreferences(): PlayerPreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_PREFERENCES
+
+    const parsed = JSON.parse(raw) as Partial<PlayerPreferences>
+    return {
+      volume:
+        typeof parsed.volume === "number" && parsed.volume >= 0 && parsed.volume <= 1
+          ? parsed.volume
+          : DEFAULT_PREFERENCES.volume,
+      playbackSpeed:
+        typeof parsed.playbackSpeed === "number" &&
+        (SPEED_OPTIONS as readonly number[]).includes(parsed.playbackSpeed)
+          ? (parsed.playbackSpeed as SpeedOption)
+          : DEFAULT_PREFERENCES.playbackSpeed,
+    }
+  } catch {
+    return DEFAULT_PREFERENCES
+  }
+}
+
+export function savePlayerPreferences(prefs: Partial<PlayerPreferences>): void {
+  if (typeof window === "undefined") return
+
+  try {
+    const current = loadPlayerPreferences()
+    const merged = { ...current, ...prefs }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
+  } catch {
+    // localStorage may be unavailable (e.g. private browsing quota exceeded)
+  }
+}


### PR DESCRIPTION
## Summary

- Add a persistent bottom-bar audio player that stays visible across all authenticated `(app)` routes during playback
- Replace external "Listen to Episode" link with in-app playback using HTML5 `<audio>` element
- Use React Context with **triple split** (API / State / Progress) for render performance — high-frequency `timeupdate` events (~4x/sec) only re-render the seek bar
- Integrate Media Session API for OS-level controls (lock screen, notification center, headphone buttons)
- Persist playback speed and volume preferences to localStorage
- Responsive layout: single-row desktop (72px), two-row mobile (96px)
- Full accessibility: ARIA labels, keyboard navigation, `aria-live` region for time announcements

### New files
- `src/contexts/audio-player-context.tsx` — Triple context provider with `useReducer`, `<audio>` ref, Media Session, error handling
- `src/lib/media-session.ts` — Media Session API helpers
- `src/lib/player-preferences.ts` — localStorage persistence (SSR-safe)
- `src/components/layout/app-shell.tsx` — Client wrapper keeping `(app)/layout.tsx` as Server Component
- `src/components/audio-player/` — PlayerBar, SeekBar, PlaybackSpeed, VolumeControl
- `src/components/ui/slider.tsx` — shadcn/ui Slider (Radix)
- `docs/adr/004-audio-player-state-management.md` — ADR for React Context decision

### Modified files
- `src/app/(app)/layout.tsx` — Delegates to `<AppShell>`
- `src/app/(app)/episode/[id]/page.tsx` — In-app play/pause/resume button
- `CHANGELOG.md` — Feature entry
- `AGENTS.md` — Added ADR section

## Test plan

- [x] 49 new unit tests (356 total), all passing
- [x] 19 Storybook stories across all player sub-components (responsive variants, state variants, mock context)
- [x] `bun run lint` — clean
- [x] `bun run test` — 356/356 pass
- [x] `bun run build` — succeeds
- [x] `bun run build-storybook` — succeeds
- [x] Code review passed (3 blockers found → fixed → re-approved)
- [x] QA verification of all 15+ acceptance criteria from issue #93

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-app audio player with playback controls: play, pause, skip forward/backward (±15s), adjustable playback speed (1x, 1.25x, 1.5x, 2x), and volume control.
  * Episode pages now display dynamic play/pause buttons reflecting playback state.
  * Playback preferences (volume and speed) persist across sessions.
  * Integrated OS media controls via Media Session API.

* **Documentation**
  * Added architecture decision records documenting audio player state management design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->