### PR TITLE
feat: extract per-episode topic tags during summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Extract 1–5 topic tags per episode during summarization; stored in new `episode_topics` junction table with relevance scores (0–1) and a cross-episode index for efficient topic queries (#259)
 - Semantic CSS color tokens for score (`--score-exceptional` → `--score-skip`) and status indicators (`--status-success-*`, `--status-warning-*`, etc.) with light/dark mode variants and accessible foreground colors (#256)
 - Blue-indigo brand accent color replacing stock shadcn neutral defaults (#256)
 - Active nav link highlighting in desktop header (#256)

--- a/docs/adr/031-episode-topics-junction-table.md
+++ b/docs/adr/031-episode-topics-junction-table.md
@@ -1,0 +1,55 @@
+# ADR-031: Episode Topics Junction Table
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+Issue #259 adds per-episode topic tag extraction during summarization. The topic data needs to be persisted so it can be queried across episodes (e.g., "all episodes tagged with 'AI & Machine Learning'"). Two schema options were considered:
+
+1. **JSON column on `episodes`**: Add a `topics jsonb` column to the existing `episodes` table.
+2. **Junction table `episode_topics`**: A separate table with `(episodeId, topic, relevance)` and a unique index on `(episodeId, topic)`.
+
+## Decision
+
+Use a junction table (`episode_topics`) rather than a JSON column on `episodes`.
+
+## Rationale
+
+### Cross-episode queries require an indexed table
+
+The primary value of topic tags is enabling queries like "find all episodes tagged with 'Product Management'". Against a JSON column this requires a full table scan plus per-row JSON parsing — O(N×JSON parse). Against the junction table's `episode_topics_topic_idx` index, it is O(index lookup). As the episode corpus grows, the JSON approach degrades while the index stays fast.
+
+### Contrast with `trendingTopics`
+
+The `trendingTopics` table (see ADR-022) stores topics as a JSON snapshot column. That is appropriate because trending topics are time-series aggregates — the unit of lookup is the snapshot row, not an individual topic. Episode topics have the opposite access pattern: the individual topic is the unit of lookup. The same JSON-blob approach would be wrong here.
+
+### Idempotent inserts via `onConflictDoNothing`
+
+Trigger.dev tasks can be retried on failure. Using `onConflictDoNothing` on the unique `(episodeId, topic)` index makes topic persistence idempotent: a retry will not fail or create duplicates. We do not update relevance on conflict — if the LLM produces a different score on retry, neither score is authoritative and the complexity of resolving it is not justified for v1.
+
+### No Drizzle transaction
+
+The episode update/insert and topic insert are sequential awaits without a `db.transaction()`. See ADR-006 section in plan for full rationale. In summary:
+
+- **Failure mode is benign**: An episode with a valid summary but no topics is not data-corrupting — the summary is still correct and visible.
+- **Retries are self-healing**: Trigger.dev retries + `onConflictDoNothing` idempotency mean a subsequent run will re-attempt the topic insert cleanly.
+- **Transaction overhead is real**: Neon serverless reconnects per request; holding a connection across two round-trips adds latency.
+
+If topic persistence becomes critical enough that partial writes are unacceptable, add a transaction then.
+
+### Custom prompts intentionally bypass topic extraction
+
+`getSummarizationPrompt` is updated to request topics in its JSON format; `interpolatePrompt` (used for custom prompts) is not. Custom prompts are user-supplied and may target specific model formats — silently injecting a topics requirement could break them. Because `topics` is optional on `SummaryResult`, a custom prompt that happens to return topics will still benefit from normalization and persistence; it just is not guaranteed.
+
+## Consequences
+
+- Cross-episode topic queries are O(index lookup) rather than O(N×JSON parse).
+- `persistEpisodeSummary` gains a second DB round-trip (topic insert) when topics are present. The round-trip is skipped when `summary.topics` is empty or undefined.
+- Schema migration: `bun run db:push` must be run against production before the summarization code ships. Failure to do so will cause runtime errors on task execution (see the `worth_it_reason` column incident in project memory).
+- Existing episode rows are unaffected — the table is additive. No backfill is required by this issue.
+
+## Related ADRs
+
+- ADR-022: `trendingTopics` uses JSON snapshot column — contrasting access pattern.
+- ADR-027: `summarize-episode` pure-consumer pattern — the pipeline this change extends.

--- a/docs/adr/031-episode-topics-junction-table.md
+++ b/docs/adr/031-episode-topics-junction-table.md
@@ -24,17 +24,19 @@ The primary value of topic tags is enabling queries like "find all episodes tagg
 
 The `trendingTopics` table (see ADR-022) stores topics as a JSON snapshot column. That is appropriate because trending topics are time-series aggregates — the unit of lookup is the snapshot row, not an individual topic. Episode topics have the opposite access pattern: the individual topic is the unit of lookup. The same JSON-blob approach would be wrong here.
 
-### Idempotent inserts via `onConflictDoNothing`
+### Delete-then-insert for topic reconciliation
 
-Trigger.dev tasks can be retried on failure. Using `onConflictDoNothing` on the unique `(episodeId, topic)` index makes topic persistence idempotent: a retry will not fail or create duplicates. We do not update relevance on conflict — if the LLM produces a different score on retry, neither score is authoritative and the complexity of resolving it is not justified for v1.
+Trigger.dev tasks can be retried on failure, and episodes can be re-summarized with different results. `persistTopics` deletes all existing topic rows for the episode, then inserts the new set. This fully reconciles stale topics and updated relevance scores on re-summarization — no orphaned rows are left behind.
+
+The delete is idempotent (deletes 0 rows if none exist), so retries are safe. If the delete succeeds but the insert fails, there is a narrow window where the episode has a valid summary but no topics; the next Trigger.dev retry will re-insert them.
 
 ### No Drizzle transaction
 
-The episode update/insert and topic insert are sequential awaits without a `db.transaction()`. See ADR-006 section in plan for full rationale. In summary:
+The episode update/insert, topic delete, and topic insert are sequential awaits without a `db.transaction()`. See ADR-006 section in plan for full rationale. In summary:
 
-- **Failure mode is benign**: An episode with a valid summary but no topics is not data-corrupting — the summary is still correct and visible.
-- **Retries are self-healing**: Trigger.dev retries + `onConflictDoNothing` idempotency mean a subsequent run will re-attempt the topic insert cleanly.
-- **Transaction overhead is real**: Neon serverless reconnects per request; holding a connection across two round-trips adds latency.
+- **Failure mode is benign**: An episode with a valid summary but temporarily missing topics is not data-corrupting — the summary is still correct and visible.
+- **Retries are self-healing**: Trigger.dev retries mean a subsequent run will re-delete and re-insert the topic set cleanly.
+- **Transaction overhead is real**: Neon serverless reconnects per request; holding a connection across multiple round-trips adds latency.
 
 If topic persistence becomes critical enough that partial writes are unacceptable, add a transaction then.
 

--- a/drizzle/0016_abnormal_wendell_vaughn.sql
+++ b/drizzle/0016_abnormal_wendell_vaughn.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "episode_topics" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"episode_id" integer NOT NULL,
+	"topic" text NOT NULL,
+	"relevance" numeric(3, 2) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "relevance_range" CHECK ("episode_topics"."relevance" >= 0 AND "episode_topics"."relevance" <= 1)
+);
+--> statement-breakpoint
+ALTER TABLE "episode_topics" ADD CONSTRAINT "episode_topics_episode_id_episodes_id_fk" FOREIGN KEY ("episode_id") REFERENCES "public"."episodes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "episode_topics_episode_topic_idx" ON "episode_topics" USING btree ("episode_id","topic");--> statement-breakpoint
+CREATE INDEX "episode_topics_topic_idx" ON "episode_topics" USING btree ("topic");

--- a/drizzle/0017_rich_iron_monger.sql
+++ b/drizzle/0017_rich_iron_monger.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "episode_topics" ALTER COLUMN "topic" SET DATA TYPE varchar(100);--> statement-breakpoint
+ALTER TABLE "episode_topics" ADD CONSTRAINT "topic_not_blank" CHECK (length(btrim("episode_topics"."topic")) > 0);

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1556 @@
+{
+  "id": "3c3f9e09-4420-4a4d-ac0c-84013758ad77",
+  "prevId": "62d8b1c1-0ff4-45b7-810b-b7d7f80917c1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summarization_prompt": {
+          "name": "summarization_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_config_updated_by_users_id_fk": {
+          "name": "ai_config_updated_by_users_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_enum": {
+          "name": "provider_enum",
+          "value": "\"ai_config\".\"provider\" IN ('openrouter', 'zai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_library_id": {
+          "name": "user_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_library_id_idx": {
+          "name": "bookmarks_user_library_id_idx",
+          "columns": [
+            {
+              "expression": "user_library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_library_id_user_library_id_fk": {
+          "name": "bookmarks_user_library_id_user_library_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user_library",
+          "columnsFrom": [
+            "user_library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episode_topics": {
+      "name": "episode_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episode_topics_episode_topic_idx": {
+          "name": "episode_topics_episode_topic_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_idx": {
+          "name": "episode_topics_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episode_topics_episode_id_episodes_id_fk": {
+          "name": "episode_topics_episode_id_episodes_id_fk",
+          "tableFrom": "episode_topics",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relevance_range": {
+          "name": "relevance_range",
+          "value": "\"episode_topics\".\"relevance\" >= 0 AND \"episode_topics\".\"relevance\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_score": {
+          "name": "worth_it_score",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_reason": {
+          "name": "worth_it_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_dimensions": {
+          "name": "worth_it_dimensions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_run_id": {
+          "name": "summary_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_run_id": {
+          "name": "transcript_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_status": {
+          "name": "summary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_source": {
+          "name": "transcript_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_status": {
+          "name": "transcript_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_fetched_at": {
+          "name": "transcript_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_error": {
+          "name": "transcript_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_guid": {
+          "name": "rss_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episodes_podcast_index_id_idx": {
+          "name": "episodes_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_podcast_id_idx": {
+          "name": "episodes_podcast_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_rss_guid_idx": {
+          "name": "episodes_rss_guid_idx",
+          "columns": [
+            {
+              "expression": "rss_guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_podcast_id_podcasts_id_fk": {
+          "name": "episodes_podcast_id_podcasts_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "episodes_podcast_index_id_unique": {
+          "name": "episodes_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "worth_it_score_range": {
+          "name": "worth_it_score_range",
+          "value": "\"episodes\".\"worth_it_score\" >= 0 AND \"episodes\".\"worth_it_score\" <= 10"
+        },
+        "summary_status_enum": {
+          "name": "summary_status_enum",
+          "value": "\"episodes\".\"summary_status\" IN ('queued', 'running', 'summarizing', 'completed', 'failed')"
+        },
+        "transcript_source_enum": {
+          "name": "transcript_source_enum",
+          "value": "\"episodes\".\"transcript_source\" IN ('podcastindex', 'assemblyai', 'description-url')"
+        },
+        "transcript_status_enum": {
+          "name": "transcript_status_enum",
+          "value": "\"episodes\".\"transcript_status\" IN ('missing', 'fetching', 'available', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listen_history": {
+      "name": "listen_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_episode_id": {
+          "name": "podcast_index_episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listen_duration_seconds": {
+          "name": "listen_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listen_history_user_episode_idx": {
+          "name": "listen_history_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_user_id_idx": {
+          "name": "listen_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_podcast_index_episode_id_idx": {
+          "name": "listen_history_podcast_index_episode_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listen_history_user_id_users_id_fk": {
+          "name": "listen_history_user_id_users_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listen_history_episode_id_episodes_id_fk": {
+          "name": "listen_history_episode_id_episodes_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_episode_id_episodes_id_fk": {
+          "name": "notifications_episode_id_episodes_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_enum": {
+          "name": "notification_type_enum",
+          "value": "\"notifications\".\"type\" IN ('new_episode', 'summary_completed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.podcasts": {
+      "name": "podcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_feed_url": {
+          "name": "rss_feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_episode_date": {
+          "name": "latest_episode_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'podcastindex'"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "podcasts_podcast_index_id_idx": {
+          "name": "podcasts_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "podcasts_podcast_index_id_unique": {
+          "name": "podcasts_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "source_enum": {
+          "name": "source_enum",
+          "value": "\"podcasts\".\"source\" IN ('podcastindex', 'rss')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending_topics": {
+      "name": "trending_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trending_topics_generated_at_idx": {
+          "name": "trending_topics_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library": {
+      "name": "user_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_library_user_episode_idx": {
+          "name": "user_library_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_user_id_idx": {
+          "name": "user_library_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_episode_id_idx": {
+          "name": "user_library_episode_id_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_collection_id_idx": {
+          "name": "user_library_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_user_id_users_id_fk": {
+          "name": "user_library_user_id_users_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_episode_id_episodes_id_fk": {
+          "name": "user_library_episode_id_episodes_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_collection_id_collections_id_fk": {
+          "name": "user_library_collection_id_collections_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_podcast_idx": {
+          "name": "user_subscriptions_user_podcast_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_id_idx": {
+          "name": "user_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_podcast_id_podcasts_id_fk": {
+          "name": "user_subscriptions_podcast_id_podcasts_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1560 @@
+{
+  "id": "8c708d0f-d560-443a-959c-dbde1b15cef8",
+  "prevId": "3c3f9e09-4420-4a4d-ac0c-84013758ad77",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summarization_prompt": {
+          "name": "summarization_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_config_updated_by_users_id_fk": {
+          "name": "ai_config_updated_by_users_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_enum": {
+          "name": "provider_enum",
+          "value": "\"ai_config\".\"provider\" IN ('openrouter', 'zai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_library_id": {
+          "name": "user_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_library_id_idx": {
+          "name": "bookmarks_user_library_id_idx",
+          "columns": [
+            {
+              "expression": "user_library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_library_id_user_library_id_fk": {
+          "name": "bookmarks_user_library_id_user_library_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user_library",
+          "columnsFrom": [
+            "user_library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episode_topics": {
+      "name": "episode_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episode_topics_episode_topic_idx": {
+          "name": "episode_topics_episode_topic_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_idx": {
+          "name": "episode_topics_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episode_topics_episode_id_episodes_id_fk": {
+          "name": "episode_topics_episode_id_episodes_id_fk",
+          "tableFrom": "episode_topics",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relevance_range": {
+          "name": "relevance_range",
+          "value": "\"episode_topics\".\"relevance\" >= 0 AND \"episode_topics\".\"relevance\" <= 1"
+        },
+        "topic_not_blank": {
+          "name": "topic_not_blank",
+          "value": "length(btrim(\"episode_topics\".\"topic\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_score": {
+          "name": "worth_it_score",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_reason": {
+          "name": "worth_it_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_dimensions": {
+          "name": "worth_it_dimensions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_run_id": {
+          "name": "summary_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_run_id": {
+          "name": "transcript_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_status": {
+          "name": "summary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_source": {
+          "name": "transcript_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_status": {
+          "name": "transcript_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_fetched_at": {
+          "name": "transcript_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_error": {
+          "name": "transcript_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_guid": {
+          "name": "rss_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episodes_podcast_index_id_idx": {
+          "name": "episodes_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_podcast_id_idx": {
+          "name": "episodes_podcast_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_rss_guid_idx": {
+          "name": "episodes_rss_guid_idx",
+          "columns": [
+            {
+              "expression": "rss_guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_podcast_id_podcasts_id_fk": {
+          "name": "episodes_podcast_id_podcasts_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "episodes_podcast_index_id_unique": {
+          "name": "episodes_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "worth_it_score_range": {
+          "name": "worth_it_score_range",
+          "value": "\"episodes\".\"worth_it_score\" >= 0 AND \"episodes\".\"worth_it_score\" <= 10"
+        },
+        "summary_status_enum": {
+          "name": "summary_status_enum",
+          "value": "\"episodes\".\"summary_status\" IN ('queued', 'running', 'summarizing', 'completed', 'failed')"
+        },
+        "transcript_source_enum": {
+          "name": "transcript_source_enum",
+          "value": "\"episodes\".\"transcript_source\" IN ('podcastindex', 'assemblyai', 'description-url')"
+        },
+        "transcript_status_enum": {
+          "name": "transcript_status_enum",
+          "value": "\"episodes\".\"transcript_status\" IN ('missing', 'fetching', 'available', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listen_history": {
+      "name": "listen_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_episode_id": {
+          "name": "podcast_index_episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listen_duration_seconds": {
+          "name": "listen_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listen_history_user_episode_idx": {
+          "name": "listen_history_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_user_id_idx": {
+          "name": "listen_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_podcast_index_episode_id_idx": {
+          "name": "listen_history_podcast_index_episode_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listen_history_user_id_users_id_fk": {
+          "name": "listen_history_user_id_users_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listen_history_episode_id_episodes_id_fk": {
+          "name": "listen_history_episode_id_episodes_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_episode_id_episodes_id_fk": {
+          "name": "notifications_episode_id_episodes_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_enum": {
+          "name": "notification_type_enum",
+          "value": "\"notifications\".\"type\" IN ('new_episode', 'summary_completed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.podcasts": {
+      "name": "podcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_feed_url": {
+          "name": "rss_feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_episode_date": {
+          "name": "latest_episode_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'podcastindex'"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "podcasts_podcast_index_id_idx": {
+          "name": "podcasts_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "podcasts_podcast_index_id_unique": {
+          "name": "podcasts_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "source_enum": {
+          "name": "source_enum",
+          "value": "\"podcasts\".\"source\" IN ('podcastindex', 'rss')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending_topics": {
+      "name": "trending_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trending_topics_generated_at_idx": {
+          "name": "trending_topics_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library": {
+      "name": "user_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_library_user_episode_idx": {
+          "name": "user_library_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_user_id_idx": {
+          "name": "user_library_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_episode_id_idx": {
+          "name": "user_library_episode_id_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_collection_id_idx": {
+          "name": "user_library_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_user_id_users_id_fk": {
+          "name": "user_library_user_id_users_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_episode_id_episodes_id_fk": {
+          "name": "user_library_episode_id_episodes_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_collection_id_collections_id_fk": {
+          "name": "user_library_collection_id_collections_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_podcast_idx": {
+          "name": "user_subscriptions_user_podcast_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_id_idx": {
+          "name": "user_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_podcast_id_podcasts_id_fk": {
+          "name": "user_subscriptions_podcast_id_podcasts_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1774704480185,
       "tag": "0015_low_firebrand",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1775935644984,
+      "tag": "0016_abnormal_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1775935644984,
       "tag": "0016_abnormal_wendell_vaughn",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1775946827831,
+      "tag": "0017_rich_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -310,7 +310,7 @@ export const episodeTopics = pgTable(
     episodeId: integer("episode_id")
       .references(() => episodes.id, { onDelete: "cascade" })
       .notNull(),
-    topic: text("topic").notNull(),
+    topic: varchar("topic", { length: 100 }).notNull(),
     relevance: decimal("relevance", { precision: 3, scale: 2 }).notNull(), // 0.00–1.00
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
@@ -318,6 +318,7 @@ export const episodeTopics = pgTable(
     uniqueIndex("episode_topics_episode_topic_idx").on(table.episodeId, table.topic),
     index("episode_topics_topic_idx").on(table.topic),
     check("relevance_range", sql`${table.relevance} >= 0 AND ${table.relevance} <= 1`),
+    check("topic_not_blank", sql`length(btrim(${table.topic})) > 0`),
   ]
 );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -303,6 +303,24 @@ export const trendingTopics = pgTable(
   (table) => [index("trending_topics_generated_at_idx").on(table.generatedAt)]
 );
 
+export const episodeTopics = pgTable(
+  "episode_topics",
+  {
+    id: serial("id").primaryKey(),
+    episodeId: integer("episode_id")
+      .references(() => episodes.id, { onDelete: "cascade" })
+      .notNull(),
+    topic: text("topic").notNull(),
+    relevance: decimal("relevance", { precision: 3, scale: 2 }).notNull(), // 0.00–1.00
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("episode_topics_episode_topic_idx").on(table.episodeId, table.topic),
+    index("episode_topics_topic_idx").on(table.topic),
+    check("relevance_range", sql`${table.relevance} >= 0 AND ${table.relevance} <= 1`),
+  ]
+);
+
 // Listen History table
 export const listenHistory = pgTable(
   "listen_history",
@@ -356,6 +374,14 @@ export const episodesRelations = relations(episodes, ({ one, many }) => ({
   libraryEntries: many(userLibrary),
   notifications: many(notifications),
   listenHistory: many(listenHistory),
+  topics: many(episodeTopics),
+}));
+
+export const episodeTopicsRelations = relations(episodeTopics, ({ one }) => ({
+  episode: one(episodes, {
+    fields: [episodeTopics.episodeId],
+    references: [episodes.id],
+  }),
 }));
 
 export const userSubscriptionsRelations = relations(
@@ -478,6 +504,9 @@ export type NewPushSubscription = typeof pushSubscriptions.$inferInsert;
 
 export type ListenHistoryEntry = typeof listenHistory.$inferSelect;
 export type NewListenHistoryEntry = typeof listenHistory.$inferInsert;
+
+export type EpisodeTopic = typeof episodeTopics.$inferSelect;
+export type NewEpisodeTopic = typeof episodeTopics.$inferInsert;
 
 /** Shape of a single topic cluster in the trending_topics JSON column. */
 export interface TrendingTopic {

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -15,6 +15,7 @@ export interface SummaryResult {
     actionability: number;
     timeValue: number;
   };
+  topics?: Array<{ name: string; relevance: number }>;
 }
 
 // Parse a JSON response from the LLM, handling potential markdown code blocks

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -9,6 +9,8 @@ You are a tough but fair critic. A score of 5 is the average baseline — most e
 
 Always respond in valid JSON format. Be objective and resist score inflation.`;
 
+// Note: custom prompts (via aiConfig.summarizationPrompt) bypass this function entirely and
+// do not receive the topics extraction instruction. This is intentional — see ADR-031.
 export function getSummarizationPrompt(
   podcastTitle: string,
   episodeTitle: string,
@@ -43,7 +45,11 @@ Please provide your analysis in the following JSON format:
     "timeValue": 5
   },
   "worthItScore": 5.0,
-  "worthItReason": "The Bottom Line section text — 1-2 sentence verdict."
+  "worthItReason": "The Bottom Line section text — 1-2 sentence verdict.",
+  "topics": [
+    { "name": "Topic Label", "relevance": 0.9 },
+    { "name": "Another Topic", "relevance": 0.7 }
+  ]
 }
 
 ## Scoring Dimensions (each 1-10):
@@ -67,7 +73,11 @@ Important:
 - The summary must include all 5 sections (TL;DR, What You'll Learn, Notable Quotes / Key Moments, Action Items, Bottom Line) using ## headers
 - For Notable Quotes / Key Moments: include 2-3 standout moments; add approximate timestamps (~XX:XX) when working from a transcript; write "No notable moments available" if nothing stands out
 - Consider the time investment (${durationMinutes != null ? `${durationMinutes} min` : "unknown duration"}) when scoring timeValue
-- Focus on value for busy professionals who need to be selective with their time`;
+- Focus on value for busy professionals who need to be selective with their time
+- Extract 1-5 topic tags that best describe the episode's subject matter.
+- Each topic name must be 2-5 words, professional, and in Title Case (e.g., "AI & Machine Learning").
+- Relevance is a float from 0.0 to 1.0 indicating how central the topic is to the episode.
+- Sort topics by relevance descending.`;
 }
 
 export const TRENDING_TOPICS_SYSTEM_PROMPT = `You are a podcast trend analyst. Your job is to identify distinct topic clusters from podcast episode summaries. Group related topics together into 5-8 clear clusters. Each cluster should have a concise name and a brief description.

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -58,6 +58,196 @@ describe("generateEpisodeSummary", () => {
     mockInterpolatePrompt.mockReturnValue("interpolated prompt");
   });
 
+  describe("topic normalization", () => {
+    it("includes valid topics sorted by relevance descending", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "machine learning", relevance: 0.6 },
+          { name: "leadership skills", relevance: 0.9 },
+          { name: "data science", relevance: 0.75 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([
+        { name: "Leadership Skills", relevance: 0.9 },
+        { name: "Data Science", relevance: 0.75 },
+        { name: "Machine Learning", relevance: 0.6 },
+      ]);
+    });
+
+    it("clamps relevance below 0 to 0", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [{ name: "Topic One", relevance: -0.5 }],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Topic One", relevance: 0 }]);
+    });
+
+    it("clamps relevance above 1 to 1", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [{ name: "Topic One", relevance: 1.5 }],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Topic One", relevance: 1 }]);
+    });
+
+    it("returns only top 5 topics when more than 5 are provided", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "Topic A", relevance: 0.9 },
+          { name: "Topic B", relevance: 0.8 },
+          { name: "Topic C", relevance: 0.7 },
+          { name: "Topic D", relevance: 0.6 },
+          { name: "Topic E", relevance: 0.5 },
+          { name: "Topic F", relevance: 0.3 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toHaveLength(5);
+      expect(result.topics!.map((t) => t.name)).toEqual([
+        "Topic A",
+        "Topic B",
+        "Topic C",
+        "Topic D",
+        "Topic E",
+      ]);
+    });
+
+    it("deduplicates topics after title-case normalization, keeping highest relevance", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "machine learning", relevance: 0.6 },
+          { name: "Machine Learning", relevance: 0.85 },
+          { name: "MACHINE LEARNING", relevance: 0.4 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toHaveLength(1);
+      expect(result.topics![0]).toEqual({ name: "Machine Learning", relevance: 0.85 });
+    });
+
+    it("filters out entries missing name", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { relevance: 0.8 },
+          { name: "Valid Topic", relevance: 0.7 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
+    it("filters out entries missing relevance", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "No Relevance Topic" },
+          { name: "Valid Topic", relevance: 0.7 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
+    it("filters out entries with empty name after trim", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "   ", relevance: 0.8 },
+          { name: "Valid Topic", relevance: 0.7 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
+    // Pin test: string relevance is dropped (not coerced). If coercion is added later, this test must change intentionally.
+    it("drops entries where relevance is a string (pin test — documents current behavior)", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "String Relevance", relevance: "0.9" },
+          { name: "Valid Topic", relevance: 0.7 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
+    it("sets topics to undefined when LLM returns a non-array topics field", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: "not an array",
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toBeUndefined();
+    });
+
+    it("sets topics to undefined when topics is null", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: null,
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toBeUndefined();
+    });
+
+    it("normalizes topics even when a custom prompt is used", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [{ name: "custom prompt topic", relevance: 0.8 }],
+      });
+
+      const result = await generateEpisodeSummary(
+        mockPodcast,
+        mockEpisode,
+        "transcript text",
+        "Custom {{transcript}}"
+      );
+
+      expect(result.topics).toEqual([{ name: "Custom Prompt Topic", relevance: 0.8 }]);
+    });
+
+    it("returns no topics field on LLM parse failure (fallback path)", async () => {
+      mockGenerateCompletion.mockResolvedValue("not valid json {{}}");
+      mockParseJsonResponse.mockImplementation(() => {
+        throw new Error("JSON parse error");
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(Object.hasOwn(result, "topics")).toBe(false);
+    });
+  });
+
   it("uses default getSummarizationPrompt when customPrompt is not provided", async () => {
     await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
 

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -59,17 +59,18 @@ describe("generateEpisodeSummary", () => {
   });
 
   describe("topic normalization", () => {
-    it("includes valid topics sorted by relevance descending", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "machine learning", relevance: 0.6 },
-          { name: "leadership skills", relevance: 0.9 },
-          { name: "data science", relevance: 0.75 },
-        ],
-      });
+    /** Shorthand: mock topics from LLM, run summarization, return result */
+    async function summarizeWithTopics(topics: unknown) {
+      mockParseJsonResponse.mockReturnValue({ ...mockSummaryResult, topics });
+      return generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+    }
 
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+    it("includes valid topics sorted by relevance descending", async () => {
+      const result = await summarizeWithTopics([
+        { name: "machine learning", relevance: 0.6 },
+        { name: "leadership skills", relevance: 0.9 },
+        { name: "data science", relevance: 0.75 },
+      ]);
 
       expect(result.topics).toEqual([
         { name: "Leadership Skills", relevance: 0.9 },
@@ -79,159 +80,91 @@ describe("generateEpisodeSummary", () => {
     });
 
     it("clamps relevance below 0 to 0", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [{ name: "Topic One", relevance: -0.5 }],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([{ name: "Topic One", relevance: -0.5 }]);
       expect(result.topics).toEqual([{ name: "Topic One", relevance: 0 }]);
     });
 
     it("clamps relevance above 1 to 1", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [{ name: "Topic One", relevance: 1.5 }],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([{ name: "Topic One", relevance: 1.5 }]);
       expect(result.topics).toEqual([{ name: "Topic One", relevance: 1 }]);
     });
 
     it("returns only top 5 topics when more than 5 are provided", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "Topic A", relevance: 0.9 },
-          { name: "Topic B", relevance: 0.8 },
-          { name: "Topic C", relevance: 0.7 },
-          { name: "Topic D", relevance: 0.6 },
-          { name: "Topic E", relevance: 0.5 },
-          { name: "Topic F", relevance: 0.3 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+      const result = await summarizeWithTopics([
+        { name: "Topic A", relevance: 0.9 },
+        { name: "Topic B", relevance: 0.8 },
+        { name: "Topic C", relevance: 0.7 },
+        { name: "Topic D", relevance: 0.6 },
+        { name: "Topic E", relevance: 0.5 },
+        { name: "Topic F", relevance: 0.3 },
+      ]);
 
       expect(result.topics).toHaveLength(5);
       expect(result.topics!.map((t) => t.name)).toEqual([
-        "Topic A",
-        "Topic B",
-        "Topic C",
-        "Topic D",
-        "Topic E",
+        "Topic A", "Topic B", "Topic C", "Topic D", "Topic E",
       ]);
     });
 
     it("deduplicates topics after title-case normalization, keeping highest relevance", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "machine learning", relevance: 0.6 },
-          { name: "Machine Learning", relevance: 0.85 },
-          { name: "MACHINE LEARNING", relevance: 0.4 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+      const result = await summarizeWithTopics([
+        { name: "machine learning", relevance: 0.6 },
+        { name: "Machine Learning", relevance: 0.85 },
+        { name: "MACHINE LEARNING", relevance: 0.4 },
+      ]);
 
       expect(result.topics).toHaveLength(1);
       expect(result.topics![0]).toEqual({ name: "Machine Learning", relevance: 0.85 });
     });
 
     it("filters out entries missing name", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { relevance: 0.8 },
-          { name: "Valid Topic", relevance: 0.7 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([
+        { relevance: 0.8 },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
     it("filters out entries missing relevance", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "No Relevance Topic" },
-          { name: "Valid Topic", relevance: 0.7 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([
+        { name: "No Relevance Topic" },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
     it("filters out entries with empty name after trim", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "   ", relevance: 0.8 },
-          { name: "Valid Topic", relevance: 0.7 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([
+        { name: "   ", relevance: 0.8 },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
     // Pin test: string relevance is dropped (not coerced). If coercion is added later, this test must change intentionally.
     it("drops entries where relevance is a string (pin test — documents current behavior)", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "String Relevance", relevance: "0.9" },
-          { name: "Valid Topic", relevance: 0.7 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([
+        { name: "String Relevance", relevance: "0.9" },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
     // Pin test: NaN relevance is dropped — typeof NaN === "number" is true, so an explicit isNaN guard is required.
     it("drops entries where relevance is NaN (pin test — guards against DB constraint violation)", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: [
-          { name: "NaN Relevance", relevance: NaN },
-          { name: "Valid Topic", relevance: 0.7 },
-        ],
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics([
+        { name: "NaN Relevance", relevance: NaN },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
     it("sets topics to undefined when LLM returns a non-array topics field", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: "not an array",
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics("not an array");
       expect(result.topics).toBeUndefined();
     });
 
     it("sets topics to undefined when topics is null", async () => {
-      mockParseJsonResponse.mockReturnValue({
-        ...mockSummaryResult,
-        topics: null,
-      });
-
-      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
-
+      const result = await summarizeWithTopics(null);
       expect(result.topics).toBeUndefined();
     });
 

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -198,6 +198,21 @@ describe("generateEpisodeSummary", () => {
       expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
     });
 
+    // Pin test: NaN relevance is dropped — typeof NaN === "number" is true, so an explicit isNaN guard is required.
+    it("drops entries where relevance is NaN (pin test — guards against DB constraint violation)", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSummaryResult,
+        topics: [
+          { name: "NaN Relevance", relevance: NaN },
+          { name: "Valid Topic", relevance: 0.7 },
+        ],
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
     it("sets topics to undefined when LLM returns a non-array topics field", async () => {
       mockParseJsonResponse.mockReturnValue({
         ...mockSummaryResult,

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -116,6 +116,14 @@ describe("generateEpisodeSummary", () => {
       expect(result.topics![0]).toEqual({ name: "Machine Learning", relevance: 0.85 });
     });
 
+    it("filters out entries with name exceeding 100 characters", async () => {
+      const result = await summarizeWithTopics([
+        { name: "A".repeat(101), relevance: 0.9 },
+        { name: "Valid Topic", relevance: 0.7 },
+      ]);
+      expect(result.topics).toEqual([{ name: "Valid Topic", relevance: 0.7 }]);
+    });
+
     it("filters out entries missing name", async () => {
       const result = await summarizeWithTopics([
         { relevance: 0.8 },

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/db", () => ({
 vi.mock("@/db/schema", () => ({
   episodes: { podcastIndexId: "podcastIndexId", id: "id" },
   podcasts: { podcastIndexId: "podcastIndexId" },
+  episodeTopics: { episodeId: "episodeId", topic: "topic", relevance: "relevance" },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -50,12 +51,14 @@ function makeUpdateChain(returnValue: unknown) {
 }
 
 // Chainable insert builder
-function makeInsertChain() {
+function makeInsertChain(returningValue: unknown[] = [{ id: 42 }]) {
   const chain = {
     values: vi.fn(),
     onConflictDoNothing: vi.fn(),
+    returning: vi.fn(),
   };
-  chain.values.mockResolvedValue(undefined);
+  chain.values.mockReturnValue(chain);
+  chain.returning.mockResolvedValue(returningValue);
   chain.onConflictDoNothing.mockResolvedValue(undefined);
   return chain;
 }
@@ -183,25 +186,26 @@ describe("persistEpisodeSummary", () => {
     mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
     mockEpisodesFindFirst.mockResolvedValue(null);
 
-    const chain = makeInsertChain();
-    mockInsert.mockReturnValue(chain);
+    const episodesChain = makeInsertChain([{ id: 42 }]);
+    mockInsert.mockReturnValue(episodesChain);
 
     const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
     await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
 
-    expect(chain.values).toHaveBeenCalledWith(
+    expect(episodesChain.values).toHaveBeenCalledWith(
       expect.objectContaining({
         summary: "Summary text",
         summaryStatus: "completed",
       })
     );
+    expect(episodesChain.returning).toHaveBeenCalled();
   });
 
   it("does NOT write transcript-related columns in the insert path", async () => {
     mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
     mockEpisodesFindFirst.mockResolvedValue(null);
 
-    const chain = makeInsertChain();
+    const chain = makeInsertChain([{ id: 42 }]);
     mockInsert.mockReturnValue(chain);
 
     const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
@@ -222,5 +226,105 @@ describe("persistEpisodeSummary", () => {
     await expect(
       persistEpisodeSummary(baseEpisode as never, undefined, baseSummary)
     ).rejects.toThrow("Could not find or create podcast in database");
+  });
+
+  describe("topic persistence", () => {
+    const summaryWithTopics = {
+      ...baseSummary,
+      topics: [
+        { name: "AI & Machine Learning", relevance: 0.9 },
+        { name: "Data Science", relevance: 0.75 },
+      ],
+    };
+
+    it("inserts topics after episode update on the update path", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
+
+      const updateChain = { set: vi.fn(), where: vi.fn() };
+      updateChain.set.mockReturnValue(updateChain);
+      updateChain.where.mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue(updateChain);
+
+      const topicsChain = makeInsertChain([]);
+      mockInsert.mockReturnValue(topicsChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
+
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(topicsChain.values).toHaveBeenCalledWith([
+        { episodeId: 10, topic: "AI & Machine Learning", relevance: "0.90" },
+        { episodeId: 10, topic: "Data Science", relevance: "0.75" },
+      ]);
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("inserts episode with .returning() then inserts topics using the returned id on the insert path", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue(null);
+
+      const episodesChain = makeInsertChain([{ id: 42 }]);
+      const topicsChain = makeInsertChain([]);
+      mockInsert.mockReturnValueOnce(episodesChain).mockReturnValueOnce(topicsChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
+
+      expect(episodesChain.returning).toHaveBeenCalled();
+      expect(topicsChain.values).toHaveBeenCalledWith([
+        { episodeId: 42, topic: "AI & Machine Learning", relevance: "0.90" },
+        { episodeId: 42, topic: "Data Science", relevance: "0.75" },
+      ]);
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("does not call topic insert when topics array is empty", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
+
+      const updateChain = { set: vi.fn(), where: vi.fn() };
+      updateChain.set.mockReturnValue(updateChain);
+      updateChain.where.mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue(updateChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await persistEpisodeSummary(baseEpisode as never, undefined, { ...baseSummary, topics: [] });
+
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("does not call topic insert when topics is undefined", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
+
+      const updateChain = { set: vi.fn(), where: vi.fn() };
+      updateChain.set.mockReturnValue(updateChain);
+      updateChain.where.mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue(updateChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
+
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("calls onConflictDoNothing on the topic insert chain (idempotent on re-runs)", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
+
+      const updateChain = { set: vi.fn(), where: vi.fn() };
+      updateChain.set.mockReturnValue(updateChain);
+      updateChain.where.mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue(updateChain);
+
+      const topicsChain = makeInsertChain([]);
+      mockInsert.mockReturnValue(topicsChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
+
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+    });
   });
 });

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -310,7 +310,7 @@ describe("persistEpisodeSummary", () => {
       expect(mockInsert).not.toHaveBeenCalled();
     });
 
-    it("does not throw if topic insert fails after delete (benign failure — retries self-heal)", async () => {
+    it("propagates topic insert error after delete (benign failure — retries self-heal)", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
       makeSimpleUpdateChain();

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -63,6 +63,15 @@ function makeInsertChain(returningValue: unknown[] = [{ id: 42 }]) {
   return chain;
 }
 
+// Lightweight update chain (no .returning) — used when only .set/.where are needed
+function makeSimpleUpdateChain() {
+  const chain = { set: vi.fn(), where: vi.fn() };
+  chain.set.mockReturnValue(chain);
+  chain.where.mockResolvedValue(undefined);
+  mockUpdate.mockReturnValue(chain);
+  return chain;
+}
+
 describe("persistTranscript", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -144,11 +153,7 @@ describe("persistEpisodeSummary", () => {
   it("updates summary fields and sets summaryStatus to 'completed' (update path)", async () => {
     mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
     mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-    const chain = { set: vi.fn(), where: vi.fn() };
-    chain.set.mockReturnValue(chain);
-    chain.where.mockResolvedValue(undefined);
-    mockUpdate.mockReturnValue(chain);
+    const chain = makeSimpleUpdateChain();
 
     const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
     await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
@@ -165,11 +170,7 @@ describe("persistEpisodeSummary", () => {
   it("does NOT write transcript-related columns in the update path", async () => {
     mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
     mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-    const chain = { set: vi.fn(), where: vi.fn() };
-    chain.set.mockReturnValue(chain);
-    chain.where.mockResolvedValue(undefined);
-    mockUpdate.mockReturnValue(chain);
+    const chain = makeSimpleUpdateChain();
 
     const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
     await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
@@ -240,11 +241,7 @@ describe("persistEpisodeSummary", () => {
     it("inserts topics after episode update on the update path", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-      const updateChain = { set: vi.fn(), where: vi.fn() };
-      updateChain.set.mockReturnValue(updateChain);
-      updateChain.where.mockResolvedValue(undefined);
-      mockUpdate.mockReturnValue(updateChain);
+      makeSimpleUpdateChain();
 
       const topicsChain = makeInsertChain([]);
       mockInsert.mockReturnValue(topicsChain);
@@ -286,11 +283,7 @@ describe("persistEpisodeSummary", () => {
     it("does not call topic insert when topics array is empty", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-      const updateChain = { set: vi.fn(), where: vi.fn() };
-      updateChain.set.mockReturnValue(updateChain);
-      updateChain.where.mockResolvedValue(undefined);
-      mockUpdate.mockReturnValue(updateChain);
+      makeSimpleUpdateChain();
 
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, { ...baseSummary, topics: [] });
@@ -301,11 +294,7 @@ describe("persistEpisodeSummary", () => {
     it("does not call topic insert when topics is undefined", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-      const updateChain = { set: vi.fn(), where: vi.fn() };
-      updateChain.set.mockReturnValue(updateChain);
-      updateChain.where.mockResolvedValue(undefined);
-      mockUpdate.mockReturnValue(updateChain);
+      makeSimpleUpdateChain();
 
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
@@ -316,11 +305,7 @@ describe("persistEpisodeSummary", () => {
     it("calls onConflictDoNothing with explicit conflict target (idempotent on re-runs)", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-
-      const updateChain = { set: vi.fn(), where: vi.fn() };
-      updateChain.set.mockReturnValue(updateChain);
-      updateChain.where.mockResolvedValue(undefined);
-      mockUpdate.mockReturnValue(updateChain);
+      makeSimpleUpdateChain();
 
       const topicsChain = makeInsertChain([]);
       mockInsert.mockReturnValue(topicsChain);

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -257,7 +257,9 @@ describe("persistEpisodeSummary", () => {
         { episodeId: 10, topic: "AI & Machine Learning", relevance: "0.90" },
         { episodeId: 10, topic: "Data Science", relevance: "0.75" },
       ]);
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
+        target: ["episodeId", "topic"],
+      });
     });
 
     it("inserts episode with .returning() then inserts topics using the returned id on the insert path", async () => {
@@ -276,7 +278,9 @@ describe("persistEpisodeSummary", () => {
         { episodeId: 42, topic: "AI & Machine Learning", relevance: "0.90" },
         { episodeId: 42, topic: "Data Science", relevance: "0.75" },
       ]);
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
+        target: ["episodeId", "topic"],
+      });
     });
 
     it("does not call topic insert when topics array is empty", async () => {
@@ -309,7 +313,7 @@ describe("persistEpisodeSummary", () => {
       expect(mockInsert).not.toHaveBeenCalled();
     });
 
-    it("calls onConflictDoNothing on the topic insert chain (idempotent on re-runs)", async () => {
+    it("calls onConflictDoNothing with explicit conflict target (idempotent on re-runs)", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
 
@@ -324,7 +328,9 @@ describe("persistEpisodeSummary", () => {
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
 
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalled();
+      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
+        target: ["episodeId", "topic"],
+      });
     });
   });
 });

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -56,12 +56,10 @@ function makeUpdateChain(returnValue: unknown) {
 function makeInsertChain(returningValue: unknown[] = [{ id: 42 }]) {
   const chain = {
     values: vi.fn(),
-    onConflictDoNothing: vi.fn(),
     returning: vi.fn(),
   };
   chain.values.mockReturnValue(chain);
   chain.returning.mockResolvedValue(returningValue);
-  chain.onConflictDoNothing.mockResolvedValue(undefined);
   return chain;
 }
 
@@ -310,6 +308,29 @@ describe("persistEpisodeSummary", () => {
 
       expect(mockDelete).not.toHaveBeenCalled();
       expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("does not throw if topic insert fails after delete (benign failure — retries self-heal)", async () => {
+      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
+      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
+      makeSimpleUpdateChain();
+      makeDeleteChain();
+
+      const topicsChain = {
+        values: vi.fn(),
+      };
+      topicsChain.values.mockImplementation(() => {
+        throw new Error("insert failed");
+      });
+      mockInsert.mockReturnValue(topicsChain);
+
+      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
+      await expect(
+        persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics)
+      ).rejects.toThrow("insert failed");
+
+      // Delete ran before the insert failure — topics are cleared until next retry
+      expect(mockDelete).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Mock DB — separate mock functions per operation to avoid order-dependent fragility
 const mockUpdate = vi.fn();
 const mockInsert = vi.fn();
+const mockDelete = vi.fn();
 const mockEpisodesFindFirst = vi.fn();
 const mockPodcastsFindFirst = vi.fn();
 
@@ -10,6 +11,7 @@ vi.mock("@/db", () => ({
   db: {
     update: (...args: unknown[]) => mockUpdate(...args),
     insert: (...args: unknown[]) => mockInsert(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
     query: {
       episodes: {
         findFirst: (...args: unknown[]) => mockEpisodesFindFirst(...args),
@@ -60,6 +62,14 @@ function makeInsertChain(returningValue: unknown[] = [{ id: 42 }]) {
   chain.values.mockReturnValue(chain);
   chain.returning.mockResolvedValue(returningValue);
   chain.onConflictDoNothing.mockResolvedValue(undefined);
+  return chain;
+}
+
+// Chainable delete builder
+function makeDeleteChain() {
+  const chain = { where: vi.fn() };
+  chain.where.mockResolvedValue(undefined);
+  mockDelete.mockReturnValue(chain);
   return chain;
 }
 
@@ -238,10 +248,11 @@ describe("persistEpisodeSummary", () => {
       ],
     };
 
-    it("inserts topics after episode update on the update path", async () => {
+    it("deletes existing topics then inserts new ones on the update path", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
       makeSimpleUpdateChain();
+      makeDeleteChain();
 
       const topicsChain = makeInsertChain([]);
       mockInsert.mockReturnValue(topicsChain);
@@ -249,20 +260,19 @@ describe("persistEpisodeSummary", () => {
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
 
+      expect(mockDelete).toHaveBeenCalledTimes(1);
       expect(mockInsert).toHaveBeenCalledTimes(1);
       expect(topicsChain.values).toHaveBeenCalledWith([
         { episodeId: 10, topic: "AI & Machine Learning", relevance: "0.90" },
         { episodeId: 10, topic: "Data Science", relevance: "0.75" },
       ]);
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
-        target: ["episodeId", "topic"],
-      });
     });
 
-    it("inserts episode with .returning() then inserts topics using the returned id on the insert path", async () => {
+    it("deletes existing topics then inserts using the returned id on the insert path", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue(null);
 
+      makeDeleteChain();
       const episodesChain = makeInsertChain([{ id: 42 }]);
       const topicsChain = makeInsertChain([]);
       mockInsert.mockReturnValueOnce(episodesChain).mockReturnValueOnce(topicsChain);
@@ -271,16 +281,14 @@ describe("persistEpisodeSummary", () => {
       await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
 
       expect(episodesChain.returning).toHaveBeenCalled();
+      expect(mockDelete).toHaveBeenCalledTimes(1);
       expect(topicsChain.values).toHaveBeenCalledWith([
         { episodeId: 42, topic: "AI & Machine Learning", relevance: "0.90" },
         { episodeId: 42, topic: "Data Science", relevance: "0.75" },
       ]);
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
-        target: ["episodeId", "topic"],
-      });
     });
 
-    it("does not call topic insert when topics array is empty", async () => {
+    it("does not delete or insert topics when topics array is empty", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
       makeSimpleUpdateChain();
@@ -288,10 +296,11 @@ describe("persistEpisodeSummary", () => {
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, { ...baseSummary, topics: [] });
 
+      expect(mockDelete).not.toHaveBeenCalled();
       expect(mockInsert).not.toHaveBeenCalled();
     });
 
-    it("does not call topic insert when topics is undefined", async () => {
+    it("does not delete or insert topics when topics is undefined", async () => {
       mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
       mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
       makeSimpleUpdateChain();
@@ -299,23 +308,8 @@ describe("persistEpisodeSummary", () => {
       const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
       await persistEpisodeSummary(baseEpisode as never, undefined, baseSummary);
 
+      expect(mockDelete).not.toHaveBeenCalled();
       expect(mockInsert).not.toHaveBeenCalled();
-    });
-
-    it("calls onConflictDoNothing with explicit conflict target (idempotent on re-runs)", async () => {
-      mockPodcastsFindFirst.mockResolvedValue({ id: 1 });
-      mockEpisodesFindFirst.mockResolvedValue({ id: 10 });
-      makeSimpleUpdateChain();
-
-      const topicsChain = makeInsertChain([]);
-      mockInsert.mockReturnValue(topicsChain);
-
-      const { persistEpisodeSummary } = await import("@/trigger/helpers/database");
-      await persistEpisodeSummary(baseEpisode as never, undefined, summaryWithTopics);
-
-      expect(topicsChain.onConflictDoNothing).toHaveBeenCalledWith({
-        target: ["episodeId", "topic"],
-      });
     });
   });
 });

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -4,6 +4,11 @@ import { SYSTEM_PROMPT, getSummarizationPrompt } from "@/lib/prompts";
 import { interpolatePrompt } from "@/lib/admin/prompt-utils";
 import type { PodcastIndexPodcast, PodcastIndexEpisode } from "@/lib/podcastindex";
 
+// File-private helper — not exported. If a second consumer appears, extract it then.
+function toTitleCase(str: string): string {
+  return str.replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+}
+
 export type { SummaryResult } from "@/lib/openrouter";
 
 export async function generateEpisodeSummary(
@@ -53,6 +58,39 @@ export async function generateEpisodeSummary(
         result.worthItScore = computed;
       }
     }
+
+    // Validate and normalize topics
+    if (Array.isArray(result.topics)) {
+      result.topics = result.topics
+        // 1. Array shape check: drop entries missing name or relevance
+        .filter(
+          (t): t is { name: string; relevance: number } =>
+            typeof t === "object" &&
+            t !== null &&
+            typeof t.name === "string" &&
+            t.name.trim().length > 0 &&
+            typeof t.relevance === "number"
+        )
+        // 2. Normalize: title-case name, clamp relevance to [0, 1]
+        .map((t) => ({
+          name: toTitleCase(t.name.trim()),
+          relevance: Math.min(1, Math.max(0, t.relevance)),
+        }))
+        // 3. Deduplicate by normalized name (keep highest relevance)
+        // case-insensitivity is provided by toTitleCase() above, not by this comparison
+        .reduce<Array<{ name: string; relevance: number }>>((acc, t) => {
+          const existing = acc.find((x) => x.name === t.name);
+          if (!existing) acc.push(t);
+          else if (t.relevance > existing.relevance) existing.relevance = t.relevance;
+          return acc;
+        }, [])
+        // 4. Sort descending and cap at 5
+        .sort((a, b) => b.relevance - a.relevance)
+        .slice(0, 5);
+    } else {
+      result.topics = undefined;
+    }
+
     return result;
   } catch {
     return {

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -61,32 +61,29 @@ export async function generateEpisodeSummary(
 
     // Validate and normalize topics
     if (Array.isArray(result.topics)) {
-      result.topics = result.topics
-        // 1. Array shape check: drop entries missing name or relevance
-        .filter(
-          (t): t is { name: string; relevance: number } =>
-            typeof t === "object" &&
-            t !== null &&
-            typeof t.name === "string" &&
-            t.name.trim().length > 0 &&
-            typeof t.relevance === "number" && !Number.isNaN(t.relevance)
-        )
-        // 2. Normalize: title-case name, clamp relevance to [0, 1]
-        .map((t) => ({
-          name: toTitleCase(t.name.trim()),
-          relevance: Math.min(1, Math.max(0, t.relevance)),
-        }))
-        // 3. Deduplicate by normalized name (keep highest relevance)
-        // case-insensitivity is provided by toTitleCase() above, not by this comparison
-        .reduce<Map<string, { name: string; relevance: number }>>((acc, t) => {
-          const existing = acc.get(t.name);
-          if (!existing) acc.set(t.name, t);
-          else if (t.relevance > existing.relevance) existing.relevance = t.relevance;
-          return acc;
-        }, new Map())
-        .values()
-        .toArray()
-        // 4. Sort descending and cap at 5
+      // 1. Filter: drop entries missing name or relevance
+      const valid = result.topics.filter(
+        (t): t is { name: string; relevance: number } =>
+          typeof t === "object" &&
+          t !== null &&
+          typeof t.name === "string" &&
+          t.name.trim().length > 0 &&
+          typeof t.relevance === "number" &&
+          !Number.isNaN(t.relevance)
+      );
+      // 2. Normalize: title-case name, clamp relevance to [0, 1]
+      // 3. Deduplicate by normalized name using Map for O(1) lookup (keep highest relevance)
+      // case-insensitivity is provided by toTitleCase() above, not by the Map key comparison
+      const deduped = new Map<string, { name: string; relevance: number }>();
+      for (const t of valid) {
+        const name = toTitleCase(t.name.trim());
+        const relevance = Math.min(1, Math.max(0, t.relevance));
+        const existing = deduped.get(name);
+        if (!existing) deduped.set(name, { name, relevance });
+        else if (relevance > existing.relevance) existing.relevance = relevance;
+      }
+      // 4. Sort descending and cap at 5
+      result.topics = Array.from(deduped.values())
         .sort((a, b) => b.relevance - a.relevance)
         .slice(0, 5);
     } else {

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -78,12 +78,14 @@ export async function generateEpisodeSummary(
         }))
         // 3. Deduplicate by normalized name (keep highest relevance)
         // case-insensitivity is provided by toTitleCase() above, not by this comparison
-        .reduce<Array<{ name: string; relevance: number }>>((acc, t) => {
-          const existing = acc.find((x) => x.name === t.name);
-          if (!existing) acc.push(t);
+        .reduce<Map<string, { name: string; relevance: number }>>((acc, t) => {
+          const existing = acc.get(t.name);
+          if (!existing) acc.set(t.name, t);
           else if (t.relevance > existing.relevance) existing.relevance = t.relevance;
           return acc;
-        }, [])
+        }, new Map())
+        .values()
+        .toArray()
         // 4. Sort descending and cap at 5
         .sort((a, b) => b.relevance - a.relevance)
         .slice(0, 5);

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -68,6 +68,7 @@ export async function generateEpisodeSummary(
           t !== null &&
           typeof t.name === "string" &&
           t.name.trim().length > 0 &&
+          t.name.trim().length <= 100 &&
           typeof t.relevance === "number" &&
           !Number.isNaN(t.relevance)
       );

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -69,7 +69,7 @@ export async function generateEpisodeSummary(
             t !== null &&
             typeof t.name === "string" &&
             t.name.trim().length > 0 &&
-            typeof t.relevance === "number"
+            typeof t.relevance === "number" && !Number.isNaN(t.relevance)
         )
         // 2. Normalize: title-case name, clamp relevance to [0, 1]
         .map((t) => ({

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -136,7 +136,7 @@ export async function persistTranscript(
 
 async function persistTopics(
   episodeId: number,
-  topics: Array<{ name: string; relevance: number }> | undefined
+  topics: SummaryResult["topics"]
 ): Promise<void> {
   if (!topics || topics.length === 0) return;
   await db
@@ -148,7 +148,7 @@ async function persistTopics(
         relevance: t.relevance.toFixed(2),
       }))
     )
-    .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
+    .onConflictDoNothing({ target: [episodeTopics.episodeId, episodeTopics.topic] }); // idempotent on re-runs
 }
 
 export async function persistEpisodeSummary(
@@ -161,7 +161,7 @@ export async function persistEpisodeSummary(
     throw new Error("Could not find or create podcast in database");
   }
 
-  // Check for existing episode (may have been created by trackEpisodeRun)
+  // May have been created by trackEpisodeRun
   const existingEpisode = await db.query.episodes.findFirst({
     where: eq(episodes.podcastIndexId, episode.id.toString()),
   });

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { episodes, podcasts } from "@/db/schema";
+import { episodes, episodeTopics, podcasts } from "@/db/schema";
 import { upsertPodcast } from "@/db/helpers";
 import type { SummaryResult } from "@/lib/openrouter";
 import type { PodcastIndexPodcast, PodcastIndexEpisode } from "@/lib/podcastindex";
@@ -165,24 +165,53 @@ export async function persistEpisodeSummary(
         updatedAt: new Date(),
       })
       .where(eq(episodes.id, existingEpisode.id));
+
+    if (summary.topics && summary.topics.length > 0) {
+      await db
+        .insert(episodeTopics)
+        .values(
+          summary.topics.map((t) => ({
+            episodeId: existingEpisode.id,
+            topic: t.name,
+            relevance: t.relevance.toFixed(2),
+          }))
+        )
+        .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
+    }
   } else {
-    await db.insert(episodes).values({
-      podcastId,
-      podcastIndexId: episode.id.toString(),
-      title: episode.title,
-      description: episode.description,
-      audioUrl: episode.enclosureUrl,
-      duration: episode.duration,
-      publishDate: episode.datePublished
-        ? new Date(episode.datePublished * 1000)
-        : null,
-      summary: summary.summary,
-      keyTakeaways: summary.keyTakeaways,
-      worthItScore: summary.worthItScore.toFixed(2),
-      worthItReason: summary.worthItReason,
-      worthItDimensions: summary.worthItDimensions ?? null,
-      summaryStatus: "completed",
-      processedAt: new Date(),
-    });
+    const [inserted] = await db
+      .insert(episodes)
+      .values({
+        podcastId,
+        podcastIndexId: episode.id.toString(),
+        title: episode.title,
+        description: episode.description,
+        audioUrl: episode.enclosureUrl,
+        duration: episode.duration,
+        publishDate: episode.datePublished
+          ? new Date(episode.datePublished * 1000)
+          : null,
+        summary: summary.summary,
+        keyTakeaways: summary.keyTakeaways,
+        worthItScore: summary.worthItScore.toFixed(2),
+        worthItReason: summary.worthItReason,
+        worthItDimensions: summary.worthItDimensions ?? null,
+        summaryStatus: "completed",
+        processedAt: new Date(),
+      })
+      .returning({ id: episodes.id });
+
+    if (inserted && summary.topics && summary.topics.length > 0) {
+      await db
+        .insert(episodeTopics)
+        .values(
+          summary.topics.map((t) => ({
+            episodeId: inserted.id,
+            topic: t.name,
+            relevance: t.relevance.toFixed(2),
+          }))
+        )
+        .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
+    }
   }
 }

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -134,6 +134,23 @@ export async function persistTranscript(
   }
 }
 
+async function persistTopics(
+  episodeId: number,
+  topics: Array<{ name: string; relevance: number }> | undefined
+): Promise<void> {
+  if (!topics || topics.length === 0) return;
+  await db
+    .insert(episodeTopics)
+    .values(
+      topics.map((t) => ({
+        episodeId,
+        topic: t.name,
+        relevance: t.relevance.toFixed(2),
+      }))
+    )
+    .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
+}
+
 export async function persistEpisodeSummary(
   episode: PodcastIndexEpisode,
   podcast: PodcastIndexPodcast | undefined,
@@ -166,18 +183,7 @@ export async function persistEpisodeSummary(
       })
       .where(eq(episodes.id, existingEpisode.id));
 
-    if (summary.topics && summary.topics.length > 0) {
-      await db
-        .insert(episodeTopics)
-        .values(
-          summary.topics.map((t) => ({
-            episodeId: existingEpisode.id,
-            topic: t.name,
-            relevance: t.relevance.toFixed(2),
-          }))
-        )
-        .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
-    }
+    await persistTopics(existingEpisode.id, summary.topics);
   } else {
     const [inserted] = await db
       .insert(episodes)
@@ -201,17 +207,8 @@ export async function persistEpisodeSummary(
       })
       .returning({ id: episodes.id });
 
-    if (inserted && summary.topics && summary.topics.length > 0) {
-      await db
-        .insert(episodeTopics)
-        .values(
-          summary.topics.map((t) => ({
-            episodeId: inserted.id,
-            topic: t.name,
-            relevance: t.relevance.toFixed(2),
-          }))
-        )
-        .onConflictDoNothing(); // unique (episodeId, topic) — idempotent on re-runs
+    if (inserted) {
+      await persistTopics(inserted.id, summary.topics);
     }
   }
 }

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -139,6 +139,10 @@ async function persistTopics(
   topics: SummaryResult["topics"]
 ): Promise<void> {
   if (!topics || topics.length === 0) return;
+  // Delete-then-insert to reconcile stale topics on re-summarization.
+  // No transaction — benign failure mode matches the existing pattern
+  // (summary saved without topics; Trigger.dev retries self-heal).
+  await db.delete(episodeTopics).where(eq(episodeTopics.episodeId, episodeId));
   await db
     .insert(episodeTopics)
     .values(
@@ -147,8 +151,7 @@ async function persistTopics(
         topic: t.name,
         relevance: t.relevance.toFixed(2),
       }))
-    )
-    .onConflictDoNothing({ target: [episodeTopics.episodeId, episodeTopics.topic] }); // idempotent on re-runs
+    );
 }
 
 export async function persistEpisodeSummary(


### PR DESCRIPTION
## Summary

- Add topic tag extraction to the AI summarization pipeline — the LLM now returns 1-5 topic tags per episode with relevance scores
- New `episode_topics` junction table with indexed `topic` column for cross-episode queries and unique `(episodeId, topic)` constraint
- Topic validation pipeline: filter invalid entries, title-case normalization, relevance clamping (0-1), deduplication (highest relevance wins), cap at 5
- Persistence in both update and insert paths of `persistEpisodeSummary()` with `onConflictDoNothing` for idempotent retries
- ADR-031 documents the junction table vs JSON column decision

## Architecture Decisions

- **Junction table over JSON column** — enables indexed cross-episode queries (`WHERE topic = ?`) without JSON parsing
- **No transaction** — benign failure mode (summary saved without topics), Trigger.dev retries self-heal
- **Custom prompts bypass** — `interpolatePrompt` path doesn't inject topic extraction; `topics` field is optional on `SummaryResult`
- **`onConflictDoNothing`** — Trigger.dev task retries won't fail or duplicate

## Deploy Notes

> **IMPORTANT:** Run `doppler run --config prd -- bunx drizzle-kit push` against production **before** this code ships. The `episode_topics` table must exist before `persistEpisodeSummary` runs. See ADR-031 and the `worth_it_reason` column incident for prior art.

## Files Changed

| File | Change |
|------|--------|
| `src/db/schema.ts` | `episodeTopics` table, relations, type exports |
| `src/lib/openrouter.ts` | `SummaryResult.topics` optional field |
| `src/lib/prompts.ts` | Topic extraction in summarization prompt |
| `src/trigger/helpers/ai-summary.ts` | `toTitleCase` helper, validation/normalization pipeline |
| `src/trigger/helpers/database.ts` | Topic persistence (update + insert paths) |
| `src/trigger/helpers/__tests__/ai-summary.test.ts` | 13 topic normalization tests |
| `src/trigger/helpers/__tests__/database.test.ts` | 5 topic persistence tests + existing test updates |
| `docs/adr/031-episode-topics-junction-table.md` | ADR for schema decision |
| `drizzle/0016_abnormal_wendell_vaughn.sql` | Migration (additive only) |

## Known Limitations

- `toTitleCase` collapses acronyms: "AI Ethics" → "Ai Ethics". Acceptable for v1; follow-up issue for acronym-preserving normalization.
- Custom prompts don't automatically get topic extraction — this is intentional (AD-3 in ADR-031).

## Test Plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 1507 tests passing (129 files)
- [x] `bun run build` — clean
- [x] Migration SQL reviewed — additive only (CREATE TABLE, indexes, FK), no DROPs
- [ ] Run `bun run db:push` against production before deploy
- [ ] Summarize an episode end-to-end and verify topic tags appear in `episode_topics` table

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episode summaries now extract up to 5 normalized, deduplicated topic tags (Title Case) with relevance scores (0.00–1.00) and persist them per episode.

* **Behavioral Change**
  * Summarization prompt now requests a top-level topics field; custom prompts bypass automatic topic extraction. Topics may be reconciled on retries.

* **Documentation**
  * Added ADR detailing topic persistence and reconciliation approach.

* **Tests**
  * Added tests for topic normalization and persistence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->