### PR TITLE
chore: stabilize SSRF redirect tests with public-IP fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Episode artwork and title in the audio player bar now link to the episode detail page (`/episode/[id]`), with hover feedback, aria-label for accessibility, and touch feedback on mobile (#115)
 
 ### Fixed
+- Fixed non-deterministic SSRF redirect tests by using public-IP fixtures instead of hostname-based URLs
 - Fixed DNS rebinding TOCTOU vulnerability in SSRF-protected fetch by pinning validated DNS resolution to TCP connections via undici Agent (#80)
 - Cancel stale discover search requests when query changes, preventing outdated results from overwriting current results (#104)
 - Podcast page back navigation is now context-aware — shows "Back to Subscriptions", "Back to Dashboard", etc. based on where the user came from (#86)
@@ -36,7 +37,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - PodcastIndex API authentication headers are now stabilized to 30-second windows, enabling Next.js `fetch` caching and reducing redundant network requests
 - Rate limiting upgraded from in-memory to distributed (Postgres-backed) for serverless compatibility
 - CI workflow simplified to quality checks only (lint, test, Storybook); Vercel handles builds and deploys
-- Updated SSRF redirect tests to use public-IP fixtures for deterministic safety checks
 
 ### Added
 - Persistent in-app audio player with play/pause, seek, skip ±15s, playback speed, volume, and OS media controls via Media Session API (#93)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ ContentGenie helps you find podcasts, get AI-generated episode summaries with ke
 - [Doppler CLI](https://docs.doppler.com/docs/install-cli) for secrets management
 - Access to the Doppler `contentgenie` project
 
-```bash
-# Install Bun
-curl -fsSL https://bun.sh/install | bash
-```
-
 ### Setup
 
 ```bash


### PR DESCRIPTION
## Summary
- Stabilize SSRF redirect tests by switching from hostname-based fixtures to public-IP fixtures for deterministic safety checks
- Move SSRF test changelog entry to Fixed section (test flakiness is a bug fix, not a user-facing change)
- Remove standalone Bun install block from README (duplicates existing Prerequisites link)

## Test plan
- [x] bun run lint
- [x] bun run test -- src/lib/__tests__/rss-security.test.ts
- [x] bun run test
- [x] bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic SSRF redirect tests for improved reliability.

* **Tests**
  * Enhanced SSRF security test coverage with improved DNS-based validation logic to ensure consistent protection against redirect vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->