### PR TITLE
fix: address remaining PR #170 review comments

### DIFF
--- a/src/components/audio-player/queue-panel.tsx
+++ b/src/components/audio-player/queue-panel.tsx
@@ -174,7 +174,7 @@ function QueueList() {
 interface QueuePanelProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  trigger: React.ReactNode
+  trigger: React.ReactElement
 }
 
 export function QueuePanel({ open, onOpenChange, trigger }: QueuePanelProps) {

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -318,8 +318,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
         audio.src = episode.audioUrl
         audio.load()
         audio.play().catch(() => {
-          // Autoplay blocked — user will see "play" button
+          // Play failed — keep player state consistent
           dispatch({ type: "SET_PLAYING", isPlaying: false })
+          dispatch({ type: "SET_BUFFERING", isBuffering: false })
         })
         updateMediaSessionMetadata({
           title: episode.title,
@@ -529,6 +530,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           },
         })
 
+        clearAutoPlayTimer()
         autoPlayTimerRef.current = setTimeout(() => {
           autoPlayTimerRef.current = null
           api.playNext()

--- a/src/lib/__tests__/queue-persistence.test.ts
+++ b/src/lib/__tests__/queue-persistence.test.ts
@@ -62,6 +62,22 @@ describe("loadQueue", () => {
     expect(result[1].id).toBe("ep-2")
   })
 
+  it("deduplicates items with the same ID", () => {
+    const duplicate: AudioEpisode = {
+      ...validEpisode,
+      title: "Duplicate of ep-1",
+    }
+    window.localStorage.setItem(
+      "contentgenie-player-queue",
+      JSON.stringify([validEpisode, duplicate, validEpisode2])
+    )
+    const result = loadQueue()
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe("ep-1")
+    expect(result[0].title).toBe("Test Episode") // keeps first occurrence
+    expect(result[1].id).toBe("ep-2")
+  })
+
   it("returns empty array for corrupted JSON", () => {
     window.localStorage.setItem(
       "contentgenie-player-queue",


### PR DESCRIPTION
## Summary
- Tighten `QueuePanelProps.trigger` type from `React.ReactNode` to `React.ReactElement` to match `asChild` contract on `PopoverTrigger`/`SheetTrigger`
- Reset `isBuffering` in `playEpisode` catch handler to prevent UI stuck in spinner state on play failure
- Call `clearAutoPlayTimer()` before scheduling new auto-play timeout to prevent double-firing on repeated `ended` events
- Add regression test for `loadQueue()` ID deduplication

Follows up on review comments from PR #170 that were addressed locally but not pushed before merge.

## Test plan
- [x] `bun run lint` — no errors
- [x] `bun run test` — 877 tests passing
- [ ] Verify queue panel opens correctly on desktop (Popover) and mobile (Sheet)
- [ ] Verify player recovers cleanly when autoplay is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where autoplay timers could overlap when multiple consecutive tracks end, preventing unintended playback behavior and track skipping
  * Improved error handling to properly clear buffering state when playback fails, ensuring the UI accurately reflects the player status

* **Tests**
  * Added test coverage for queue deduplication functionality, verifying that duplicate episodes are correctly identified and removed while preserving the first occurrence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->