### PR TITLE
feat: support text/vtt and text/html transcript types from PodcastIndex

### DIFF
--- a/src/trigger/helpers/__tests__/transcript.test.ts
+++ b/src/trigger/helpers/__tests__/transcript.test.ts
@@ -133,6 +133,29 @@ This is a test`;
     expect(result).not.toContain("-->");
   });
 
+  it("removes WEBVTT header with multiple metadata lines", () => {
+    const vtt = `WEBVTT
+Kind: captions
+Language: en
+
+00:00:01.000 --> 00:00:04.000
+Hello world`;
+    const result = stripVttTimestamps(vtt);
+    expect(result).toBe("Hello world");
+    expect(result).not.toContain("Kind");
+    expect(result).not.toContain("Language");
+  });
+
+  it("preserves numeric-only transcript lines that aren't cue IDs", () => {
+    const vtt = `WEBVTT
+
+00:00:01.000 --> 00:00:04.000
+The answer is
+100`;
+    const result = stripVttTimestamps(vtt);
+    expect(result).toContain("100");
+  });
+
   it("removes NOTE blocks entirely", () => {
     const vtt = `WEBVTT
 
@@ -324,6 +347,16 @@ describe("stripHtmlTranscript", () => {
     expect(result).not.toContain("&amp;");
     expect(result).not.toContain("&mdash;");
     expect(result).not.toContain("&#39;");
+  });
+
+  it("strips entity-encoded tags that survive initial tag removal", () => {
+    const html = "<p>Safe text &lt;b&gt;bold&lt;/b&gt; end</p>";
+    const result = stripHtmlTranscript(html);
+    expect(result).toContain("Safe text");
+    expect(result).toContain("bold");
+    expect(result).toContain("end");
+    expect(result).not.toContain("<b");
+    expect(result).not.toContain("&lt;");
   });
 
   it("strips a full HTML document leaving only text content", () => {

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -18,13 +18,14 @@ const SUPPORTED_TRANSCRIPT_TYPES = [
 export function stripVttTimestamps(raw: string): string {
   let text = raw;
 
-  text = text.replace(/^WEBVTT[^\n]*\n(.*?\n)?\n/m, "");
+  text = text.replace(/^WEBVTT[^\n]*\n([^\n]+\n)*\n/m, "");
   text = text.replace(/^(?:NOTE|STYLE|REGION)[^\n]*(?:\n[^\n]+)*/gm, "");
+  // Cue IDs must be removed before timing lines — the lookahead needs the timing line present
+  text = text.replace(/^\d+\s*$(?=\n(?:\d{2}:)?\d{2}:\d{2}\.\d{3}\s+-->)/gm, "");
   text = text.replace(
     /^(?:\d{2}:)?\d{2}:\d{2}\.\d{3}\s+-->\s+(?:\d{2}:)?\d{2}:\d{2}\.\d{3}[^\n]*$/gm,
     ""
   );
-  text = text.replace(/^\d+\s*$/gm, "");
 
   // Timestamp tags must be removed before named tags to avoid partial matches
   text = text.replace(/<(?:\d{2}:)?\d{2}:\d{2}\.\d{3}>/g, "");
@@ -48,6 +49,7 @@ export function stripHtmlTranscript(raw: string): string {
   text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ");
   text = text.replace(/<[^>]+>/g, " ");
   text = he.decode(text);
+  text = text.replace(/<[^>]+>/g, " ");
   text = text.replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
 
   return text;
@@ -79,8 +81,8 @@ export async function fetchTranscript(
 
   // Priority: least processing needed → most processing needed
   const transcriptEntry = SUPPORTED_TRANSCRIPT_TYPES
-    .map((type) => episode.transcripts.find((t) => t.type === type))
-    .find((entry) => entry?.url);
+    .map((type) => episode.transcripts.find((t) => t.type === type && t.url))
+    .find((entry) => entry != null);
 
   if (!transcriptEntry?.url) {
     return undefined;


### PR DESCRIPTION
## Summary

- Add `text/vtt` and `text/html` transcript format support to `fetchTranscript`, expanding PodcastIndex coverage to ~98 additional episodes that serve these formats
- Priority-ordered type selection: `text/plain` > `application/srt` > `text/vtt` > `text/html`
- VTT content stripped of WEBVTT headers, NOTE/STYLE/REGION blocks, timing lines, cue IDs, and inline tags
- HTML content stripped of script/style blocks, HTML tags, and entities decoded via `he.decode()`
- Existing `text/plain` and `application/srt` behavior unchanged — zero impact on callers

## Changes

| File | Change |
|------|--------|
| `src/trigger/helpers/transcript.ts` | Add `stripVttTimestamps`, `stripHtmlTranscript`, `normalizeTranscriptContent`; update `fetchTranscript` with priority type array |
| `src/trigger/helpers/__tests__/transcript.test.ts` | 28 new test cases across 4 describe blocks |

## Test plan

- [x] 41/41 transcript tests pass (28 new + 13 existing)
- [x] Full suite: 1350 tests pass, zero regressions
- [x] `bun run lint` — clean
- [x] `bun run build` — succeeds
- [x] VTT stripping: headers, NOTE/STYLE/REGION blocks, timing lines, cue IDs, inline tags, timestamp tags
- [x] HTML stripping: script/style blocks, all tags, entity decoding
- [x] Priority order verified: prefers text/plain when multiple types available
- [x] Whitespace-only results after stripping return undefined
- [x] No stubs/TODOs/FIXMEs

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcript handling: adjusted MIME priority (plain → SRT → VTT → HTML), automatic normalization of VTT and HTML into plain text, better HTML detection, and a warning when normalization yields empty content.

* **Tests**
  * Expanded coverage for transcript selection and normalization: VTT timestamp/tag stripping, HTML-to-text extraction and decoding, MIME-based dispatch, preference order, and empty-content warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->