### PR TITLE
fix: stop swallowing errors in fetchTranscriptFromUrl

### DIFF
--- a/src/trigger/helpers/__tests__/transcript.test.ts
+++ b/src/trigger/helpers/__tests__/transcript.test.ts
@@ -94,12 +94,12 @@ describe("fetchTranscriptFromUrl", () => {
     expect(result).toContain("[Transcript truncated...]");
   });
 
-  it("returns undefined on error", async () => {
+  it("throws on fetch error", async () => {
     vi.mocked(safeFetch).mockRejectedValue(new Error("Network error"));
 
-    const result = await fetchTranscriptFromUrl("https://example.com/t");
-
-    expect(result).toBeUndefined();
+    await expect(fetchTranscriptFromUrl("https://example.com/t")).rejects.toThrow(
+      "Network error"
+    );
   });
 
   it("returns undefined for empty response", async () => {

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -98,8 +98,6 @@ export async function fetchTranscriptFromUrl(
     }
 
     return content;
-  } catch {
-    return undefined;
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
## Summary

- Remove the bare `catch {}` block in `fetchTranscriptFromUrl` that silently swallowed all `safeFetch` errors and returned `undefined`
- This caused the caller in `summarize-episode.ts` to log the unhelpful "Description transcript URL returned no content" instead of the actual error (e.g. 403, timeout, DNS failure)
- Errors now propagate to the caller's existing catch block, which logs the real failure reason in Trigger.dev

## Test plan

- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — all 624 tests pass
- [x] `bun run build` — production build succeeds
- [ ] Re-trigger episode 49946503603 on Trigger.dev and verify the real error appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)