### PR TITLE
fix: use Z.AI coding plan endpoint for GLM-5 compatibility

### DIFF
--- a/src/lib/ai/__tests__/zai-provider.test.ts
+++ b/src/lib/ai/__tests__/zai-provider.test.ts
@@ -47,7 +47,7 @@ describe("ZaiProvider", () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://api.z.ai/api/paas/v4/chat/completions");
+    expect(url).toBe("https://api.z.ai/api/coding/paas/v4/chat/completions");
     expect(options.headers.Authorization).toBe("Bearer zai-test-key");
     expect(options.headers["Content-Type"]).toBe("application/json");
     expect(options.headers).not.toHaveProperty("HTTP-Referer");

--- a/src/lib/ai/providers/zai.ts
+++ b/src/lib/ai/providers/zai.ts
@@ -1,6 +1,6 @@
 import type { AiProvider, AiMessage, AiCompletionOptions } from "@/lib/ai/types";
 
-const ZAI_API_URL = "https://api.z.ai/api/paas/v4/chat/completions";
+const ZAI_API_URL = "https://api.z.ai/api/coding/paas/v4/chat/completions";
 
 export class ZaiProvider implements AiProvider {
   readonly name = "zai";


### PR DESCRIPTION
## Summary

- The Z.AI Pro/Coding plan requires the endpoint `https://api.z.ai/api/coding/paas/v4` — not the standard `https://api.z.ai/api/paas/v4` our code was using
- Using the wrong endpoint returns `429 / error 1113` ("Insufficient balance or no resource package") even with a valid Pro plan and GLM-5 configured
- Updated the URL constant in `src/lib/ai/providers/zai.ts` and fixed the matching assertion in the test

## Test plan

- [x] `bun run lint` — no errors
- [x] `bun run test` — all 624 tests pass
- [ ] Verify re-summarization works in prod after merge and deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI service endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->