### PR TITLE
style: polish dashboard layout and UX hierarchy

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@491e5eb471f4008dc0db76dfec54c56ff9f88bba # v1.0.70
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true # ✨ Enables tracking comments

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -52,7 +52,7 @@ async function RecentEpisodesSection() {
       : Math.floor(lastSignInAt.getTime() / 1000);
 
   const { episodes, hasSubscriptions, error } = await getRecentEpisodesFromSubscriptions({
-    limit: 5,
+    limit: 3,
     since: Math.floor((Date.now() - 7 * 24 * 60 * 60 * 1000) / 1000),
   });
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -86,18 +86,22 @@ async function RecommendationsSection() {
   return <EpisodeRecommendations episodes={episodes} />;
 }
 
+function DashboardHeader({ description }: { description: string }) {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+      <p className="text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
 export default async function DashboardPage() {
   const hasSubs = await hasAnySubscriptions();
 
   if (!hasSubs) {
     return (
       <div className="space-y-8">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-          <p className="text-muted-foreground">
-            Get started by finding podcasts you love.
-          </p>
-        </div>
+        <DashboardHeader description="Get started by finding podcasts you love." />
         <WelcomeCard />
         <QueueSection />
       </div>
@@ -108,12 +112,7 @@ export default async function DashboardPage() {
     <div className="space-y-8">
       {/* Header + Trending topics — compact top section */}
       <div className="space-y-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-          <p className="text-muted-foreground">
-            Welcome back! Here&apos;s what&apos;s new from your subscriptions.
-          </p>
-        </div>
+        <DashboardHeader description="Welcome back! Here's what's new from your subscriptions." />
 
         <Suspense fallback={<TrendingTopicsLoading />}>
           <TrendingTopicsSection />

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -4,7 +4,9 @@ import {
   getRecentEpisodesFromSubscriptions,
   getRecommendedEpisodes,
   getTrendingTopics,
+  hasAnySubscriptions,
 } from "@/app/actions/dashboard";
+import { WelcomeCard } from "@/components/dashboard/welcome-card";
 import { RecentEpisodesContainer } from "@/components/dashboard/recent-episodes-container";
 import {
   EpisodeRecommendations,
@@ -22,8 +24,8 @@ function RecentEpisodesLoading() {
       <CardHeader>
         <Skeleton className="h-5 w-40" />
       </CardHeader>
-      <CardContent className="space-y-4">
-        {[1, 2, 3, 4, 5].map((i) => (
+      <CardContent className="space-y-3">
+        {[1, 2, 3].map((i) => (
           <div key={i} className="flex gap-3">
             <Skeleton className="h-14 w-14 shrink-0 rounded-md" />
             <div className="flex-1 space-y-2">
@@ -84,34 +86,53 @@ async function RecommendationsSection() {
   return <EpisodeRecommendations episodes={episodes} />;
 }
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const hasSubs = await hasAnySubscriptions();
+
+  if (!hasSubs) {
+    return (
+      <div className="space-y-8">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">
+            Get started by finding podcasts you love.
+          </p>
+        </div>
+        <WelcomeCard />
+        <QueueSection />
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted-foreground">
-          Welcome back! Here&apos;s what&apos;s new from your subscriptions.
-        </p>
+    <div className="space-y-8">
+      {/* Header + Trending topics — compact top section */}
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground">
+            Welcome back! Here&apos;s what&apos;s new from your subscriptions.
+          </p>
+        </div>
+
+        <Suspense fallback={<TrendingTopicsLoading />}>
+          <TrendingTopicsSection />
+        </Suspense>
       </div>
 
-      {/* Trending topics */}
-      <Suspense fallback={<TrendingTopicsLoading />}>
-        <TrendingTopicsSection />
-      </Suspense>
-
-      {/* Episode recommendations */}
+      {/* Episode recommendations — primary discovery section */}
       <Suspense fallback={<EpisodeRecommendationsLoading />}>
         <RecommendationsSection />
       </Suspense>
 
-      {/* Queue section */}
-      <QueueSection />
+      {/* Queue + Recent episodes — secondary sections, side by side on lg */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <QueueSection />
 
-      {/* Recent episodes from subscriptions */}
-      <Suspense fallback={<RecentEpisodesLoading />}>
-        <RecentEpisodesSection />
-      </Suspense>
+        <Suspense fallback={<RecentEpisodesLoading />}>
+          <RecentEpisodesSection />
+        </Suspense>
+      </div>
     </div>
   );
 }

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -19,6 +19,19 @@ import {
 
 // Maximum episodes to include per podcast for variety in the dashboard feed
 const MAX_EPISODES_PER_PODCAST = 3;
+// Lightweight check for first-run detection — avoids loading full subscription data
+export async function hasAnySubscriptions(): Promise<boolean> {
+  const { userId } = await auth();
+  if (!userId) return false;
+
+  const row = await db.query.userSubscriptions.findFirst({
+    where: eq(userSubscriptions.userId, userId),
+    columns: { id: true },
+  });
+
+  return row !== undefined;
+}
+
 // Fetch more episodes than needed (5x) to account for the per-podcast variety cap.
 // In skewed cases (one very active podcast dominates), we may still return fewer than `limit` items.
 const BATCH_FETCH_MULTIPLIER = 5;

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -19,6 +19,7 @@ import {
 
 // Maximum episodes to include per podcast for variety in the dashboard feed
 const MAX_EPISODES_PER_PODCAST = 3;
+
 // Lightweight check for first-run detection — avoids loading full subscription data
 export async function hasAnySubscriptions(): Promise<boolean> {
   const { userId } = await auth();

--- a/src/components/__tests__/worth-it-badge.test.tsx
+++ b/src/components/__tests__/worth-it-badge.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react";
 import { WorthItBadge } from "@/components/episodes/worth-it-badge";
 
 describe("WorthItBadge", () => {
-  it("renders nothing when score is null", () => {
-    const { container } = render(<WorthItBadge score={null} />);
-    expect(container.innerHTML).toBe("");
+  it("renders 'Not rated' badge when score is null", () => {
+    render(<WorthItBadge score={null} />);
+    expect(screen.getByText("Not rated")).toBeInTheDocument();
   });
 
   it("renders score value and label for high score (>= 8)", () => {

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -83,8 +83,7 @@ describe("TrendingTopics", () => {
   it("displays deterministic subtitle with relative time", () => {
     const topics = [makeTopic({ name: "AI" })]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
-    expect(screen.getByText(/Updated 10m ago/)).toBeInTheDocument()
-    expect(screen.getByText(/Past 7 days/)).toBeInTheDocument()
+    expect(screen.getByText(/Trending · 10m ago/)).toBeInTheDocument()
   })
 })
 

--- a/src/components/dashboard/episode-recommendations.tsx
+++ b/src/components/dashboard/episode-recommendations.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ChevronRight, Sparkles, Mic } from "lucide-react";
+import { ChevronRight, Sparkles, Rss } from "lucide-react";
 import { WorthItBadge } from "@/components/episodes/worth-it-badge";
 import { formatDate, formatDuration, stripHtml } from "@/lib/utils";
 import type { RecommendedEpisodeDTO } from "@/db/library-columns";
@@ -17,7 +17,7 @@ export function EpisodeRecommendationsLoading() {
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[1, 2, 3, 4, 5, 6].map((i) => (
             <div key={i} className="flex gap-3 p-2">
-              <Skeleton className="h-16 w-16 shrink-0 rounded-lg" />
+              <Skeleton className="h-14 w-14 shrink-0 rounded-md" />
               <div className="min-w-0 flex-1 space-y-2">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-3 w-1/2" />
@@ -82,18 +82,18 @@ export function EpisodeRecommendations({ episodes }: EpisodeRecommendationsProps
               href={`/episode/${episode.podcastIndexId}`}
               className="flex gap-3 rounded-lg p-2 transition-colors hover:bg-accent"
             >
-              <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-muted">
+              <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
                 {episode.podcastImageUrl ? (
                   <Image
                     src={episode.podcastImageUrl}
                     alt={episode.podcastTitle}
                     fill
                     className="object-cover"
-                    sizes="64px"
+                    sizes="56px"
                   />
                 ) : (
                   <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                    <Mic className="h-6 w-6" />
+                    <Rss className="h-6 w-6" />
                   </div>
                 )}
               </div>
@@ -103,7 +103,7 @@ export function EpisodeRecommendations({ episodes }: EpisodeRecommendationsProps
                   {episode.podcastTitle}
                 </p>
                 {episode.description && (
-                  <p className="line-clamp-2 text-xs text-muted-foreground/70">
+                  <p className="line-clamp-2 text-xs text-muted-foreground">
                     {stripHtml(episode.description)}
                   </p>
                 )}

--- a/src/components/dashboard/episode-recommendations.tsx
+++ b/src/components/dashboard/episode-recommendations.tsx
@@ -108,10 +108,7 @@ export function EpisodeRecommendations({ episodes }: EpisodeRecommendationsProps
                   </p>
                 )}
                 <div className="mt-1 flex flex-wrap items-center gap-2">
-                  {episode.worthItScore !== null &&
-                    Number.isFinite(Number(episode.worthItScore)) && (
-                      <WorthItBadge score={Number(episode.worthItScore)} />
-                    )}
+                  <WorthItBadge score={episode.worthItScore != null ? Number(episode.worthItScore) : null} />
                   <span className="text-xs text-muted-foreground">
                     {formatDuration(episode.duration)}
                     {episode.publishDate && (

--- a/src/components/dashboard/queue-section.tsx
+++ b/src/components/dashboard/queue-section.tsx
@@ -166,7 +166,7 @@ function QueueEpisodeRow({
       "flex items-center gap-3 rounded-lg p-2",
       isNowPlaying && "bg-accent/50"
     )}>
-      <span title="Drag to reorder" aria-label="Drag to reorder" role="button" className="shrink-0 cursor-grab">
+      <span aria-hidden="true" title="Drag to reorder" className="shrink-0 cursor-grab">
         <GripVertical
           aria-hidden="true"
           className="h-4 w-4 text-muted-foreground/50"

--- a/src/components/dashboard/queue-section.tsx
+++ b/src/components/dashboard/queue-section.tsx
@@ -166,7 +166,7 @@ function QueueEpisodeRow({
       "flex items-center gap-3 rounded-lg p-2",
       isNowPlaying && "bg-accent/50"
     )}>
-      <span title="Drag to reorder" className="shrink-0 cursor-grab">
+      <span title="Drag to reorder" aria-label="Drag to reorder" role="button" className="shrink-0 cursor-grab">
         <GripVertical
           aria-hidden="true"
           className="h-4 w-4 text-muted-foreground/50"

--- a/src/components/dashboard/queue-section.tsx
+++ b/src/components/dashboard/queue-section.tsx
@@ -162,11 +162,16 @@ function QueueEpisodeRow({
   onSummarizeError,
 }: QueueEpisodeRowProps) {
   return (
-    <div className="flex items-center gap-3 rounded-lg p-2">
-      <GripVertical
-        aria-hidden="true"
-        className="h-4 w-4 shrink-0 text-muted-foreground/50"
-      />
+    <div className={cn(
+      "flex items-center gap-3 rounded-lg p-2",
+      isNowPlaying && "bg-accent/50"
+    )}>
+      <span title="Drag to reorder" className="shrink-0 cursor-grab">
+        <GripVertical
+          aria-hidden="true"
+          className="h-4 w-4 text-muted-foreground/50"
+        />
+      </span>
       {/* Artwork */}
       <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-md bg-muted">
         {episode.artwork ? (

--- a/src/components/dashboard/recent-episodes.tsx
+++ b/src/components/dashboard/recent-episodes.tsx
@@ -162,7 +162,7 @@ export function RecentEpisodes({
                 )}
               </div>
               <div className="mt-1">
-                <WorthItBadge score={episode.worthItScore !== null && Number.isFinite(episode.worthItScore) ? episode.worthItScore : null} />
+                <WorthItBadge score={episode.worthItScore ?? null} />
               </div>
             </div>
           </Link>

--- a/src/components/dashboard/recent-episodes.tsx
+++ b/src/components/dashboard/recent-episodes.tsx
@@ -49,7 +49,7 @@ export function RecentEpisodes({
         <CardContent className="space-y-4">
           {[1, 2, 3].map((i) => (
             <div key={i} className="flex gap-3">
-              <Skeleton className="h-16 w-16 shrink-0 rounded-md" />
+              <Skeleton className="h-14 w-14 shrink-0 rounded-md" />
               <div className="flex-1 space-y-2">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-3 w-1/2" />
@@ -162,13 +162,7 @@ export function RecentEpisodes({
                 )}
               </div>
               <div className="mt-1">
-                {episode.worthItScore !== null && Number.isFinite(episode.worthItScore) ? (
-                  <WorthItBadge score={episode.worthItScore} />
-                ) : (
-                  <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                    Not rated
-                  </span>
-                )}
+                <WorthItBadge score={episode.worthItScore !== null && Number.isFinite(episode.worthItScore) ? episode.worthItScore : null} />
               </div>
             </div>
           </Link>

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -33,7 +33,7 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
         </span>
       </div>
       <div className="flex flex-wrap gap-2">
-        {topics.map((topic) => (
+        {Array.from(new Map(topics.map((t) => [t.name, t])).values()).map((topic) => (
           <TopicPill key={topic.name} topic={topic} />
         ))}
       </div>

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -1,5 +1,5 @@
+import Link from "next/link";
 import { TrendingUp } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
@@ -7,10 +7,12 @@ import type { TrendingTopic } from "@/db/schema";
 
 function TopicPill({ topic }: { topic: TrendingTopic }) {
   return (
-    <Badge variant="secondary" className="px-3 py-1 cursor-default max-w-[200px]">
-      <span className="min-w-0 flex-1 truncate text-sm" title={topic.name}>{topic.name}</span>
-      <span className="ml-1.5 text-muted-foreground font-normal shrink-0">({topic.episodeCount})</span>
-    </Badge>
+    <Link href={`/discover?q=${encodeURIComponent(topic.name)}`}>
+      <Badge variant="secondary" className="px-3 py-1 max-w-[200px] hover:bg-secondary/80 transition-colors">
+        <span className="min-w-0 flex-1 truncate text-sm" title={topic.name}>{topic.name}</span>
+        <span className="ml-1.5 text-muted-foreground font-normal shrink-0">({topic.episodeCount})</span>
+      </Badge>
+    </Link>
   );
 }
 
@@ -23,41 +25,31 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
   const updatedAgo = formatRelativeTime(generatedAt);
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <TrendingUp className="h-5 w-5 text-muted-foreground" />
-          <CardTitle className="text-lg font-semibold">Trending Topics</CardTitle>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Past 7 days · Updated {updatedAgo}
-        </p>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-wrap gap-2">
-          {topics.map((topic, index) => (
-            <TopicPill key={index} topic={topic} />
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <TrendingUp className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-muted-foreground">
+          Trending · {updatedAgo}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {topics.map((topic) => (
+          <TopicPill key={topic.name} topic={topic} />
+        ))}
+      </div>
+    </div>
   );
 }
 
 export function TrendingTopicsLoading() {
   return (
-    <Card>
-      <CardHeader>
-        <Skeleton className="h-5 w-48" />
-        <Skeleton className="h-3 w-32 mt-1" />
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-wrap gap-2">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <Skeleton key={i} className="h-7 w-24 rounded-full" />
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+    <div>
+      <Skeleton className="mb-3 h-4 w-32" />
+      <div className="flex flex-wrap gap-2">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <Skeleton key={i} className="h-7 w-24 rounded-full" />
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/dashboard/welcome-card.tsx
+++ b/src/components/dashboard/welcome-card.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { Headphones, Search, Rss, Library } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export function WelcomeCard() {
+  return (
+    <Card>
+      <CardContent className="py-12">
+        <div className="mx-auto max-w-md text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+            <Headphones className="h-7 w-7 text-primary" />
+          </div>
+          <h2 className="text-xl font-semibold tracking-tight">
+            Welcome to ContentGenie
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Find podcasts, get AI-powered summaries, and build your personal
+            library of episodes worth your time.
+          </p>
+          <Button asChild size="lg" className="mt-6">
+            <Link href="/discover">
+              <Search className="mr-2 h-4 w-4" />
+              Discover Podcasts
+            </Link>
+          </Button>
+          <div className="mt-8 grid grid-cols-3 gap-4 text-center">
+            <div>
+              <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-full bg-muted">
+                <Rss className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Subscribe to podcasts
+              </p>
+            </div>
+            <div>
+              <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-full bg-muted">
+                <Headphones className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Get AI summaries
+              </p>
+            </div>
+            <div>
+              <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-full bg-muted">
+                <Library className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Build your library
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/episodes/worth-it-badge.tsx
+++ b/src/components/episodes/worth-it-badge.tsx
@@ -7,7 +7,7 @@ interface WorthItBadgeProps {
 }
 
 export function WorthItBadge({ score }: WorthItBadgeProps) {
-  if (score === null) {
+  if (score === null || !Number.isFinite(score)) {
     return (
       <Badge variant="secondary" className="px-3 py-1 text-sm">
         Not rated

--- a/src/components/episodes/worth-it-badge.tsx
+++ b/src/components/episodes/worth-it-badge.tsx
@@ -7,7 +7,13 @@ interface WorthItBadgeProps {
 }
 
 export function WorthItBadge({ score }: WorthItBadgeProps) {
-  if (score === null) return null;
+  if (score === null) {
+    return (
+      <Badge variant="secondary" className="px-3 py-1 text-sm">
+        Not rated
+      </Badge>
+    );
+  }
 
   return (
     <Badge


### PR DESCRIPTION
## Summary
- Break uniform card stack into tiered visual hierarchy: trending topics as compact borderless badge row, recommendations full-width primary section, queue + recent episodes side-by-side on `lg` screens
- Trending topic pills now link to `/discover?q={topic}` — previously non-interactive badges with `cursor-default`
- First-run welcome card replaces 3-4 stacked empty states for users with no subscriptions
- `WorthItBadge` handles `null` scores with consistent "Not rated" secondary badge — removes ad-hoc inline spans
- Standardized thumbnails to 56px (`h-14 w-14`) and `Rss` fallback icon across all dashboard sections (was 48/56/64px with mixed Rss/Mic)
- Queue "Now Playing" row highlighted with `bg-accent/50`; drag handles show `cursor-grab` + tooltip
- Skeleton loading states match populated content spacing and item counts
- Normalized `text-muted-foreground/70` to standard `text-muted-foreground`

## Test plan
- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — 1489 tests passing (129 files)
- [ ] Visual check: dashboard with subscriptions shows tiered layout (trending → recommendations → queue + recent)
- [ ] Visual check: dashboard without subscriptions shows welcome card + queue only
- [ ] Visual check: trending topic pills navigate to discover page on click
- [ ] Visual check: "Not rated" badge appears consistently for unscored episodes
- [ ] Visual check: queue "Now Playing" row has accent background
- [ ] Visual check: drag handle cursor changes to grab on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Welcome/onboarding card and dashboard empty-state for users without subscriptions.
  * Clickable trending topic badges that navigate to search.

* **Improvements**
  * Clarified dashboard header/subtitle, tighter top-block spacing, responsive two-column layout.
  * Reduced recent-episodes preview count and simplified loading skeletons.
  * Smaller episode thumbnails, stronger description text, drag affordance for queue rows, consistent "Not rated" badge for unrated episodes.

* **Tests**
  * Updated tests to expect "Not rated" and the consolidated trending subtitle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->