### PR TITLE
feat: replace worth-it scoring with boolean signal hybrid

### DIFF
--- a/.storybook/mocks/db-schema.ts
+++ b/.storybook/mocks/db-schema.ts
@@ -1,11 +1,15 @@
 // Stub for @/db/schema in Storybook
+export const rateLimits = {};
 export const users = {};
 export const podcasts = {};
 export const episodes = {};
 export const userSubscriptions = {};
 export const collections = {};
 export const userLibrary = {};
+export const aiConfig = {};
 export const bookmarks = {};
 export const notifications = {};
 export const pushSubscriptions = {};
+export const trendingTopics = {};
+export const episodeTopics = {};
 export const listenHistory = {};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Admin link in sidebar (visible to `org:admin` users only)
 
 ### Changed
+- Replace 3-dimension numeric worth-it scoring with boolean signal hybrid (8 yes/no quality signals + ±1 adjustment) for more stable, interpretable episode scores (#260)
 - Score and status badge components migrated from hardcoded Tailwind colors to semantic design tokens (#256)
 - Empty state icons standardized to consistent `rounded-full bg-muted p-3` container pattern across 7 components (#256)
 - `InstallBanner` uses semantic `bg-card`/`text-card-foreground` tokens instead of hardcoded zinc colors (#256)

--- a/docs/adr/032-boolean-signal-scoring.md
+++ b/docs/adr/032-boolean-signal-scoring.md
@@ -1,0 +1,93 @@
+# ADR-032: Boolean Signal Hybrid Scoring
+
+**Status:** Accepted
+**Date:** 2026-04-12
+
+## Context
+
+The existing worth-it scoring system asks the LLM to rate episodes on three numeric dimensions (uniqueness, actionability, timeValue) on a 1–10 scale, then averages them into a composite score. This approach has two structural problems:
+
+1. **LLMs cannot calibrate absolute numeric scores reliably.** Asking a model to distinguish a "6" from a "7" on a subjective scale produces systematic inflation and poor inter-run consistency. Scores cluster around 6–8 regardless of actual content quality.
+2. **"Uniqueness" is unjudgeable in isolation.** A single episode summary provides no corpus context — the model has no basis for assessing whether insights are unique relative to the broader podcast landscape.
+
+The scoring system needs to shift from subjective numeric calibration to objective binary questions that LLMs can answer reliably.
+
+## Decision
+
+Replace the 3-dimension numeric scoring system with **8 boolean signal questions** plus a **constrained ±1 LLM adjustment**. The score formula becomes:
+
+```
+score = clamp(1 + count_of_true_signals + adjustment, 1, 10)
+```
+
+### The 8 signals
+
+| Signal | Question |
+|--------|----------|
+| `hasActionableInsights` | Does the episode contain 3+ actionable insights? |
+| `hasNearTermApplicability` | Could a listener apply something within a week? |
+| `staysFocused` | Does the episode stay focused with low filler-to-content ratio? |
+| `goesBeyondSurface` | Does it go beyond surface-level discussion? |
+| `isWellStructured` | Is it well-structured and easy to follow? |
+| `timeJustified` | Is the time investment justified by content density? |
+| `hasConcreteExamples` | Does it include concrete examples, data, or evidence? |
+| `hasExpertPerspectives` | Does it feature expert or practitioner perspectives? |
+
+### Adjustment
+
+After answering the signals, the LLM may apply a small adjustment:
+- **-1**: Signals slightly overstate quality (e.g., technically structured but painfully boring)
+- **0**: Signals accurately capture quality (default, used in most cases)
+- **+1**: Signals slightly understate quality (e.g., a masterclass that transcends the checklist)
+
+### Backward compatibility
+
+The `worth_it_dimensions` column is an untyped JSON blob. A discriminated union with a `kind` field distinguishes formats:
+
+- **New rows:** `{ kind: "signals", signals: {...}, adjustment, adjustmentReason }`
+- **Old rows:** `{ uniqueness, actionability, timeValue }` (no `kind` field)
+
+Detection: if `kind === "signals"`, use the new path; otherwise treat as legacy dimensions. No database migration is required — the column is `json` with no DB-level shape constraint.
+
+### Score computation is server-side
+
+The LLM returns the 8 boolean signals and the adjustment; the score is computed server-side via `computeSignalScore()`. The LLM never returns a numeric score in the new format. This eliminates prompt-score disagreements and makes scoring deterministic given the same signals.
+
+## Trade-offs
+
+### Discrete vs. continuous scores
+
+Scores become discrete integers (1–10) instead of continuous decimals. This is acceptable because:
+- The signal checklist provides the real qualitative detail — the number is a summary
+- Integer scores are easier for users to reason about
+- The old continuous scores were illusory precision — an averaged 7.33 vs. 7.00 carried no meaningful distinction
+
+### Mixed-format display during transition
+
+Old episodes retain their decimal scores (e.g., "7.3"). New episodes produce integer-like scores (e.g., "7.0"). The UI uses `toFixed(1)` for both. This is acceptable; over time, bulk-resummarize can migrate old episodes to the new format.
+
+### Custom prompts may not return signals
+
+Custom prompts (per ADR-028) bypass `getSummarizationPrompt()` entirely. The server-side score computation implements a 3-tier fallback:
+1. If `worthItSignals` is present → compute score from signals (new path)
+2. If `worthItDimensions` is present with old format → average dimensions (legacy path)
+3. If neither → use raw `worthItScore` from LLM response (fallback)
+
+This means custom prompt users see no change in behavior.
+
+## Consequences
+
+- **Existing thresholds remain valid.** The score distribution maps cleanly to existing tiers:
+  - Exceptional (≥ 8): 7–8 signals — genuinely exceptional content
+  - Above Average (≥ 6): 5–6 signals — solid, majority-positive content
+  - Average (≥ 4): 3–4 signals — decent but unremarkable
+  - Below Average (≥ 2): 1–2 signals — weak
+  - Skip (< 2): 0 signals with zero/negative adjustment
+- **Recommendation threshold (`SCORE_THRESHOLD = "6.00"`) is preserved.** Score ≥ 6 means 5+ signals fired — a majority of quality indicators.
+- **Bulk-resummarize can migrate old episodes** to the new signal format. No urgent backfill is required.
+- **`worthItReason` now includes structured signal information** — a compact summary of which signals fired and the adjustment justification.
+- **No schema migration required.** The `worth_it_dimensions` JSON column and `worth_it_score` decimal column both accommodate the new format without changes.
+
+## Related ADRs
+
+- ADR-028: Admin panel architecture — custom prompt pipeline that this change must not break.

--- a/docs/adr/032-boolean-signal-scoring.md
+++ b/docs/adr/032-boolean-signal-scoring.md
@@ -16,7 +16,7 @@ The scoring system needs to shift from subjective numeric calibration to objecti
 
 Replace the 3-dimension numeric scoring system with **8 boolean signal questions** plus a **constrained ±1 LLM adjustment**. The score formula becomes:
 
-```
+```text
 score = clamp(1 + count_of_true_signals + adjustment, 1, 10)
 ```
 

--- a/src/app/(app)/episode/[id]/page.tsx
+++ b/src/app/(app)/episode/[id]/page.tsx
@@ -46,6 +46,7 @@ import { OfflineBanner } from "@/components/ui/offline-banner";
 import { cacheEpisode, getCachedEpisode } from "@/lib/offline-cache";
 import { IN_PROGRESS_STATUSES, type TranscriptStatus } from "@/db/schema";
 import { ADMIN_ROLE } from "@/lib/auth-roles";
+import type { WorthItDimensionsData } from "@/lib/openrouter";
 import type { summarizeEpisode } from "@/trigger/summarize-episode";
 
 interface EpisodePageProps {
@@ -86,11 +87,7 @@ interface SummaryData {
   keyTakeaways: string[];
   worthItScore: number | null;
   worthItReason?: string;
-  worthItDimensions?: {
-    uniqueness: number;
-    actionability: number;
-    timeValue: number;
-  } | null;
+  worthItDimensions?: WorthItDimensionsData | null;
   cached: boolean;
 }
 

--- a/src/components/__tests__/summary-display.test.tsx
+++ b/src/components/__tests__/summary-display.test.tsx
@@ -207,7 +207,7 @@ describe("SummaryDisplay", () => {
         summary="Short summary."
         keyTakeaways={[]}
         worthItScore={7}
-        worthItDimensions={{ uniqueness: 3, actionability: 4, timeValue: 9 }}
+        worthItDimensions={{ kind: "dimensions", uniqueness: 3, actionability: 4, timeValue: 9 }}
       />
     );
     expect(screen.getByText("Score Breakdown")).toBeInTheDocument();
@@ -223,6 +223,7 @@ describe("SummaryDisplay", () => {
         keyTakeaways={[]}
         worthItScore={7}
         worthItDimensions={{
+          kind: "dimensions",
           uniqueness: 8,
           actionability: NaN as unknown as number,
           timeValue: 6,

--- a/src/components/episodes/summary-display.stories.tsx
+++ b/src/components/episodes/summary-display.stories.tsx
@@ -82,7 +82,7 @@ export const WithSignals: Story = {
     ],
     worthItScore: 7,
     worthItReason:
-      "5/8 signals: actionable insights, near-term applicability, focused, beyond surface, concrete examples. Adjustment: +1 (exceptional guest lineup).",
+      "5/8 signals: actionable insights, near-term applicability, focused, beyond surface, well-structured. Adjustment: +1 (exceptional guest lineup).",
     worthItDimensions: {
       kind: "signals",
       signals: {

--- a/src/components/episodes/summary-display.stories.tsx
+++ b/src/components/episodes/summary-display.stories.tsx
@@ -70,3 +70,46 @@ export const LowScore: Story = {
     worthItReason: "Limited value — mostly rehashed material from other episodes.",
   },
 };
+
+export const WithSignals: Story = {
+  args: {
+    summary:
+      "This episode dives deep into the latest advancements in AI-powered tools for content creators.",
+    keyTakeaways: [
+      "AI tools can reduce podcast editing time by up to 60%",
+      "Content creators should focus on authenticity",
+      "Emerging transcription tools achieve 98%+ accuracy",
+    ],
+    worthItScore: 7,
+    worthItReason:
+      "5/8 signals: actionable insights, near-term applicability, focused, beyond surface, concrete examples. Adjustment: +1 (exceptional guest lineup).",
+    worthItDimensions: {
+      kind: "signals",
+      signals: {
+        hasActionableInsights: true,
+        hasNearTermApplicability: true,
+        staysFocused: true,
+        goesBeyondSurface: true,
+        isWellStructured: true,
+        timeJustified: false,
+        hasConcreteExamples: false,
+        hasExpertPerspectives: false,
+      },
+      adjustment: 1,
+      adjustmentReason:
+        "Exceptional guest lineup elevates the content beyond the checklist.",
+    },
+  },
+};
+
+export const WithLegacyDimensions: Story = {
+  args: {
+    ...FullSummary.args,
+    worthItDimensions: {
+      kind: "dimensions",
+      uniqueness: 8,
+      actionability: 7,
+      timeValue: 9,
+    },
+  },
+};

--- a/src/components/episodes/summary-display.tsx
+++ b/src/components/episodes/summary-display.tsx
@@ -9,12 +9,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   Sparkles,
   CheckCircle,
+  XCircle,
   Loader2,
   AlertCircle,
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
 import { getScoreColor, getScoreLabel } from "@/lib/score-utils";
+import { WORTH_IT_SIGNAL_KEYS, SIGNAL_LABELS, type WorthItDimensionsData } from "@/lib/openrouter";
 import type { SummarizationStep } from "@/trigger/types";
 
 export type { SummarizationStep } from "@/trigger/types";
@@ -24,11 +26,7 @@ interface SummaryDisplayProps {
   keyTakeaways: string[] | null;
   worthItScore: number | null;
   worthItReason?: string;
-  worthItDimensions?: {
-    uniqueness: number;
-    actionability: number;
-    timeValue: number;
-  } | null;
+  worthItDimensions?: WorthItDimensionsData | null;
   isLoading?: boolean;
   error?: string | null;
   currentStep?: SummarizationStep | null;
@@ -224,8 +222,13 @@ export function SummaryDisplay({
     isLongSummary && !showFullSummary
       ? summary.slice(0, 600) + "..."
       : summary;
-  const normalizedDimensionEntries = worthItDimensions
+  const isSignalFormat =
+    worthItDimensions != null && "kind" in worthItDimensions && worthItDimensions.kind === "signals";
+  const isLegacyDimensionFormat =
+    worthItDimensions != null && !isSignalFormat && "uniqueness" in worthItDimensions;
+  const normalizedDimensionEntries = isLegacyDimensionFormat && worthItDimensions
     ? Object.entries(worthItDimensions).reduce<[string, number][]>((acc, [key, raw]) => {
+        if (key === "kind") return acc;
         const num = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
         if (!Number.isFinite(num)) return acc;
         acc.push([key, Math.min(10, Math.max(0, num))]);
@@ -276,6 +279,28 @@ export function SummaryDisplay({
                 <span>10</span>
               </div>
             </div>
+            {isSignalFormat && worthItDimensions.kind === "signals" && (
+              <div className="mt-4 space-y-2 border-t pt-4">
+                <p className="text-sm font-medium text-foreground">Quality Signals</p>
+                {WORTH_IT_SIGNAL_KEYS.map((key) => (
+                  <div key={key} className="flex items-center gap-2 text-sm">
+                    {worthItDimensions.signals[key] ? (
+                      <CheckCircle className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-muted-foreground/40" />
+                    )}
+                    <span className={worthItDimensions.signals[key] ? "text-foreground" : "text-muted-foreground"}>
+                      {SIGNAL_LABELS[key]}
+                    </span>
+                  </div>
+                ))}
+                {worthItDimensions.adjustment !== 0 && (
+                  <p className="mt-2 text-xs text-muted-foreground italic">
+                    Adjustment: {worthItDimensions.adjustment > 0 ? "+1" : "-1"} — {worthItDimensions.adjustmentReason}
+                  </p>
+                )}
+              </div>
+            )}
             {normalizedDimensionEntries.length > 0 && (
               <div className="mt-4 space-y-3 border-t pt-4">
                 <p className="text-sm font-medium text-foreground">Score Breakdown</p>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,7 @@ import {
   bigint,
 } from "drizzle-orm/pg-core";
 import { relations, sql } from "drizzle-orm";
+import type { WorthItSignals } from "@/lib/openrouter";
 
 // Rate limits table (managed by rate-limiter-flexible, see ADR-001).
 // Defined here so drizzle-kit push doesn't try to drop it.
@@ -88,11 +89,10 @@ export const episodes = pgTable(
     keyTakeaways: json("key_takeaways").$type<string[]>(),
     worthItScore: decimal("worth_it_score", { precision: 4, scale: 2 }), // 0.00 - 10.00
     worthItReason: text("worth_it_reason"),
-    worthItDimensions: json("worth_it_dimensions").$type<{
-      uniqueness: number;
-      actionability: number;
-      timeValue: number;
-    }>(),
+    worthItDimensions: json("worth_it_dimensions").$type<
+      | { kind: "signals"; signals: WorthItSignals; adjustment: -1 | 0 | 1; adjustmentReason: string }
+      | { uniqueness: number; actionability: number; timeValue: number }
+    >(),
     processedAt: timestamp("processed_at"),
     summaryRunId: text("summary_run_id"),
     transcriptRunId: text("transcript_run_id"),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -91,7 +91,7 @@ export const episodes = pgTable(
     worthItReason: text("worth_it_reason"),
     worthItDimensions: json("worth_it_dimensions").$type<
       | { kind: "signals"; signals: WorthItSignals; adjustment: -1 | 0 | 1; adjustmentReason: string }
-      | { uniqueness: number; actionability: number; timeValue: number }
+      | { kind: "dimensions"; uniqueness: number; actionability: number; timeValue: number }
     >(),
     processedAt: timestamp("processed_at"),
     summaryRunId: text("summary_run_id"),

--- a/src/lib/__tests__/prompts.test.ts
+++ b/src/lib/__tests__/prompts.test.ts
@@ -14,12 +14,12 @@ describe("SYSTEM_PROMPT", () => {
   it("contains key instructions", () => {
     expect(SYSTEM_PROMPT).toContain("critical");
     expect(SYSTEM_PROMPT).toContain("JSON format");
-    expect(SYSTEM_PROMPT).toContain("worth it");
+    expect(SYSTEM_PROMPT).toContain("signal");
   });
 
-  it("contains anti-inflation anchoring", () => {
-    expect(SYSTEM_PROMPT).toContain("5");
-    expect(SYSTEM_PROMPT).toContain("score inflation");
+  it("mentions signal-based evaluation", () => {
+    expect(SYSTEM_PROMPT).toContain("signal");
+    expect(SYSTEM_PROMPT).toContain("inflation");
   });
 });
 
@@ -71,10 +71,10 @@ describe("getSummarizationPrompt", () => {
     );
     expect(prompt).toContain('"summary"');
     expect(prompt).toContain('"keyTakeaways"');
-    expect(prompt).toContain('"worthItScore"');
+    expect(prompt).toContain('"worthItReason"');
   });
 
-  it("includes worthItDimensions in the prompt", () => {
+  it("includes worthItSignals in the prompt", () => {
     const prompt = getSummarizationPrompt(
       "Podcast",
       "Episode",
@@ -82,10 +82,10 @@ describe("getSummarizationPrompt", () => {
       3600,
       "Transcript content here"
     );
-    expect(prompt).toContain('"worthItDimensions"');
-    expect(prompt).toContain('"uniqueness"');
-    expect(prompt).toContain('"actionability"');
-    expect(prompt).toContain('"timeValue"');
+    expect(prompt).toContain('"worthItSignals"');
+    expect(prompt).toContain('"hasActionableInsights"');
+    expect(prompt).toContain('"staysFocused"');
+    expect(prompt).toContain('"worthItAdjustment"');
   });
 
   it("includes structured summary sections", () => {
@@ -103,7 +103,7 @@ describe("getSummarizationPrompt", () => {
     expect(prompt).toContain("Bottom Line");
   });
 
-  it("includes anti-inflation scoring guide", () => {
+  it("includes signal-based scoring instructions", () => {
     const prompt = getSummarizationPrompt(
       "Podcast",
       "Episode",
@@ -111,8 +111,8 @@ describe("getSummarizationPrompt", () => {
       3600,
       "Transcript content here"
     );
-    expect(prompt).toContain("5: Average");
-    expect(prompt).toContain("Justify every point above 5");
+    expect(prompt).toContain("Boolean Quality Signals");
+    expect(prompt).toContain("Adjustment (-1, 0, or +1)");
   });
 });
 

--- a/src/lib/__tests__/score-utils.test.ts
+++ b/src/lib/__tests__/score-utils.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect } from "vitest";
-import { getScoreColor, getScoreLabel } from "@/lib/score-utils";
+import {
+  getScoreColor,
+  getScoreLabel,
+  clampAdjustment,
+  coerceSignals,
+  computeSignalScore,
+} from "@/lib/score-utils";
+import { WORTH_IT_SIGNAL_KEYS } from "@/lib/openrouter";
+import type { WorthItSignals } from "@/lib/openrouter";
+
+/** Helper: create a WorthItSignals object with all signals set to `value`. */
+function allSignals(value: boolean): WorthItSignals {
+  return coerceSignals(
+    Object.fromEntries(WORTH_IT_SIGNAL_KEYS.map((k) => [k, value]))
+  );
+}
+
+/** Helper: create signals with the first `n` keys true, rest false. */
+function nTrueSignals(n: number): WorthItSignals {
+  return coerceSignals(
+    Object.fromEntries(WORTH_IT_SIGNAL_KEYS.map((k, i) => [k, i < n]))
+  );
+}
 
 describe("getScoreColor", () => {
   it("returns exceptional colors for scores >= 8", () => {
@@ -57,5 +79,151 @@ describe("getScoreLabel", () => {
   it("returns 'Skip' for scores < 2", () => {
     expect(getScoreLabel(0)).toBe("Skip");
     expect(getScoreLabel(1.9)).toBe("Skip");
+  });
+});
+
+describe("clampAdjustment", () => {
+  it("passes through -1, 0, and 1 unchanged", () => {
+    expect(clampAdjustment(-1)).toBe(-1);
+    expect(clampAdjustment(0)).toBe(0);
+    expect(clampAdjustment(1)).toBe(1);
+  });
+
+  it("clamps values above 1 to 1", () => {
+    expect(clampAdjustment(5)).toBe(1);
+    expect(clampAdjustment(100)).toBe(1);
+  });
+
+  it("clamps values below -1 to -1", () => {
+    expect(clampAdjustment(-3)).toBe(-1);
+    expect(clampAdjustment(-100)).toBe(-1);
+  });
+
+  it("rounds fractional values to nearest integer then clamps", () => {
+    expect(clampAdjustment(0.7)).toBe(1);
+    expect(clampAdjustment(0.4)).toBe(0);
+    expect(clampAdjustment(-0.6)).toBe(-1);
+    // Math.round(-0.4) === -0 in JS; both -0 and +0 are valid as adjustment 0
+    expect(clampAdjustment(-0.4)).toBe(-0);
+  });
+
+  it("returns 0 for undefined", () => {
+    expect(clampAdjustment(undefined)).toBe(0);
+  });
+
+  it("returns 0 for string values", () => {
+    expect(clampAdjustment("foo")).toBe(0);
+    expect(clampAdjustment("1")).toBe(0);
+  });
+
+  it("returns 0 for NaN", () => {
+    expect(clampAdjustment(NaN)).toBe(0);
+  });
+
+  it("returns 0 for null", () => {
+    expect(clampAdjustment(null)).toBe(0);
+  });
+});
+
+describe("coerceSignals", () => {
+  it("returns identity when all values are booleans", () => {
+    const input = {
+      hasActionableInsights: true,
+      hasNearTermApplicability: false,
+      staysFocused: true,
+      goesBeyondSurface: false,
+      isWellStructured: true,
+      timeJustified: false,
+      hasConcreteExamples: true,
+      hasExpertPerspectives: false,
+    };
+    expect(coerceSignals(input)).toEqual(input);
+  });
+
+  it("coerces truthy non-boolean values to true", () => {
+    const result = coerceSignals({
+      hasActionableInsights: 1,
+      hasNearTermApplicability: "yes",
+      staysFocused: "true",
+      goesBeyondSurface: 42,
+      isWellStructured: true,
+      timeJustified: true,
+      hasConcreteExamples: true,
+      hasExpertPerspectives: true,
+    });
+    for (const key of WORTH_IT_SIGNAL_KEYS) {
+      expect(result[key]).toBe(true);
+    }
+  });
+
+  it("coerces falsy non-boolean values to false", () => {
+    const result = coerceSignals({
+      hasActionableInsights: 0,
+      hasNearTermApplicability: "",
+      staysFocused: null,
+      goesBeyondSurface: undefined,
+      isWellStructured: false,
+      timeJustified: false,
+      hasConcreteExamples: false,
+      hasExpertPerspectives: false,
+    });
+    for (const key of WORTH_IT_SIGNAL_KEYS) {
+      expect(result[key]).toBe(false);
+    }
+  });
+
+  it("defaults missing keys to false", () => {
+    const result = coerceSignals({});
+    for (const key of WORTH_IT_SIGNAL_KEYS) {
+      expect(result[key]).toBe(false);
+    }
+  });
+
+  it("ignores extra keys not in the signal list", () => {
+    const result = coerceSignals({
+      hasActionableInsights: true,
+      unknownKey: true,
+      anotherExtra: "value",
+    });
+    expect(result.hasActionableInsights).toBe(true);
+    expect(Object.hasOwn(result, "unknownKey")).toBe(false);
+    expect(Object.hasOwn(result, "anotherExtra")).toBe(false);
+  });
+});
+
+describe("computeSignalScore", () => {
+  it("returns 9 when all 8 signals are true with adjustment 0", () => {
+    expect(computeSignalScore(allSignals(true), 0)).toBe(9);
+  });
+
+  it("returns 1 when all signals are false with adjustment 0", () => {
+    expect(computeSignalScore(allSignals(false), 0)).toBe(1);
+  });
+
+  it("computes 1 + trueCount + adjustment for mixed signals", () => {
+    expect(computeSignalScore(nTrueSignals(5), 1)).toBe(7);
+    expect(computeSignalScore(nTrueSignals(3), 0)).toBe(4);
+    expect(computeSignalScore(nTrueSignals(6), -1)).toBe(6);
+  });
+
+  it("clamps to minimum of 1 (0 true signals + adjustment -1)", () => {
+    expect(computeSignalScore(allSignals(false), -1)).toBe(1);
+  });
+
+  it("clamps to maximum of 10 (8 true signals + adjustment +1)", () => {
+    expect(computeSignalScore(allSignals(true), 1)).toBe(10);
+  });
+
+  it("internally clamps out-of-range adjustments via clampAdjustment", () => {
+    // adjustment 5 should be clamped to 1
+    expect(computeSignalScore(nTrueSignals(4), 5)).toBe(6);
+    // adjustment -10 should be clamped to -1
+    expect(computeSignalScore(nTrueSignals(4), -10)).toBe(4);
+  });
+
+  it("produces correct scores for each signal count with adjustment 0", () => {
+    for (let n = 0; n <= 8; n++) {
+      expect(computeSignalScore(nTrueSignals(n), 0)).toBe(1 + n);
+    }
   });
 });

--- a/src/lib/__tests__/score-utils.test.ts
+++ b/src/lib/__tests__/score-utils.test.ts
@@ -140,19 +140,40 @@ describe("coerceSignals", () => {
     expect(coerceSignals(input)).toEqual(input);
   });
 
-  it("coerces truthy non-boolean values to true", () => {
+  it("coerces recognized non-boolean values correctly", () => {
     const result = coerceSignals({
-      hasActionableInsights: 1,
-      hasNearTermApplicability: "yes",
-      staysFocused: "true",
-      goesBeyondSurface: 42,
-      isWellStructured: true,
-      timeJustified: true,
-      hasConcreteExamples: true,
-      hasExpertPerspectives: true,
+      hasActionableInsights: 1,            // number 1 → true
+      hasNearTermApplicability: "true",    // string "true" → true
+      staysFocused: "TRUE",               // case-insensitive → true
+      goesBeyondSurface: 0,               // number 0 → false
+      isWellStructured: "false",           // string "false" → false
+      timeJustified: "yes",               // unrecognized string → false
+      hasConcreteExamples: 42,            // number ≠ 1 → false
+      hasExpertPerspectives: null,        // null → false
+    });
+    expect(result.hasActionableInsights).toBe(true);
+    expect(result.hasNearTermApplicability).toBe(true);
+    expect(result.staysFocused).toBe(true);
+    expect(result.goesBeyondSurface).toBe(false);
+    expect(result.isWellStructured).toBe(false);
+    expect(result.timeJustified).toBe(false);
+    expect(result.hasConcreteExamples).toBe(false);
+    expect(result.hasExpertPerspectives).toBe(false);
+  });
+
+  it("coerces string 'false' to false (not truthy like Boolean())", () => {
+    const result = coerceSignals({
+      hasActionableInsights: "false",
+      hasNearTermApplicability: "FALSE",
+      staysFocused: " False ",
+      goesBeyondSurface: false,
+      isWellStructured: false,
+      timeJustified: false,
+      hasConcreteExamples: false,
+      hasExpertPerspectives: false,
     });
     for (const key of WORTH_IT_SIGNAL_KEYS) {
-      expect(result[key]).toBe(true);
+      expect(result[key]).toBe(false);
     }
   });
 

--- a/src/lib/offline-cache.ts
+++ b/src/lib/offline-cache.ts
@@ -1,5 +1,6 @@
 import { get, set, del, keys, entries, delMany, createStore } from "idb-keyval";
 import type { SavedItemDTO } from "@/db/library-columns";
+import type { WorthItDimensionsData } from "@/lib/openrouter";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -62,11 +63,7 @@ export interface SummaryData {
   keyTakeaways: string[];
   worthItScore: number | null;
   worthItReason?: string;
-  worthItDimensions?: {
-    uniqueness: number;
-    actionability: number;
-    timeValue: number;
-  } | null;
+  worthItDimensions?: WorthItDimensionsData | null;
   cached: boolean;
 }
 

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -5,16 +5,53 @@ export { generateCompletion } from "@/lib/ai";
 /** @deprecated Use `AiMessage` from `@/lib/ai` instead. */
 export type OpenRouterMessage = AiMessage;
 
+/** The 8 boolean quality signals the LLM evaluates. */
+export interface WorthItSignals {
+  hasActionableInsights: boolean;
+  hasNearTermApplicability: boolean;
+  staysFocused: boolean;
+  goesBeyondSurface: boolean;
+  isWellStructured: boolean;
+  timeJustified: boolean;
+  hasConcreteExamples: boolean;
+  hasExpertPerspectives: boolean;
+}
+
+/** All valid signal keys, for iteration. */
+export const WORTH_IT_SIGNAL_KEYS: readonly (keyof WorthItSignals)[] = [
+  "hasActionableInsights",
+  "hasNearTermApplicability",
+  "staysFocused",
+  "goesBeyondSurface",
+  "isWellStructured",
+  "timeJustified",
+  "hasConcreteExamples",
+  "hasExpertPerspectives",
+] as const;
+
+/** Human-readable labels for each signal, used in UI and prompt. */
+export const SIGNAL_LABELS: Record<keyof WorthItSignals, string> = {
+  hasActionableInsights: "Contains 3+ actionable insights",
+  hasNearTermApplicability: "Listener could apply something within a week",
+  staysFocused: "Episode stays focused, low filler-to-content ratio",
+  goesBeyondSurface: "Goes beyond surface-level discussion",
+  isWellStructured: "Well-structured and easy to follow",
+  timeJustified: "Time investment justified by content density",
+  hasConcreteExamples: "Includes concrete examples, data, or evidence",
+  hasExpertPerspectives: "Features expert/practitioner perspectives",
+};
+
+/** Discriminated union for backward compatibility with legacy dimension format. */
+export type WorthItDimensionsData =
+  | { kind: "signals"; signals: WorthItSignals; adjustment: -1 | 0 | 1; adjustmentReason: string }
+  | { kind: "dimensions"; uniqueness: number; actionability: number; timeValue: number };
+
 export interface SummaryResult {
   summary: string;
   keyTakeaways: string[];
   worthItScore: number;
   worthItReason: string;
-  worthItDimensions?: {
-    uniqueness: number;
-    actionability: number;
-    timeValue: number;
-  };
+  worthItDimensions?: WorthItDimensionsData;
   topics?: Array<{ name: string; relevance: number }>;
 }
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -3,11 +3,11 @@
 export const SYSTEM_PROMPT = `You are a critical podcast evaluator for busy professionals. Your job is to:
 1. Create structured, actionable summaries that capture the essence of podcast episodes
 2. Extract key takeaways that listeners can immediately apply
-3. Provide a calibrated "worth it" score using dimensional scoring
+3. Evaluate content quality by answering 8 yes/no signal questions, then provide a small adjustment
 
-You are a tough but fair critic. A score of 5 is the average baseline — most episodes are average. You must justify every point above 5 with specific evidence from the content. Scores of 8+ are reserved for truly exceptional content with unique perspectives and highly actionable insights. A 10 is virtually unheard of.
+You are a tough but fair critic. Answer each signal question honestly — only mark true when the episode genuinely meets the criterion. The final score is computed server-side from your signals.
 
-Always respond in valid JSON format. Be objective and resist score inflation.`;
+Always respond in valid JSON format. Be objective and resist inflation.`;
 
 // Note: custom prompts (via aiConfig.summarizationPrompt) bypass this function entirely and
 // do not receive the topics extraction instruction. This is intentional — see ADR-031.
@@ -39,12 +39,18 @@ Please provide your analysis in the following JSON format:
     "Second actionable insight",
     "Third actionable insight"
   ],
-  "worthItDimensions": {
-    "uniqueness": 5,
-    "actionability": 5,
-    "timeValue": 5
+  "worthItSignals": {
+    "hasActionableInsights": true,
+    "hasNearTermApplicability": false,
+    "staysFocused": true,
+    "goesBeyondSurface": true,
+    "isWellStructured": true,
+    "timeJustified": false,
+    "hasConcreteExamples": true,
+    "hasExpertPerspectives": false
   },
-  "worthItScore": 5.0,
+  "worthItAdjustment": 0,
+  "worthItAdjustmentReason": "No adjustment needed — signals accurately reflect quality.",
   "worthItReason": "The Bottom Line section text — 1-2 sentence verdict.",
   "topics": [
     { "name": "Topic Label", "relevance": 0.9 },
@@ -52,27 +58,31 @@ Please provide your analysis in the following JSON format:
   ]
 }
 
-## Scoring Dimensions (each 1-10):
-- **uniqueness**: How original is the content? Does it offer perspectives not found elsewhere?
-- **actionability**: How practical are the insights? Can the listener do something concrete afterward?
-- **timeValue**: Is the value delivered worth the ${durationMinutes != null ? `${durationMinutes}-minute` : "unknown"} time investment?
+## Boolean Quality Signals (answer true or false for each):
+- **hasActionableInsights**: Does the episode contain 3 or more actionable insights?
+- **hasNearTermApplicability**: Could a listener apply something from this episode within a week?
+- **staysFocused**: Does the episode stay focused with a low filler-to-content ratio?
+- **goesBeyondSurface**: Does it go beyond surface-level discussion?
+- **isWellStructured**: Is it well-structured and easy to follow?
+- **timeJustified**: Is the ${durationMinutes != null ? `${durationMinutes}-minute` : "unknown"} time investment justified by the content density?
+- **hasConcreteExamples**: Does it include concrete examples, data, or evidence?
+- **hasExpertPerspectives**: Does it feature expert or practitioner perspectives?
 
-## Anti-Inflation Scoring Guide:
-- 1-2: Poor — misleading or no useful content
-- 3-4: Below average — limited value, mostly recycled ideas
-- **5: Average** — decent content, nothing special (this is the baseline)
-- 6-7: Above average — solid insights, worth the time
-- 8-9: Exceptional — unique perspectives, highly actionable
-- 10: Masterpiece — field-defining, must-listen
+## Adjustment (-1, 0, or +1):
+After answering the signals, you may apply a small adjustment:
+- **-1**: The signals slightly overstate quality (e.g., technically structured but painfully boring)
+- **0**: The signals accurately capture quality (use this in most cases)
+- **+1**: The signals slightly understate quality (e.g., a masterclass that transcends the checklist)
 
-The **worthItScore** is the average of the three dimensions, rounded to 1 decimal place.
+You MUST provide a brief reason for your adjustment in "worthItAdjustmentReason".
+The final score is computed server-side: 1 + (count of true signals) + adjustment.
 
 Important:
-- 5 is the average baseline. Justify every point above 5 with specific evidence.
+- Answer each signal question honestly — only mark true when the episode genuinely meets the criterion
 - Extract 3-5 key takeaways, prioritizing actionable insights
 - The summary must include all 5 sections (TL;DR, What You'll Learn, Notable Quotes / Key Moments, Action Items, Bottom Line) using ## headers
 - For Notable Quotes / Key Moments: include 2-3 standout moments; add approximate timestamps (~XX:XX) when working from a transcript; write "No notable moments available" if nothing stands out
-- Consider the time investment (${durationMinutes != null ? `${durationMinutes} min` : "unknown duration"}) when scoring timeValue
+- Consider the time investment (${durationMinutes != null ? `${durationMinutes} min` : "unknown duration"}) when evaluating timeJustified
 - Focus on value for busy professionals who need to be selective with their time
 - Extract 1-5 topic tags that best describe the episode's subject matter.
 - Each topic name must be 2-5 words, professional, and in Title Case (e.g., "AI & Machine Learning").

--- a/src/lib/score-utils.ts
+++ b/src/lib/score-utils.ts
@@ -30,17 +30,29 @@ export function clampAdjustment(raw: unknown): -1 | 0 | 1 {
   return Math.round(raw) as -1 | 0 | 1;
 }
 
+/** Safely coerce an unknown value to boolean. Handles string "true"/"false" and numeric 0/1. */
+export function toSignalBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+  }
+  if (typeof value === "number") return value === 1;
+  return false;
+}
+
 /** Coerce a raw object into a valid WorthItSignals. Missing keys → false. */
 export function coerceSignals(raw: Record<string, unknown>): WorthItSignals {
   return {
-    hasActionableInsights: Boolean(raw.hasActionableInsights),
-    hasNearTermApplicability: Boolean(raw.hasNearTermApplicability),
-    staysFocused: Boolean(raw.staysFocused),
-    goesBeyondSurface: Boolean(raw.goesBeyondSurface),
-    isWellStructured: Boolean(raw.isWellStructured),
-    timeJustified: Boolean(raw.timeJustified),
-    hasConcreteExamples: Boolean(raw.hasConcreteExamples),
-    hasExpertPerspectives: Boolean(raw.hasExpertPerspectives),
+    hasActionableInsights: toSignalBoolean(raw.hasActionableInsights),
+    hasNearTermApplicability: toSignalBoolean(raw.hasNearTermApplicability),
+    staysFocused: toSignalBoolean(raw.staysFocused),
+    goesBeyondSurface: toSignalBoolean(raw.goesBeyondSurface),
+    isWellStructured: toSignalBoolean(raw.isWellStructured),
+    timeJustified: toSignalBoolean(raw.timeJustified),
+    hasConcreteExamples: toSignalBoolean(raw.hasConcreteExamples),
+    hasExpertPerspectives: toSignalBoolean(raw.hasExpertPerspectives),
   };
 }
 

--- a/src/lib/score-utils.ts
+++ b/src/lib/score-utils.ts
@@ -3,6 +3,9 @@
  * Used by both SummaryDisplay (full card) and WorthItBadge (compact).
  */
 
+import type { WorthItSignals } from "@/lib/openrouter";
+import { WORTH_IT_SIGNAL_KEYS } from "@/lib/openrouter";
+
 export function getScoreColor(score: number): string {
   if (score >= 8) return "bg-score-exceptional text-score-exceptional-foreground";
   if (score >= 6) return "bg-score-above text-score-above-foreground";
@@ -17,4 +20,34 @@ export function getScoreLabel(score: number): string {
   if (score >= 4) return "Average";
   if (score >= 2) return "Below Average";
   return "Skip";
+}
+
+/** Clamp a raw adjustment value to -1 | 0 | 1. Non-numbers and NaN → 0. */
+export function clampAdjustment(raw: unknown): -1 | 0 | 1 {
+  if (typeof raw !== "number" || Number.isNaN(raw)) return 0;
+  if (raw < -1) return -1;
+  if (raw > 1) return 1;
+  return Math.round(raw) as -1 | 0 | 1;
+}
+
+/** Coerce a raw object into a valid WorthItSignals. Missing keys → false. */
+export function coerceSignals(raw: Record<string, unknown>): WorthItSignals {
+  return {
+    hasActionableInsights: Boolean(raw.hasActionableInsights),
+    hasNearTermApplicability: Boolean(raw.hasNearTermApplicability),
+    staysFocused: Boolean(raw.staysFocused),
+    goesBeyondSurface: Boolean(raw.goesBeyondSurface),
+    isWellStructured: Boolean(raw.isWellStructured),
+    timeJustified: Boolean(raw.timeJustified),
+    hasConcreteExamples: Boolean(raw.hasConcreteExamples),
+    hasExpertPerspectives: Boolean(raw.hasExpertPerspectives),
+  };
+}
+
+/** Compute the worth-it score from boolean signals + adjustment. Range: [1, 10]. */
+export function computeSignalScore(signals: WorthItSignals, adjustment: number): number {
+  const trueCount = WORTH_IT_SIGNAL_KEYS.filter((k) => signals[k]).length;
+  const base = 1 + trueCount;
+  const clampedAdj = clampAdjustment(adjustment);
+  return Math.min(10, Math.max(1, base + clampedAdj));
 }

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -9,9 +9,13 @@ vi.mock("@/lib/ai", () => ({
   generateCompletion: (...args: unknown[]) => mockGenerateCompletion(...args),
 }));
 
-vi.mock("@/lib/openrouter", () => ({
-  parseJsonResponse: (...args: unknown[]) => mockParseJsonResponse(...args),
-}));
+vi.mock("@/lib/openrouter", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openrouter")>();
+  return {
+    ...actual,
+    parseJsonResponse: (...args: unknown[]) => mockParseJsonResponse(...args),
+  };
+});
 
 vi.mock("@/lib/prompts", () => ({
   SYSTEM_PROMPT: "system prompt",
@@ -41,13 +45,34 @@ const mockPodcast = {
   description: "",
 } as PodcastIndexPodcast;
 
-const mockSummaryResult = {
+const mockSignalResult = {
+  summary: "Test summary",
+  keyTakeaways: ["Takeaway 1"],
+  worthItReason: "Good episode",
+  worthItSignals: {
+    hasActionableInsights: true,
+    hasNearTermApplicability: true,
+    staysFocused: true,
+    goesBeyondSurface: true,
+    isWellStructured: true,
+    timeJustified: false,
+    hasConcreteExamples: false,
+    hasExpertPerspectives: false,
+  },
+  worthItAdjustment: 0,
+  worthItAdjustmentReason: "Signals capture quality accurately.",
+};
+
+const mockLegacyDimensionResult = {
   summary: "Test summary",
   keyTakeaways: ["Takeaway 1"],
   worthItScore: 7,
   worthItReason: "Good episode",
   worthItDimensions: { uniqueness: 7, actionability: 7, timeValue: 7 },
 };
+
+// Default to signal-based result (matches current default prompt)
+const mockSummaryResult = mockSignalResult;
 
 describe("generateEpisodeSummary", () => {
   beforeEach(() => {
@@ -267,5 +292,149 @@ describe("generateEpisodeSummary", () => {
       expect.any(Number),
       expect.any(String)
     );
+  });
+
+  describe("signal score computation", () => {
+    it("computes score as 1 + trueCount + adjustment from signals", async () => {
+      mockParseJsonResponse.mockReturnValue({ ...mockSignalResult });
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      // 5 true signals → base 6, adj 0 → score 6
+      expect(result.worthItScore).toBe(6);
+    });
+
+    it("stores worthItDimensions with kind 'signals'", async () => {
+      mockParseJsonResponse.mockReturnValue({ ...mockSignalResult });
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.worthItDimensions).toEqual(
+        expect.objectContaining({ kind: "signals" })
+      );
+    });
+
+    it("includes signal summary in worthItReason", async () => {
+      mockParseJsonResponse.mockReturnValue({ ...mockSignalResult });
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.worthItReason).toContain("5/8 signals");
+    });
+
+    it("coerces non-boolean signal values to boolean", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSignalResult,
+        worthItSignals: {
+          hasActionableInsights: 1,
+          hasNearTermApplicability: "yes",
+          staysFocused: 0,
+          goesBeyondSurface: "",
+          isWellStructured: true,
+          timeJustified: false,
+          hasConcreteExamples: null,
+          hasExpertPerspectives: undefined,
+        },
+      });
+
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      // Truthy: 1, "yes", true → 3 true signals. base=4, adj=0 → score 4
+      expect(result.worthItScore).toBe(4);
+    });
+
+    it("logs console.warn for each non-boolean signal value", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSignalResult,
+        worthItSignals: {
+          hasActionableInsights: 1,
+          hasNearTermApplicability: true,
+          staysFocused: true,
+          goesBeyondSurface: true,
+          isWellStructured: true,
+          timeJustified: true,
+          hasConcreteExamples: true,
+          hasExpertPerspectives: true,
+        },
+      });
+
+      await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      const signalWarns = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("non-boolean signal coerced")
+      );
+      expect(signalWarns).toHaveLength(1);
+      expect(signalWarns[0][0]).toContain("hasActionableInsights");
+      warnSpy.mockRestore();
+    });
+
+    it("does not log console.warn when all signals are booleans", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockParseJsonResponse.mockReturnValue({ ...mockSignalResult });
+
+      await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      const signalWarns = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("non-boolean signal coerced")
+      );
+      expect(signalWarns).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+
+    it("clamps adjustment outside [-1,1]", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSignalResult,
+        worthItAdjustment: 5,
+      });
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      // 5 true signals → base 6, adj clamped to 1 → score 7
+      expect(result.worthItScore).toBe(7);
+    });
+
+    it("defaults missing adjustment to 0", async () => {
+      const { worthItAdjustment: _, ...withoutAdj } = mockSignalResult;
+      mockParseJsonResponse.mockReturnValue(withoutAdj);
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      // 5 true → base 6, adj 0 → score 6
+      expect(result.worthItScore).toBe(6);
+    });
+
+    it("defaults missing adjustmentReason to empty string", async () => {
+      const { worthItAdjustmentReason: _, ...withoutReason } = mockSignalResult;
+      mockParseJsonResponse.mockReturnValue(withoutReason);
+      const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      expect(result.worthItDimensions).toEqual(
+        expect.objectContaining({ adjustmentReason: "" })
+      );
+    });
+  });
+
+  describe("legacy dimension scoring (custom prompts)", () => {
+    it("averages dimensions when LLM returns old format", async () => {
+      mockParseJsonResponse.mockReturnValue({ ...mockLegacyDimensionResult });
+      const result = await generateEpisodeSummary(
+        mockPodcast, mockEpisode, "transcript text", "custom prompt"
+      );
+
+      expect(result.worthItScore).toBe(7);
+      expect(result.worthItDimensions).toEqual(
+        expect.objectContaining({ kind: "dimensions" })
+      );
+    });
+
+    it("uses raw LLM score when neither signals nor dimensions present", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        summary: "Test",
+        keyTakeaways: ["one"],
+        worthItScore: 8.5,
+        worthItReason: "custom reason",
+      });
+      const result = await generateEpisodeSummary(
+        mockPodcast, mockEpisode, "transcript text", "custom prompt"
+      );
+
+      expect(result.worthItScore).toBe(8.5);
+    });
   });
 });

--- a/src/trigger/helpers/__tests__/ai-summary.test.ts
+++ b/src/trigger/helpers/__tests__/ai-summary.test.ts
@@ -319,24 +319,24 @@ describe("generateEpisodeSummary", () => {
       expect(result.worthItReason).toContain("5/8 signals");
     });
 
-    it("coerces non-boolean signal values to boolean", async () => {
+    it("coerces non-boolean signal values via toSignalBoolean", async () => {
       mockParseJsonResponse.mockReturnValue({
         ...mockSignalResult,
         worthItSignals: {
-          hasActionableInsights: 1,
-          hasNearTermApplicability: "yes",
-          staysFocused: 0,
-          goesBeyondSurface: "",
-          isWellStructured: true,
-          timeJustified: false,
-          hasConcreteExamples: null,
-          hasExpertPerspectives: undefined,
+          hasActionableInsights: 1,          // number 1 → true
+          hasNearTermApplicability: "true",  // string "true" → true
+          staysFocused: 0,                   // number 0 → false
+          goesBeyondSurface: "",             // unrecognized → false
+          isWellStructured: true,            // boolean → true
+          timeJustified: false,              // boolean → false
+          hasConcreteExamples: null,         // null → false
+          hasExpertPerspectives: undefined,  // undefined → false
         },
       });
 
       const result = await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
 
-      // Truthy: 1, "yes", true → 3 true signals. base=4, adj=0 → score 4
+      // True: 1, "true", true → 3 true signals. base=4, adj=0 → score 4
       expect(result.worthItScore).toBe(4);
     });
 
@@ -363,6 +363,25 @@ describe("generateEpisodeSummary", () => {
       );
       expect(signalWarns).toHaveLength(1);
       expect(signalWarns[0][0]).toContain("hasActionableInsights");
+      warnSpy.mockRestore();
+    });
+
+    it("does not log console.warn for missing signal keys", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockParseJsonResponse.mockReturnValue({
+        ...mockSignalResult,
+        worthItSignals: {
+          hasActionableInsights: true,
+          // All other keys missing — should NOT warn
+        },
+      });
+
+      await generateEpisodeSummary(mockPodcast, mockEpisode, "transcript text");
+
+      const signalWarns = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("non-boolean signal coerced")
+      );
+      expect(signalWarns).toHaveLength(0);
       warnSpy.mockRestore();
     });
 
@@ -435,6 +454,19 @@ describe("generateEpisodeSummary", () => {
       );
 
       expect(result.worthItScore).toBe(8.5);
+    });
+
+    it("defaults worthItScore to 5 when neither format nor raw score present", async () => {
+      mockParseJsonResponse.mockReturnValue({
+        summary: "Test",
+        keyTakeaways: ["one"],
+        worthItReason: "custom reason",
+      });
+      const result = await generateEpisodeSummary(
+        mockPodcast, mockEpisode, "transcript text", "custom prompt"
+      );
+
+      expect(result.worthItScore).toBe(5);
     });
   });
 });

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -135,9 +135,23 @@ describe("persistEpisodeSummary", () => {
   const baseSummary = {
     summary: "Summary text",
     keyTakeaways: ["point 1"],
-    worthItScore: 7.5,
-    worthItReason: "Good content",
-    worthItDimensions: { uniqueness: 8, actionability: 7, timeValue: 7 },
+    worthItScore: 7,
+    worthItReason: "5/8 signals: actionable insights, focused, beyond surface, well-structured, concrete examples. Adjustment: 0 (signals capture quality accurately).",
+    worthItDimensions: {
+      kind: "signals" as const,
+      signals: {
+        hasActionableInsights: true,
+        hasNearTermApplicability: false,
+        staysFocused: true,
+        goesBeyondSurface: true,
+        isWellStructured: true,
+        timeJustified: true,
+        hasConcreteExamples: true,
+        hasExpertPerspectives: false,
+      },
+      adjustment: 0 as const,
+      adjustmentReason: "Signals capture quality accurately.",
+    },
   };
 
   const baseEpisode = {

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -136,7 +136,7 @@ describe("persistEpisodeSummary", () => {
     summary: "Summary text",
     keyTakeaways: ["point 1"],
     worthItScore: 7,
-    worthItReason: "5/8 signals: actionable insights, focused, beyond surface, well-structured, concrete examples. Adjustment: 0 (signals capture quality accurately).",
+    worthItReason: "6/8 signals: actionable insights, focused, beyond surface, well-structured, time justified, concrete examples. Adjustment: 0 (signals capture quality accurately).",
     worthItDimensions: {
       kind: "signals" as const,
       signals: {

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -3,7 +3,7 @@ import { parseJsonResponse, type SummaryResult } from "@/lib/openrouter";
 import { WORTH_IT_SIGNAL_KEYS, SIGNAL_LABELS } from "@/lib/openrouter";
 import { SYSTEM_PROMPT, getSummarizationPrompt } from "@/lib/prompts";
 import { interpolatePrompt } from "@/lib/admin/prompt-utils";
-import { computeSignalScore, coerceSignals, clampAdjustment } from "@/lib/score-utils";
+import { computeSignalScore, coerceSignals, clampAdjustment, toSignalBoolean } from "@/lib/score-utils";
 import type { PodcastIndexPodcast, PodcastIndexEpisode } from "@/lib/podcastindex";
 
 // File-private helper — not exported. If a second consumer appears, extract it then.
@@ -49,11 +49,11 @@ export async function generateEpisodeSummary(
     const rawSignals = raw.worthItSignals;
     if (rawSignals && typeof rawSignals === "object") {
       const signalObj = rawSignals as Record<string, unknown>;
-      // Warn on non-boolean signal values before coercion
+      // Warn on non-boolean signal values before coercion (skip missing keys to reduce noise)
       for (const key of WORTH_IT_SIGNAL_KEYS) {
-        if (typeof signalObj[key] !== "boolean") {
+        if (key in signalObj && typeof signalObj[key] !== "boolean") {
           console.warn(
-            `[ai-summary] non-boolean signal coerced: ${key}=${signalObj[key]} → ${Boolean(signalObj[key])}`
+            `[ai-summary] non-boolean signal coerced: ${key}=${signalObj[key]} → ${toSignalBoolean(signalObj[key])}`
           );
         }
       }
@@ -81,8 +81,9 @@ export async function generateEpisodeSummary(
         adjustment === 0
           ? `Adjustment: 0 (${adjustmentReason || "signals capture quality accurately"}).`
           : `Adjustment: ${adjustment > 0 ? "+1" : "-1"} (${adjustmentReason}).`;
-      result.worthItReason =
-        `${firedCount}/8 signals: ${firedLabels.join(", ") || "none"}. ${adjText}`;
+      const signalSummary = `${firedCount}/8 signals: ${firedLabels.join(", ") || "none"}. ${adjText}`;
+      const llmReason = typeof raw.worthItReason === "string" ? raw.worthItReason.trim() : "";
+      result.worthItReason = llmReason ? `${llmReason} (${signalSummary})` : signalSummary;
     }
     // Legacy dimension-averaging (backward compat for custom prompts)
     else if (raw.worthItDimensions && typeof raw.worthItDimensions === "object") {
@@ -108,7 +109,10 @@ export async function generateEpisodeSummary(
         };
       }
     }
-    // Neither format (custom prompt returning raw score) — keep as-is
+    // Neither format (custom prompt returning raw score) — keep as-is, default if missing
+    if (typeof result.worthItScore !== "number") {
+      result.worthItScore = 5;
+    }
 
     // Validate and normalize topics
     if (Array.isArray(result.topics)) {

--- a/src/trigger/helpers/ai-summary.ts
+++ b/src/trigger/helpers/ai-summary.ts
@@ -1,7 +1,9 @@
 import { generateCompletion } from "@/lib/ai";
 import { parseJsonResponse, type SummaryResult } from "@/lib/openrouter";
+import { WORTH_IT_SIGNAL_KEYS, SIGNAL_LABELS } from "@/lib/openrouter";
 import { SYSTEM_PROMPT, getSummarizationPrompt } from "@/lib/prompts";
 import { interpolatePrompt } from "@/lib/admin/prompt-utils";
+import { computeSignalScore, coerceSignals, clampAdjustment } from "@/lib/score-utils";
 import type { PodcastIndexPodcast, PodcastIndexEpisode } from "@/lib/podcastindex";
 
 // File-private helper — not exported. If a second consumer appears, extract it then.
@@ -40,15 +42,57 @@ export async function generateEpisodeSummary(
   ]);
 
   try {
-    const result = parseJsonResponse<SummaryResult>(completion);
-    // Recalculate worthItScore server-side from dimensions to ensure arithmetic accuracy
-    if (result.worthItDimensions) {
-      const { uniqueness, actionability, timeValue } = result.worthItDimensions;
+    const raw = parseJsonResponse<Record<string, unknown>>(completion);
+    const result = raw as unknown as SummaryResult;
+
+    // Signal-based scoring (new format)
+    const rawSignals = raw.worthItSignals;
+    if (rawSignals && typeof rawSignals === "object") {
+      const signalObj = rawSignals as Record<string, unknown>;
+      // Warn on non-boolean signal values before coercion
+      for (const key of WORTH_IT_SIGNAL_KEYS) {
+        if (typeof signalObj[key] !== "boolean") {
+          console.warn(
+            `[ai-summary] non-boolean signal coerced: ${key}=${signalObj[key]} → ${Boolean(signalObj[key])}`
+          );
+        }
+      }
+      const signals = coerceSignals(signalObj);
+      const adjustment = clampAdjustment(raw.worthItAdjustment);
+      const adjustmentReason =
+        typeof raw.worthItAdjustmentReason === "string"
+          ? raw.worthItAdjustmentReason
+          : "";
+
+      result.worthItScore = computeSignalScore(signals, adjustment);
+      result.worthItDimensions = {
+        kind: "signals",
+        signals,
+        adjustment,
+        adjustmentReason,
+      };
+
+      // Build a compact worthItReason from fired signals
+      const firedLabels = WORTH_IT_SIGNAL_KEYS
+        .filter((k) => signals[k])
+        .map((k) => SIGNAL_LABELS[k].toLowerCase());
+      const firedCount = firedLabels.length;
+      const adjText =
+        adjustment === 0
+          ? `Adjustment: 0 (${adjustmentReason || "signals capture quality accurately"}).`
+          : `Adjustment: ${adjustment > 0 ? "+1" : "-1"} (${adjustmentReason}).`;
+      result.worthItReason =
+        `${firedCount}/8 signals: ${firedLabels.join(", ") || "none"}. ${adjText}`;
+    }
+    // Legacy dimension-averaging (backward compat for custom prompts)
+    else if (raw.worthItDimensions && typeof raw.worthItDimensions === "object") {
+      const dims = raw.worthItDimensions as Record<string, unknown>;
       if (
-        typeof uniqueness === "number" &&
-        typeof actionability === "number" &&
-        typeof timeValue === "number"
+        typeof dims.uniqueness === "number" &&
+        typeof dims.actionability === "number" &&
+        typeof dims.timeValue === "number"
       ) {
+        const { uniqueness, actionability, timeValue } = dims;
         const computed = parseFloat(((uniqueness + actionability + timeValue) / 3).toFixed(1));
         if (result.worthItScore !== computed) {
           console.warn(
@@ -56,8 +100,15 @@ export async function generateEpisodeSummary(
           );
         }
         result.worthItScore = computed;
+        result.worthItDimensions = {
+          kind: "dimensions",
+          uniqueness,
+          actionability,
+          timeValue,
+        };
       }
     }
+    // Neither format (custom prompt returning raw score) — keep as-is
 
     // Validate and normalize topics
     if (Array.isArray(result.topics)) {


### PR DESCRIPTION
## Summary

- Replace 3-dimension numeric scoring (uniqueness/actionability/timeValue averaged) with 8 boolean signal questions + constrained ±1 LLM adjustment for more stable, interpretable episode scores
- Score formula: `clamp(1 + count_of_true_signals + adjustment, 1, 10)` — LLMs answer yes/no reliably vs struggling with 1-10 calibration
- Backward compatible: old episodes retain dimension-based scores with legacy progress bars; new episodes show a signal checklist UI
- No database migration needed — the JSON column accepts both formats via a discriminated union (`kind: "signals"` vs legacy)
- Existing score thresholds (8/6/4/2 display tiers, 6.00 recommendations) remain semantically valid for the new distribution
- ADR-032 documents the scoring model change, design decisions, and threshold analysis

### Files changed (16 files, +625/-79)
- **Types:** `openrouter.ts` — `WorthItSignals`, `WorthItDimensionsData` discriminated union, `SIGNAL_LABELS`
- **Helpers:** `score-utils.ts` — `computeSignalScore()`, `clampAdjustment()`, `coerceSignals()`
- **Prompts:** `prompts.ts` — 8 boolean signal questions + adjustment instructions
- **Scoring:** `ai-summary.ts` — 3-tier fallback: signals → dimensions → raw score; `console.warn` for non-boolean coercion
- **Schema:** `schema.ts` — updated `$type<>` annotation (no migration)
- **UI:** `summary-display.tsx` — signal checklist with CheckCircle/XCircle icons; legacy progress bars preserved
- **Tests:** 30 score-utils tests, signal computation/coercion/clamping tests, updated database + prompt fixtures
- **Docs:** ADR-032, CHANGELOG

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run test` — 1540 tests pass (129 files)
- [x] `bun run build` — production build succeeds
- [ ] Storybook: verify `WithSignals` and `WithLegacyDimensions` stories render correctly
- [ ] E2E: summarize a real episode and verify signal checklist appears in the UI
- [ ] Verify old episodes with dimension-based scores still render with legacy progress bars

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Episode scoring now derives from eight boolean quality signals plus a ±1 adjustment, producing more stable, interpretable episode scores while preserving legacy compatibility.
  * Episode pages now display per-signal pass/fail indicators and an optional adjustment line; the score display supports both new and legacy formats.
* **Documentation**
  * Changelog and design docs updated to describe the signal-based scoring and transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->