### PR TITLE
fix: fetch transcript text after AssemblyAI webhook completes

### DIFF
--- a/src/trigger/__tests__/summarize-episode.test.ts
+++ b/src/trigger/__tests__/summarize-episode.test.ts
@@ -279,6 +279,45 @@ describe("summarize-episode task", () => {
     );
   });
 
+  it("proceeds without transcript when AssemblyAI follow-up GET returns no text", async () => {
+    vi.mocked(getEpisodeById).mockResolvedValue({ episode: mockEpisode } as never);
+    vi.mocked(getPodcastById).mockResolvedValue({ feed: mockPodcast } as never);
+    vi.mocked(fetchTranscript).mockResolvedValue(undefined);
+    vi.mocked(extractTranscriptUrl).mockReturnValue(null);
+    const mockToken = { id: "token-1", url: "https://hooks.trigger.dev/token/1" };
+    mockCreateToken.mockResolvedValue(mockToken);
+    vi.mocked(submitTranscriptionAsync).mockResolvedValue("transcript-null");
+    mockForToken.mockResolvedValue({
+      ok: true,
+      output: { transcript_id: "transcript-null", status: "completed" },
+    });
+    // Follow-up GET returns completed but with no text
+    vi.mocked(getTranscriptionStatus).mockResolvedValue({
+      id: "transcript-null", status: "completed", text: null, error: null,
+    });
+    vi.mocked(generateEpisodeSummary).mockResolvedValue(mockSummary);
+    vi.mocked(persistEpisodeSummary).mockResolvedValue(undefined);
+
+    const result = await taskConfig.run(
+      { episodeId: 123 },
+      mockCtx
+    );
+
+    expect(result).toEqual(mockSummary);
+    expect(getTranscriptionStatus).toHaveBeenCalledWith("transcript-null");
+    // No transcript available — summary generated without it
+    expect(generateEpisodeSummary).toHaveBeenCalledWith(
+      mockPodcast,
+      mockEpisode,
+      undefined
+    );
+    const { logger } = await import("@trigger.dev/sdk");
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "AssemblyAI transcription unavailable, proceeding without it",
+      expect.objectContaining({ error: "AssemblyAI transcript text not available yet" })
+    );
+  });
+
   it("falls back to AssemblyAI when cached transcription lookup fails", async () => {
     vi.mocked(getEpisodeById).mockResolvedValue({ episode: mockEpisode } as never);
     vi.mocked(getPodcastById).mockResolvedValue({ feed: mockPodcast } as never);
@@ -435,6 +474,10 @@ describe("summarize-episode task", () => {
       ok: true,
       output: { transcript_id: "transcript-456", status: "error" },
     });
+    // Follow-up GET fetches error details for logging
+    vi.mocked(getTranscriptionStatus).mockResolvedValue({
+      id: "transcript-456", status: "error", text: null, error: "Audio file could not be processed",
+    });
     vi.mocked(generateEpisodeSummary).mockResolvedValue(mockSummary);
     vi.mocked(persistEpisodeSummary).mockResolvedValue(undefined);
 
@@ -444,7 +487,7 @@ describe("summarize-episode task", () => {
     );
 
     expect(result).toEqual(mockSummary);
-    expect(getTranscriptionStatus).not.toHaveBeenCalled();
+    expect(getTranscriptionStatus).toHaveBeenCalledWith("transcript-456");
     expect(generateEpisodeSummary).toHaveBeenCalledWith(
       mockPodcast,
       mockEpisode,

--- a/src/trigger/summarize-episode.ts
+++ b/src/trigger/summarize-episode.ts
@@ -183,11 +183,22 @@ export const summarizeEpisode = task({
         if (result.ok && result.output.status === "completed") {
           // The webhook only contains { transcript_id, status } — fetch the
           // full transcript text via a follow-up GET request.
-          const fullResult = await retry.onThrow(
-            async () => getTranscriptionStatus(result.output.transcript_id),
-            { maxAttempts: 3 }
-          );
-          if (fullResult.text) {
+          const fullResult = await retry.onThrow(async () => {
+            const statusResult = await getTranscriptionStatus(result.output.transcript_id);
+            if (statusResult.status === "error") {
+              return statusResult;
+            }
+            if (!statusResult.text?.trim()) {
+              throw new Error("AssemblyAI transcript text not available yet");
+            }
+            return statusResult;
+          }, { maxAttempts: 3, minTimeoutInMs: 1_000 });
+          if (fullResult.status === "error") {
+            logger.warn("AssemblyAI transcript status check returned error", {
+              transcriptId: result.output.transcript_id,
+              error: fullResult.error,
+            });
+          } else if (fullResult.text) {
             transcript = fullResult.text;
             transcriptSource = "assemblyai";
             logger.info("Audio transcribed successfully", { length: transcript.length });
@@ -199,9 +210,20 @@ export const summarizeEpisode = task({
             });
           }
         } else if (result.ok) {
-          logger.warn("AssemblyAI transcription failed", {
-            status: result.output.status,
-          });
+          try {
+            const fullResult = await getTranscriptionStatus(result.output.transcript_id);
+            logger.warn("AssemblyAI transcription failed", {
+              transcriptId: result.output.transcript_id,
+              status: fullResult.status,
+              error: fullResult.error,
+            });
+          } catch (statusError) {
+            logger.warn("AssemblyAI transcription failed", {
+              transcriptId: result.output.transcript_id,
+              status: result.output.status,
+              statusFetchError: statusError instanceof Error ? statusError.message : String(statusError),
+            });
+          }
         } else {
           logger.warn("AssemblyAI transcription wait timed out");
         }


### PR DESCRIPTION
## Summary

- **Root cause:** AssemblyAI webhooks only send `{ transcript_id, status }` — not the transcript text. The code assumed `text` was in the webhook payload, so every successful transcription silently hit the "completed but returned no text" warning branch. Episodes were summarized without transcripts even when AssemblyAI successfully transcribed the audio.
- **Fix:** After the webhook fires with `status: "completed"`, make a follow-up `GET /v2/transcript/{id}` call (via the existing `getTranscriptionStatus()` function) to fetch the actual text. Includes retry logic (3 attempts).
- **Tests:** Updated all 6 AssemblyAI-related test cases to accurately mock the webhook payload (no `text` field) and assert the follow-up GET is called with the correct transcript ID.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 1172/1172 pass (23 in summarize-episode suite)
- [x] `bun run build` — succeeds
- [ ] Deploy to preview and trigger a summarization for an episode without a PodcastIndex/RSS transcript — verify AssemblyAI text is fetched and stored
- [ ] Check Trigger.dev logs for "Audio transcribed successfully" instead of "completed but returned no text"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved transcription flow: webhook responses are leaner and followed by a verified fetch to obtain final transcript results, with clearer handling when completed responses have no text and better error/status logging.
* **Tests**
  * Updated and expanded test coverage to validate the revised transcription and fallback behaviors, including completed-but-empty and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->