### PR TITLE
fix: sleep timer edge cases from post-merge review

### DIFF
--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -364,6 +364,10 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     if (fadeCleanupRef.current) {
       fadeCleanupRef.current()
       fadeCleanupRef.current = null
+      // Re-sync volume — the fade cleanup restores the pre-fade volume,
+      // but the user may have adjusted volume during the fade
+      const audio = audioRef.current
+      if (audio) audio.volume = stateRef.current.volume
     }
   }, [])
 
@@ -372,9 +376,11 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     if (!audio) return
     clearSleepTimerInterval()
     cancelFade()
+    clearAutoPlayTimer()
 
     if (audio.paused) {
       // Already paused — skip fade, just clear timer and notify
+      dispatch({ type: "SET_BUFFERING", isBuffering: false })
       dispatch({ type: "CLEAR_SLEEP_TIMER" })
       toast(SLEEP_TIMER_TOAST)
       return
@@ -383,10 +389,13 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     fadeCleanupRef.current = fadeOutAudio(audio, SLEEP_FADE_DURATION_MS, () => {
       fadeCleanupRef.current = null
       dispatch({ type: "SET_PLAYING", isPlaying: false })
+      dispatch({ type: "SET_BUFFERING", isBuffering: false })
       dispatch({ type: "CLEAR_SLEEP_TIMER" })
+      // Re-sync volume in case user adjusted it during the fade
+      audio.volume = stateRef.current.volume
       toast(SLEEP_TIMER_TOAST)
     })
-  }, [clearSleepTimerInterval, cancelFade])
+  }, [clearSleepTimerInterval, cancelFade, clearAutoPlayTimer])
 
   // Ref for stable access in intervals/event handlers without dependency churn
   const triggerSleepTimerExpiryRef = useRef(triggerSleepTimerExpiry)

--- a/src/lib/audio-fade.ts
+++ b/src/lib/audio-fade.ts
@@ -1,4 +1,4 @@
-const FADE_STEP_MS = 50;
+const FADE_STEP_MS = 50
 
 /**
  * Gradually fades out audio volume and pauses playback on completion.
@@ -13,35 +13,35 @@ export function fadeOutAudio(
   durationMs: number,
   onComplete: () => void
 ): () => void {
-  const originalVolume = audio.volume;
+  const originalVolume = audio.volume
   const safeDurationMs =
-    Number.isFinite(durationMs) && durationMs > 0 ? durationMs : FADE_STEP_MS;
-  const totalSteps = Math.max(1, Math.round(safeDurationMs / FADE_STEP_MS));
-  const volumeStep = originalVolume / totalSteps;
+    Number.isFinite(durationMs) && durationMs > 0 ? durationMs : FADE_STEP_MS
+  const totalSteps = Math.max(1, Math.round(safeDurationMs / FADE_STEP_MS))
+  const volumeStep = originalVolume / totalSteps
 
-  let currentStep = 0;
-  let completed = false;
+  let currentStep = 0
+  let completed = false
 
   const intervalId = setInterval(() => {
-    currentStep++;
+    currentStep++
 
     if (currentStep >= totalSteps) {
-      clearInterval(intervalId);
-      completed = true;
-      audio.volume = 0;
-      audio.pause();
-      audio.volume = originalVolume;
-      onComplete();
-      return;
+      clearInterval(intervalId)
+      completed = true
+      audio.volume = 0
+      audio.pause()
+      audio.volume = originalVolume
+      onComplete()
+      return
     }
 
-    audio.volume = Math.max(0, originalVolume - volumeStep * currentStep);
-  }, FADE_STEP_MS);
+    audio.volume = Math.max(0, originalVolume - volumeStep * currentStep)
+  }, FADE_STEP_MS)
 
   return () => {
-    if (completed) return;
-    completed = true;
-    clearInterval(intervalId);
-    audio.volume = originalVolume;
-  };
+    if (completed) return
+    completed = true
+    clearInterval(intervalId)
+    audio.volume = originalVolume
+  }
 }


### PR DESCRIPTION
## Summary

Addresses 4 items from [Copilot's post-merge review](https://github.com/Chalet-Labs/contentgenie/pull/173#pullrequestreview-3896814560) on PR #173:

- **Auto-play leak**: `triggerSleepTimerExpiry` now calls `clearAutoPlayTimer()` so a pending auto-play-next timeout doesn't fire after the sleep timer pauses playback
- **Stuck buffering spinner**: Dispatch `SET_BUFFERING: false` on both expiry paths (paused early-return and fade completion)
- **Volume desync after fade**: Re-sync `audio.volume` to `stateRef.current.volume` after fade completes or is canceled, since the volume-sync effect skips writes during an active fade
- **Style**: Remove semicolons from `audio-fade.ts` to match repo convention

The 5th comment (background tab timer throttling) was already handled by the existing `visibilitychange` listener.

## Test plan

- [x] `bun run lint` — no errors
- [x] `bun run test` — 952/952 passing
- [ ] Manual: start sleep timer, let episode end during countdown → verify next episode does NOT auto-play
- [ ] Manual: trigger sleep timer while audio is buffering → verify spinner clears after expiry
- [ ] Manual: adjust volume slider during sleep fade → verify correct volume after fade completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sleep timer to properly manage buffering and auto-play states when expiring.
  * Improved audio fade cleanup to maintain proper volume synchronization and clear buffering state.

* **Style**
  * Code formatting and type consistency updates to audio fade utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->