### PR TITLE
fix: restore Worth-It score colors and redesign badge as pill

### DIFF
--- a/src/components/__tests__/worth-it-badge.test.tsx
+++ b/src/components/__tests__/worth-it-badge.test.tsx
@@ -10,24 +10,27 @@ describe("WorthItBadge", () => {
 
   it("renders score value and label for high score (>= 8)", () => {
     render(<WorthItBadge score={8.5} />);
-    expect(screen.getByText("8.5")).toBeInTheDocument();
-    expect(screen.getByText("Exceptional")).toBeInTheDocument();
+    const badge = screen.getByText(/8\.5/);
+    expect(badge).toHaveTextContent("8.5");
+    expect(badge).toHaveTextContent("Exceptional");
   });
 
   it("renders score value and label for mid score (4-5.9)", () => {
     render(<WorthItBadge score={4.5} />);
-    expect(screen.getByText("4.5")).toBeInTheDocument();
-    expect(screen.getByText("Average")).toBeInTheDocument();
+    const badge = screen.getByText(/4\.5/);
+    expect(badge).toHaveTextContent("4.5");
+    expect(badge).toHaveTextContent("Average");
   });
 
   it("renders score value and label for low score (< 2)", () => {
     render(<WorthItBadge score={1.0} />);
-    expect(screen.getByText("1.0")).toBeInTheDocument();
-    expect(screen.getByText("Skip")).toBeInTheDocument();
+    const badge = screen.getByText(/1\.0/);
+    expect(badge).toHaveTextContent("1.0");
+    expect(badge).toHaveTextContent("Skip");
   });
 
   it("displays score with one decimal place", () => {
     render(<WorthItBadge score={7} />);
-    expect(screen.getByText("7.0")).toBeInTheDocument();
+    expect(screen.getByText(/7\.0/)).toBeInTheDocument();
   });
 });

--- a/src/components/episodes/worth-it-badge.stories.tsx
+++ b/src/components/episodes/worth-it-badge.stories.tsx
@@ -4,6 +4,13 @@ import { WorthItBadge } from "./worth-it-badge";
 const meta: Meta<typeof WorthItBadge> = {
   title: "Episodes/WorthItBadge",
   component: WorthItBadge,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-4 p-6">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/episodes/worth-it-badge.tsx
+++ b/src/components/episodes/worth-it-badge.tsx
@@ -9,18 +9,13 @@ export function WorthItBadge({ score }: WorthItBadgeProps) {
   if (score === null) return null;
 
   return (
-    <div className="flex items-center gap-2">
-      <div
-        className={cn(
-          "flex h-10 w-10 items-center justify-center rounded-full text-white shadow-sm",
-          getScoreColor(score)
-        )}
-      >
-        <span className="text-sm font-bold">{score.toFixed(1)}</span>
-      </div>
-      <span className="text-sm font-medium text-muted-foreground">
-        {getScoreLabel(score)}
-      </span>
-    </div>
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold text-white",
+        getScoreColor(score)
+      )}
+    >
+      {score.toFixed(1)} &middot; {getScoreLabel(score)}
+    </span>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/lib/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
   	extend: {


### PR DESCRIPTION
## Summary

- Adds `src/lib` to Tailwind content scan in `tailwind.config.ts` so `bg-green-500`, `bg-emerald-500`, `bg-yellow-500`, `bg-orange-500`, and `bg-red-500` from `score-utils.ts` are no longer purged in production JIT builds — restores color to all Worth-It score bars and the badge
- Redesigns `WorthItBadge` from a circle+separate label to a compact colored pill: `[ 8.5 · Exceptional ]` on a solid score-colored background with white text
- Updates tests in `worth-it-badge.test.tsx` to use `toHaveTextContent`/regex matchers for the new single-element pill rendering
- Adds Storybook decorator for better pill visual presentation

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 631/631 pass (5 WorthItBadge tests + 10 score-utils regression tests)
- [x] `bun run build` — success; all 5 score color classes confirmed present in production CSS output
- [x] `bun run build-storybook` — success, all 6 WorthItBadge stories compile

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the worth-it badge to display the score and rating label together in a single unified element for a more compact visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->