### PR TITLE
fix: rename Clerk redirect env vars to use NEXT_PUBLIC_ prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,21 +164,11 @@ Tables: `users`, `podcasts`, `episodes`, `user_subscriptions`, `collections`, `u
 
 Secrets are managed via **Doppler** (not `.env` files). Run `doppler setup` after cloning.
 
-Available environment variables:
-- `CLERK_SECRET_KEY` — Clerk backend auth
-- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — Clerk frontend auth
-- `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` — Fallback redirect after sign-in (e.g. `/dashboard`); only used when no `redirect_url` query param is present
-- `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` — Fallback redirect after sign-up (e.g. `/dashboard`); only used when no `redirect_url` query param is present
-- `NEXT_PUBLIC_CLERK_SIGN_IN_URL` — Clerk sign-in page URL (e.g. `/sign-in`)
-- `NEXT_PUBLIC_CLERK_SIGN_UP_URL` — Clerk sign-up page URL (e.g. `/sign-up`)
-- `DATABASE_URL` — Neon Postgres connection string
-- `OPENROUTER_API_KEY` — OpenRouter AI API
-- `PODCASTINDEX_API_KEY` — PodcastIndex API key
-- `PODCASTINDEX_API_SECRET` — PodcastIndex API secret
-- `NEXT_PUBLIC_APP_URL` — Application URL (inlined at build time)
-- `TRIGGER_SECRET_KEY` — Trigger.dev secret key (background jobs)
-- `ZAI_API_KEY` — Z.AI GLM API key
-- `ASSEMBLYAI_API_KEY` — AssemblyAI transcription API key
+See [docs/secrets-management.md](docs/secrets-management.md) for the full list of managed secrets, their types (Server vs Public), and per-environment setup instructions. Key points:
+
+- `NEXT_PUBLIC_*` variables are **inlined at build time** — rebuild after changing them in Doppler.
+- `doppler run --` is already wired into most `bun run` scripts; use `doppler run -- <cmd>` for ad-hoc commands.
+- Vercel environments are synced from Doppler automatically; Trigger.dev Prod secrets are set manually.
 
 ## Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Episode artwork and title in the audio player bar now link to the episode detail page (`/episode/[id]`), with hover feedback, aria-label for accessibility, and touch feedback on mobile (#115)
 
 ### Fixed
-- Fixed Clerk hosted sign-in/sign-up not redirecting back to the app by replacing server-only redirect environment variables with correctly-prefixed `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` / `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` that Clerk's client-side components can read
+- Fixed Clerk hosted sign-in/sign-up not redirecting back to the app by replacing `CLERK_SIGN_IN_FORCE_REDIRECT_URL` / `CLERK_SIGN_UP_FORCE_REDIRECT_URL` with `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` / `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` (public-prefixed, fallback semantics so `auth.protect()` redirect takes precedence) and adding `NEXT_PUBLIC_CLERK_SIGN_IN_URL` / `NEXT_PUBLIC_CLERK_SIGN_UP_URL` for correct routing to embedded auth pages
 - Fixed non-deterministic SSRF redirect tests by using public-IP fixtures instead of hostname-based URLs
 - Fixed DNS rebinding TOCTOU vulnerability in SSRF-protected fetch by pinning validated DNS resolution to TCP connections via undici Agent (#80)
 - Cancel stale discover search requests when query changes, preventing outdated results from overwriting current results (#104)

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -65,10 +65,10 @@ Most `package.json` scripts are wrapped with `doppler run --`, which injects env
 | `NEXT_PUBLIC_APP_URL` | Public | Application URL (inlined at build time) |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Public | Clerk publishable key (inlined at build time) |
 | `CLERK_SECRET_KEY` | Server | Clerk secret key |
-| `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | Public | Fallback redirect after sign-in (e.g. `/dashboard`); only used when no `redirect_url` query param is present |
-| `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | Public | Fallback redirect after sign-up (e.g. `/dashboard`); only used when no `redirect_url` query param is present |
-| `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | Public | Clerk sign-in page URL (e.g. `/sign-in`) |
-| `NEXT_PUBLIC_CLERK_SIGN_UP_URL` | Public | Clerk sign-up page URL (e.g. `/sign-up`) |
+| `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | Public | Fallback redirect after sign-in (e.g. `/dashboard`); only used when no `redirect_url` query param is present (inlined at build time) |
+| `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` | Public | Fallback redirect after sign-up (e.g. `/dashboard`); only used when no `redirect_url` query param is present (inlined at build time) |
+| `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | Public | Clerk sign-in page URL (e.g. `/sign-in`) (inlined at build time) |
+| `NEXT_PUBLIC_CLERK_SIGN_UP_URL` | Public | Clerk sign-up page URL (e.g. `/sign-up`) (inlined at build time) |
 | `TRIGGER_SECRET_KEY` | Server | Trigger.dev secret key (background jobs) |
 | `ZAI_API_KEY` | Server | Z.AI GLM API key (add to Doppler `dev`, `stg`, and `prd` configs) |
 | `ASSEMBLYAI_API_KEY` | Server | AssemblyAI transcription API key |


### PR DESCRIPTION
## Summary

- **Root cause**: Clerk redirect environment variables (`CLERK_SIGN_IN_FORCE_REDIRECT_URL`) were missing the `NEXT_PUBLIC_` prefix, making them invisible to the browser-side Clerk SDK. After sign-in, users landed on Clerk's profile page instead of being redirected back to the app.
- Renamed Doppler env vars to `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` / `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL` across all configs (dev, stg, prd). Used FALLBACK variant (not FORCE) so `auth.protect()` middleware's `redirect_url` takes precedence for protected routes.
- Added `NEXT_PUBLIC_CLERK_SIGN_IN_URL` (`/sign-in`) and `NEXT_PUBLIC_CLERK_SIGN_UP_URL` (`/sign-up`) for correct routing between auth flows.
- Updated `AGENTS.md`, `docs/secrets-management.md`, and `CHANGELOG.md` to reflect the new variable names and types.

## Test plan

- [ ] Verify Doppler env vars are renamed in all configs: `doppler secrets --config dev | grep CLERK`
- [ ] Rebuild Vercel preview deployment (NEXT_PUBLIC_ vars are inlined at build time)
- [ ] Sign in via embedded `/sign-in` page → should redirect to `/dashboard`
- [ ] Sign in via Clerk hosted page (accounts.dev) → should redirect to `/dashboard`
- [ ] Visit protected route while signed out → sign in → should return to original route
- [ ] Sign up flow → should redirect to `/dashboard`
- [ ] If hosted page redirect still fails after rebuild, add `signInFallbackRedirectUrl="/dashboard"` prop to `<ClerkProvider>` as defense-in-depth

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication redirect behavior so hosted sign-in/sign-up pages correctly return users to the app.

* **Documentation**
  * Updated secrets and environment docs: introduced publicNEXT_PUBLIC_* variables for Clerk fallbacks and explicit URLs, noted build-time inlining, added guidance for using managed secrets tooling and platform sync behavior, and clarified per-environment setup and manual secret steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->