### PR TITLE
docs: lean down AGENTS.md by extracting derivable knowledge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,3 @@ See [docs/secrets-management.md](docs/secrets-management.md) for the full variab
 - All non-public routes protected by Clerk middleware.
 - No `.env` files committed — Doppler handles secrets injection.
 - Server actions validate `auth()` before mutations. API routes verify authentication before processing.
-
-## Project structure & architecture
-
-See `project-structure.md` in project memory for directory layout, database schema, architecture patterns, and ADR index.


### PR DESCRIPTION
## Summary

- Move directory layout, DB schema, architecture patterns, and ADR index from `AGENTS.md` → new `docs/project-structure.md`
- All removed content was either derivable from the filesystem or available by reading the referenced files — not behavioral instructions
- Add a one-line footer in `AGENTS.md` pointing to `docs/project-structure.md` so agents know where to look

**AGENTS.md: 185 → 80 lines (-57%)**. No behavioral instructions were removed.

Follows the same pattern as [rube-de/cc-skills#88](https://github.com/rube-de/cc-skills/pull/88).

## Test plan

- [ ] CI passes (lint, tests, build)
- [ ] All sections in the original `AGENTS.md` are accounted for — either retained, moved to `docs/project-structure.md`, or collapsed to a single reference line
- [ ] `docs/project-structure.md` renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined and simplified existing project documentation for improved clarity.
  * Added comprehensive documentation detailing project structure, database schema, and architectural patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->