### PR TITLE
fix: make flaky tests environment-independent

### DIFF
--- a/src/lib/__tests__/openrouter.test.ts
+++ b/src/lib/__tests__/openrouter.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { parseJsonResponse, generateCompletion } from "@/lib/openrouter";
 
+// generateCompletion routes through @/lib/ai which calls getActiveAiConfig() → DB.
+// Mock the config module so tests never touch the database.
+vi.mock("@/lib/ai/config", () => ({
+  getActiveAiConfig: vi.fn().mockResolvedValue({
+    provider: "openrouter",
+    model: "google/gemini-2.0-flash-001",
+  }),
+  DEFAULT_AI_CONFIG: {
+    provider: "openrouter",
+    model: "google/gemini-2.0-flash-001",
+  },
+}));
+
 describe("parseJsonResponse", () => {
   it("parses plain JSON", () => {
     const result = parseJsonResponse<{ foo: string }>(

--- a/src/trigger/helpers/__tests__/notifications.test.ts
+++ b/src/trigger/helpers/__tests__/notifications.test.ts
@@ -345,8 +345,13 @@ describe("trigger/helpers/notifications", () => {
     });
 
     it("returns zero when VAPID keys are not configured", async () => {
-      vi.unstubAllEnvs();
-      // No VAPID env vars set
+      // Explicitly stub to empty strings rather than calling vi.unstubAllEnvs(),
+      // which restores the original process.env values (Doppler injects real VAPID
+      // keys locally, causing the function to proceed past the VAPID check).
+      vi.stubEnv("VAPID_PRIVATE_KEY", "");
+      vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "");
+      vi.stubEnv("VAPID_SUBJECT", "");
+      vi.resetModules();
 
       const { sendPushToUser } = await import(
         "@/trigger/helpers/notifications"


### PR DESCRIPTION
## Summary

- **`openrouter.test.ts`**: Mocks `@/lib/ai/config` so `generateCompletion` never touches the database. Previously, `generateCompletion` routes through `@/lib/ai/generate` which calls `getActiveAiConfig()` → Neon serverless HTTP. With Doppler injecting a real `DATABASE_URL` locally, the Neon driver intercepted the mocked `fetch`, causing `mockFetch.mock.calls[0]` to be the DB call instead of the OpenRouter call — so `body.model` was `undefined` instead of `"google/gemini-2.0-flash-001"`.
- **`trigger/helpers/notifications.test.ts`**: Replaces `vi.unstubAllEnvs()` with explicit empty-string stubs for the three VAPID keys + a `vi.resetModules()` call. `vi.unstubAllEnvs()` restores the *original* `process.env` values, which include real Doppler VAPID keys locally — so `ensureVapidConfigured()` didn't throw and the function proceeded past the VAPID guard.

Both tests now pass identically in local (Doppler) and CI (no secrets) environments.

## Test plan

- [ ] `bun run test` passes with 724/724 tests locally (verified before PR)
- [ ] CI passes on the PR