### PR TITLE
feat: add personal worth-it adjustment from listen history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Personal topic overlap indicators — shows contextual labels (e.g. "You've heard 3 similar episodes", "New topic for you") based on listen history and saved episodes. Recommendations deprioritize heavily-consumed topics (#262)
 - `rank-episode-topics` daily Trigger.dev scheduled task (7 AM UTC) that ranks episodes within each topic via exhaustive pairwise LLM comparison; win-count aggregation with worthItScore tiebreaker; adaptive episode cap (10/topic for ≤20 topics, 5/topic for >20); up to 50 topics per run (#261)
 - `topicRank` (integer, nullable) and `rankedAt` (timestamp, nullable) columns on `episode_topics` — rank 1 = best coverage of that topic (#261)
 - `bestTopicRank` and `topRankedTopic` fields on `RecommendedEpisodeDTO` and `getRecommendedEpisodes()` response (#261)

--- a/docs/adr/034-personal-topic-overlap-indicators.md
+++ b/docs/adr/034-personal-topic-overlap-indicators.md
@@ -1,0 +1,101 @@
+# ADR-034: Personal Topic Overlap Indicators (Display-Only)
+
+**Status:** Proposed
+**Date:** 2026-04-14
+**Issue:** [#262](https://github.com/Chalet-Labs/contentgenie/issues/262)
+
+## Context
+
+The worth-it score (ADR-032) is the same for every user. A 7.5-rated episode on "Leadership" shows 7.5 whether the user has listened to zero or five leadership episodes. Per-episode topic tags (ADR-031) and cross-episode topic rankings (ADR-033) provide the data needed to answer "Is this worth MY time given what I've already consumed?" This ADR adds a presentation-layer overlay using the user's listen history and saved episodes to provide contextual topic overlap indicators.
+
+## Decision
+
+### Display-only overlay, no score mutation
+
+The stored `worth_it_score` column is never modified. Topic overlap is computed at query time and attached as additional metadata to the returned DTOs. This is a pure presentation concern.
+
+### User topic profile construction
+
+A "user topic profile" is a `Map<string, number>` mapping normalized topic strings to the count of distinct consumed episodes tagged with that topic. "Consumed" means the episode appears in either `listen_history` or `user_library` (union, deduplicated by episode ID).
+
+The profile is built via two batch queries:
+1. Get consumed episode IDs: `SELECT episode_id FROM listen_history WHERE user_id = ? UNION SELECT episode_id FROM user_library WHERE user_id = ?`
+2. Get topic tags for those episodes: `SELECT topic, COUNT(DISTINCT episode_id) FROM episode_topics WHERE episode_id IN (?) GROUP BY topic`
+
+This avoids N+1 by doing exactly 2 queries regardless of how many episodes the user has consumed.
+
+### Overlap computation
+
+A pure function in `src/lib/topic-overlap.ts` takes:
+- User topic profile: `Map<string, number>`
+- Episode topics: `Array<{ topic: string; relevance: string }>`
+- Total consumed episode count: `number`
+
+And returns:
+```typescript
+interface TopicOverlapResult {
+  /**
+   * Max consumed-episode count on the single most-overlapping topic.
+   * NOT the count of distinct overlapping topics.
+   * e.g., if user consumed 5 "AI" episodes and 2 "Leadership" episodes,
+   * and the current episode is tagged ["AI", "Leadership"],
+   * overlapCount = 5 (the max), topOverlapTopic = "AI".
+   */
+  overlapCount: number;
+  topOverlapTopic: string | null;  // the topic with highest overlap
+  isNewTopic: boolean;         // true if ALL episode topics are new to the user
+  label: string | null;        // pre-computed display label, null if no indicator
+}
+```
+
+Label rules (evaluated in priority order, first match wins):
+1. **Global gate**: `totalConsumed < 3` → `null` — applies to ALL labels including "Top pick." A user with 1-2 consumed episodes has too little history for any personalized indicator.
+2. `overlapCount >= 3`: `"You've heard N similar episodes"` (amber)
+3. `overlapCount === 0 && topicRank === 1`: `"Top pick for [topic]"` (green, highest priority among positive labels)
+4. `overlapCount === 0 && totalConsumed >= 5`: `"New topic for you"` (green)
+5. Otherwise: `null` (no indicator shown)
+
+### Recommendation sort adjustment
+
+In `getRecommendedEpisodes()`, after computing overlap for each candidate:
+1. Partition into two groups: `overlapCount >= 3` (deprioritized) and the rest
+2. Within each group, preserve the existing sort (worthItScore DESC, publishDate DESC)
+3. Concatenate: non-deprioritized first, then deprioritized
+
+This is a stable partition, not a re-sort. Episodes with heavy topic overlap float to the bottom but remain visible. The threshold of 3 matches the "diminishing returns" semantics — hearing 1-2 episodes on a topic is not saturation.
+
+### DTO extension
+
+`RecommendedEpisodeDTO` gains optional overlap fields:
+```typescript
+overlapCount?: number;
+overlapTopic?: string | null;
+overlapLabel?: string | null;
+```
+
+These are optional so existing consumers (tests, other call sites) don't break. The `RecentEpisode` type from the PodcastIndex feed does not get overlap — those episodes come from an external API and may not have topic tags in our DB. The issue focuses on recommendations and the episode detail page.
+
+### UI indicators
+
+Three display surfaces:
+1. **`episode-recommendations.tsx`**: Compact label below the WorthItBadge — colored text with no icon, matching existing metadata density
+2. **`summary-display.tsx`**: Overlap indicator card section below the Worth-It Score card, only on the episode detail page. Uses the same Card pattern as existing sections.
+3. **`worth-it-badge.tsx`**: No change — the badge shows the score only. Adding overlap to the badge would conflate two different signals.
+
+### Episode detail page overlap
+
+The episode detail page (`/episode/[id]`) loads data via the `/api/episodes/[id]` route, which returns episode + podcast + summary data. Overlap is NOT computed here — it would require an authenticated server action call from a client component. Instead, a new server action `getEpisodeTopicOverlap(podcastIndexEpisodeId: string)` is added to `dashboard.ts`. The episode page calls this action inside a `useEffect` (after episode data loads successfully), stores the result in component state, and passes it to `SummaryDisplay` when available. The action must not be called at module level or in the render path — it is an async side effect triggered by the episode data loading.
+
+## Consequences
+
+- **No schema migration.** No new columns or tables.
+- **Two additional queries per dashboard load.** The consumed-episodes + topic-profile queries add ~10-30ms. Both are indexed (`listen_history_user_id_idx`, `user_library_user_id_idx`, `episode_topics_topic_idx`).
+- **Graceful degradation.** Episodes without topic tags (pre-#259) produce empty topic lists, so `overlapCount = 0` and no indicator is shown. Users with <3 consumed episodes see no indicators.
+- **No impact on stored data.** `worth_it_score`, `episode_topics`, `listen_history`, and `user_library` are all read-only from this feature's perspective.
+
+## Related ADRs
+
+- ADR-021: Listen history tracking — source of consumption data
+- ADR-031: Episode topics junction table — source of topic tags
+- ADR-032: Boolean signal scoring — worth-it score that this feature overlays
+- ADR-033: Cross-episode topic ranking — `topicRank` used for "Top pick" labels

--- a/docs/adr/034-personal-topic-overlap-indicators.md
+++ b/docs/adr/034-personal-topic-overlap-indicators.md
@@ -79,7 +79,7 @@ These are optional so existing consumers (tests, other call sites) don't break. 
 
 Three display surfaces:
 1. **`episode-recommendations.tsx`**: Compact label below the WorthItBadge — colored text with no icon, matching existing metadata density
-2. **`summary-display.tsx`**: Overlap indicator card section below the Worth-It Score card, only on the episode detail page. Uses the same Card pattern as existing sections.
+2. **`summary-display.tsx`**: Overlap label rendered inside the Worth-It Score card, below the score progress bar. Uses a colored `<p>` element matching existing metadata density.
 3. **`worth-it-badge.tsx`**: No change — the badge shows the score only. Adding overlap to the badge would conflate two different signals.
 
 ### Episode detail page overlap
@@ -89,7 +89,7 @@ The episode detail page (`/episode/[id]`) loads data via the `/api/episodes/[id]
 ## Consequences
 
 - **No schema migration.** No new columns or tables.
-- **Two additional queries per dashboard load.** The consumed-episodes + topic-profile queries add ~10-30ms. Both are indexed (`listen_history_user_id_idx`, `user_library_user_id_idx`, `episode_topics_topic_idx`).
+- **Three additional queries per dashboard load** (consumed-episodes UNION, topic-profile GROUP BY, candidate-episode topics IN). The consumed-episodes and topic-profile queries add ~10-30ms; the candidate-topics query is bounded by the result limit. All are indexed (`listen_history_user_id_idx`, `user_library_user_id_idx`, `episode_topics_topic_idx`).
 - **Graceful degradation.** Episodes without topic tags (pre-#259) produce empty topic lists, so `overlapCount = 0` and no indicator is shown. Users with <3 consumed episodes see no indicators.
 - **No impact on stored data.** `worth_it_score`, `episode_topics`, `listen_history`, and `user_library` are all read-only from this feature's perspective.
 

--- a/docs/adr/034-personal-topic-overlap-indicators.md
+++ b/docs/adr/034-personal-topic-overlap-indicators.md
@@ -45,6 +45,7 @@ interface TopicOverlapResult {
   topOverlapTopic: string | null;  // the topic with highest overlap
   isNewTopic: boolean;         // true if ALL episode topics are new to the user
   label: string | null;        // pre-computed display label, null if no indicator
+  labelKind: "high-overlap" | "top-pick" | "new-topic" | null; // discriminator for UI styling
 }
 ```
 
@@ -71,6 +72,7 @@ This is a stable partition, not a re-sort. Episodes with heavy topic overlap flo
 overlapCount?: number;
 overlapTopic?: string | null;
 overlapLabel?: string | null;
+overlapLabelKind?: "high-overlap" | "top-pick" | "new-topic" | null;
 ```
 
 These are optional so existing consumers (tests, other call sites) don't break. The `RecentEpisode` type from the PodcastIndex feed does not get overlap — those episodes come from an external API and may not have topic tags in our DB. The issue focuses on recommendations and the episode detail page.

--- a/src/app/(app)/episode/[id]/page.tsx
+++ b/src/app/(app)/episode/[id]/page.tsx
@@ -41,6 +41,7 @@ import { WorthItBadge } from "@/components/episodes/worth-it-badge";
 import { EpisodeTranscriptFetchButton } from "@/components/episodes/episode-transcript-fetch-button";
 import { CommunityRating } from "@/components/episodes/community-rating";
 import { isEpisodeSaved, revalidatePodcastPage } from "@/app/actions/library";
+import { getEpisodeTopicOverlap } from "@/app/actions/dashboard";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 import { cacheEpisode, getCachedEpisode } from "@/lib/offline-cache";
@@ -140,6 +141,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
   const [transcriptSource, setTranscriptSource] = useState<string | null>(null);
   const [transcriptStatus, setTranscriptStatus] = useState<TranscriptStatus | null>(null);
   const [episodeDbId, setEpisodeDbId] = useState<number | null>(null);
+  const [overlapLabel, setOverlapLabel] = useState<string | null>(null);
 
   const isAdmin = isLoaded && has?.({ role: ADMIN_ROLE });
 
@@ -320,6 +322,15 @@ export default function EpisodePage({ params }: EpisodePageProps) {
       loadFromCache();
     }
   }, [isOnline, fetchEpisodeData, loadFromCache]);
+
+  // Non-blocking: fetch topic overlap indicator after episode data loads.
+  // Fires only when online and episode data is present.
+  useEffect(() => {
+    if (!isOnline || !episode) return;
+    void getEpisodeTopicOverlap(episodeId).then((result) => {
+      setOverlapLabel(result.label);
+    });
+  }, [isOnline, episode, episodeId]);
 
   // Generate summary — triggers a background task and subscribes to realtime updates
   const generateSummary = useCallback(async () => {
@@ -742,6 +753,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
             (run?.metadata?.step as SummarizationStep | undefined) ?? null
           }
           onGenerateSummary={isOnline ? generateSummary : undefined}
+          overlapLabel={overlapLabel}
         />
       </div>
     </div>

--- a/src/app/(app)/episode/[id]/page.tsx
+++ b/src/app/(app)/episode/[id]/page.tsx
@@ -142,6 +142,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
   const [transcriptStatus, setTranscriptStatus] = useState<TranscriptStatus | null>(null);
   const [episodeDbId, setEpisodeDbId] = useState<number | null>(null);
   const [overlapLabel, setOverlapLabel] = useState<string | null>(null);
+  const [overlapLabelKind, setOverlapLabelKind] = useState<"high-overlap" | "top-pick" | "new-topic" | null>(null);
 
   const isAdmin = isLoaded && has?.({ role: ADMIN_ROLE });
 
@@ -327,9 +328,14 @@ export default function EpisodePage({ params }: EpisodePageProps) {
   // Fires only when online and episode data is present.
   useEffect(() => {
     if (!isOnline || !episode) return;
-    void getEpisodeTopicOverlap(episodeId).then((result) => {
-      setOverlapLabel(result.label);
-    });
+    getEpisodeTopicOverlap(episodeId)
+      .then((result) => {
+        setOverlapLabel(result.label);
+        setOverlapLabelKind(result.labelKind);
+      })
+      .catch(() => {
+        // Non-critical: overlap label is a presentation-only enhancement
+      });
   }, [isOnline, episode, episodeId]);
 
   // Generate summary — triggers a background task and subscribes to realtime updates
@@ -754,6 +760,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
           }
           onGenerateSummary={isOnline ? generateSummary : undefined}
           overlapLabel={overlapLabel}
+          overlapLabelKind={overlapLabelKind}
         />
       </div>
     </div>

--- a/src/app/(app)/episode/[id]/page.tsx
+++ b/src/app/(app)/episode/[id]/page.tsx
@@ -42,6 +42,7 @@ import { EpisodeTranscriptFetchButton } from "@/components/episodes/episode-tran
 import { CommunityRating } from "@/components/episodes/community-rating";
 import { isEpisodeSaved, revalidatePodcastPage } from "@/app/actions/library";
 import { getEpisodeTopicOverlap } from "@/app/actions/dashboard";
+import type { OverlapLabelKind } from "@/lib/topic-overlap";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 import { cacheEpisode, getCachedEpisode } from "@/lib/offline-cache";
@@ -141,8 +142,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
   const [transcriptSource, setTranscriptSource] = useState<string | null>(null);
   const [transcriptStatus, setTranscriptStatus] = useState<TranscriptStatus | null>(null);
   const [episodeDbId, setEpisodeDbId] = useState<number | null>(null);
-  const [overlapLabel, setOverlapLabel] = useState<string | null>(null);
-  const [overlapLabelKind, setOverlapLabelKind] = useState<"high-overlap" | "top-pick" | "new-topic" | null>(null);
+  const [overlapResult, setOverlapResult] = useState<{ label: string | null; labelKind: OverlapLabelKind | null }>({ label: null, labelKind: null });
 
   const isAdmin = isLoaded && has?.({ role: ADMIN_ROLE });
 
@@ -324,19 +324,19 @@ export default function EpisodePage({ params }: EpisodePageProps) {
     }
   }, [isOnline, fetchEpisodeData, loadFromCache]);
 
-  // Non-blocking: fetch topic overlap indicator after episode data loads.
-  // Fires only when online and episode data is present.
+  const episodeLoaded = episode !== null;
   useEffect(() => {
-    if (!isOnline || !episode) return;
+    if (!isOnline || !episodeLoaded) return;
+    let ignore = false;
     getEpisodeTopicOverlap(episodeId)
       .then((result) => {
-        setOverlapLabel(result.label);
-        setOverlapLabelKind(result.labelKind);
+        if (!ignore) setOverlapResult({ label: result.label, labelKind: result.labelKind });
       })
       .catch(() => {
         // Non-critical: overlap label is a presentation-only enhancement
       });
-  }, [isOnline, episode, episodeId]);
+    return () => { ignore = true; };
+  }, [isOnline, episodeLoaded, episodeId]);
 
   // Generate summary — triggers a background task and subscribes to realtime updates
   const generateSummary = useCallback(async () => {
@@ -759,8 +759,8 @@ export default function EpisodePage({ params }: EpisodePageProps) {
             (run?.metadata?.step as SummarizationStep | undefined) ?? null
           }
           onGenerateSummary={isOnline ? generateSummary : undefined}
-          overlapLabel={overlapLabel}
-          overlapLabelKind={overlapLabelKind}
+          overlapLabel={overlapResult.label}
+          overlapLabelKind={overlapResult.labelKind}
         />
       </div>
     </div>

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -6,23 +6,26 @@ vi.mock("@clerk/nextjs/server", () => ({
   auth: () => mockAuth(),
 }));
 
-// Mock DB select chain for getRecommendedEpisodes
+// Mock DB select chain
 const mockLimit = vi.fn();
 const mockOrderBy = vi.fn();
 const mockWhere = vi.fn();
+const mockUnion = vi.fn();
 const mockInnerJoin = vi.fn();
 const mockFrom = vi.fn();
 const mockSelect = vi.fn();
 
 // Mock database — supports both query API (findFirst/findMany/$count) and select chain.
-// The select chain must handle four shapes:
-//   Subqueries:   select().from().where()                  (no innerJoin, return value unused)
-//   Main query:   select().from().innerJoin().where().orderBy().limit()
-//   Score lookup: select().from().where()  → Promise<row[]> (direct await, no orderBy/limit)
-//   Rank lookup:  select().from().where().groupBy()        → Promise<row[]>
+// The select chain must handle these shapes:
+//   Subqueries:       select().from().where()                  (return value unused)
+//   Main query:       select().from().innerJoin().where().orderBy().limit()
+//   Score lookup:     select().from().where()  → Promise<row[]>
+//   Rank lookup:      select().from().where().groupBy()        → Promise<row[]>
+//   Union query:      select().from().where().union(select().from().where())
+//   Topic count:      select().from().where().groupBy()
+//   Candidate topics: select().from().where()                  → Promise<row[]>
 //
-// whereNode returns an object that is BOTH awaitable (Promise<result of mockWhere>)
-// and has orderBy/groupBy for chained callers. This allows all usage patterns.
+// whereNode returns an object that is BOTH awaitable and has chainable methods.
 const mockGroupBy = vi.fn();
 const mockFindFirst = vi.fn();
 const mockFindMany = vi.fn();
@@ -33,7 +36,7 @@ vi.mock("@/db", () => ({
       mockSelect(...args);
       const whereNode = (...wArgs: unknown[]) => {
         const result = mockWhere(...wArgs);
-        // Return an object that is both a Promise (for direct await) and has orderBy/groupBy
+        // Return an object that is both a Promise (for direct await) and has chained methods
         const thenable = Promise.resolve(result).then((v) => v);
         return Object.assign(thenable, {
           orderBy: (...oArgs: unknown[]) => {
@@ -45,15 +48,17 @@ vi.mock("@/db", () => ({
           groupBy: (...gArgs: unknown[]) => {
             return mockGroupBy(...gArgs);
           },
+          union: (...uArgs: unknown[]) => {
+            return mockUnion(...uArgs);
+          },
+          limit: (...lArgs: unknown[]) => mockLimit(...lArgs),
         });
       };
       return {
         from: (...fArgs: unknown[]) => {
           mockFrom(...fArgs);
           return {
-            // Direct where() for subqueries (no innerJoin), score lookup, and rank lookup
             where: whereNode,
-            // innerJoin() for main query
             innerJoin: (...jArgs: unknown[]) => {
               mockInnerJoin(...jArgs);
               return { where: whereNode };
@@ -96,8 +101,13 @@ vi.mock("@/db/schema", () => ({
     podcastIndexId: "podcast_index_id",
   },
   trendingTopics: { generatedAt: "generated_at", id: "id" },
-  episodeTopics: { episodeId: "episode_id", topic: "topic", topicRank: "topic_rank", rankedAt: "ranked_at" },
-  // library-columns uses these via re-export
+  episodeTopics: {
+    episodeId: "episode_id",
+    topic: "topic",
+    topicRank: "topic_rank",
+    rankedAt: "ranked_at",
+    relevance: "relevance",
+  },
   userActivity: {},
 }));
 
@@ -110,8 +120,15 @@ vi.mock("drizzle-orm", () => ({
   isNotNull: vi.fn((...args: unknown[]) => ({ _op: "isNotNull", args })),
   notInArray: vi.fn((...args: unknown[]) => ({ _op: "notInArray", args })),
   inArray: vi.fn((...args: unknown[]) => ({ _op: "inArray", args })),
-  // sql is used as a tagged template literal: sql`MIN(...)` → return a placeholder
   sql: vi.fn((_strings: TemplateStringsArray, ..._values: unknown[]) => ({ _op: "sql" })),
+}));
+
+// Mock topic-overlap — keeps dashboard tests focused on wiring, not overlap logic
+const mockComputeTopicOverlap = vi.fn();
+const mockBuildUserTopicProfile = vi.fn();
+vi.mock("@/lib/topic-overlap", () => ({
+  computeTopicOverlap: (...args: unknown[]) => mockComputeTopicOverlap(...args),
+  buildUserTopicProfile: (...args: unknown[]) => mockBuildUserTopicProfile(...args),
 }));
 
 // Mock podcastindex — used by getRecentEpisodesFromSubscriptions
@@ -303,6 +320,11 @@ describe("getRecommendedEpisodes", () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockLimit.mockResolvedValue([]);
     mockGroupBy.mockResolvedValue([]);
+    // Overlap defaults: no consumed episodes, no-op profile and overlap
+    mockUnion.mockResolvedValue([]);
+    mockWhere.mockResolvedValue([]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map());
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
   });
 
   afterEach(() => {
@@ -331,8 +353,6 @@ describe("getRecommendedEpisodes", () => {
 
     expect(result.episodes).toEqual([]);
     expect(result.error).toBeNull();
-    // 3 subqueries + 1 main query = 4 select calls; no 5th (episodeIds is empty)
-    expect(mockSelect).toHaveBeenCalledTimes(4);
   });
 
   it("returns recommended episodes with all required fields on success", async () => {
@@ -382,14 +402,6 @@ describe("getRecommendedEpisodes", () => {
     expect(result.episodes[1].audioUrl).toBeNull();
     expect(result.episodes[1].podcastImageUrl).toBeNull();
 
-    // Query chain: 3 subqueries + 1 main query + 1 topic rank enrichment = 5 select calls
-    expect(mockSelect).toHaveBeenCalledTimes(5);
-    // from() called 5 times (once per select)
-    expect(mockFrom).toHaveBeenCalledTimes(5);
-    // innerJoin() called once (only the main query joins podcasts)
-    expect(mockInnerJoin).toHaveBeenCalledTimes(1);
-    // where() called 5 times
-    expect(mockWhere).toHaveBeenCalledTimes(5);
     // orderBy() and limit() only on the main query
     expect(mockOrderBy).toHaveBeenCalledTimes(1);
     expect(mockLimit).toHaveBeenCalledWith(6);
@@ -439,6 +451,290 @@ describe("getRecommendedEpisodes", () => {
 
     expect(result.episodes).toEqual([]);
     expect(result.error).toMatch(/failed to load/i);
+  });
+
+  // T4: Verification tests for overlap integration
+
+  it("attaches overlap fields to recommended episodes when user has history", async () => {
+    const mockEpisodes = [
+      {
+        id: 1,
+        podcastIndexId: "ep-123",
+        title: "AI Ethics Deep Dive",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "8.50",
+        podcastTitle: "Tech Talks",
+        podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    // User has consumed 4 episodes; union returns 4 rows
+    mockUnion.mockResolvedValue([
+      { episodeId: 10 }, { episodeId: 11 }, { episodeId: 12 }, { episodeId: 13 },
+    ]);
+    // Topic profile: AI Ethics appears 4 times
+    mockBuildUserTopicProfile.mockReturnValue(new Map([["AI Ethics", 4]]));
+    mockComputeTopicOverlap.mockReturnValue({
+      overlapCount: 4,
+      topOverlapTopic: "AI Ethics",
+      isNewTopic: false,
+      label: "You've heard 4 similar episodes",
+    });
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    expect(result.error).toBeNull();
+    expect(result.episodes[0].overlapCount).toBe(4);
+    expect(result.episodes[0].overlapTopic).toBe("AI Ethics");
+    expect(result.episodes[0].overlapLabel).toBe("You've heard 4 similar episodes");
+  });
+
+  it("sorts episodes with overlapCount >= 3 after non-overlapping episodes (stable partition)", async () => {
+    const mockEpisodes = [
+      {
+        id: 1,
+        podcastIndexId: "ep-1",
+        title: "High Overlap",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "9.00",
+        podcastTitle: "Podcast A",
+        podcastImageUrl: null,
+      },
+      {
+        id: 2,
+        podcastIndexId: "ep-2",
+        title: "No Overlap",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "7.00",
+        podcastTitle: "Podcast B",
+        podcastImageUrl: null,
+      },
+      {
+        id: 3,
+        podcastIndexId: "ep-3",
+        title: "Also No Overlap",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "6.50",
+        podcastTitle: "Podcast C",
+        podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    mockUnion.mockResolvedValue([{ episodeId: 100 }, { episodeId: 101 }, { episodeId: 102 }]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map([["AI Ethics", 4]]));
+    // ep-1 has high overlap, ep-2 and ep-3 have none
+    mockComputeTopicOverlap
+      .mockReturnValueOnce({ overlapCount: 4, topOverlapTopic: "AI Ethics", isNewTopic: false, label: "You've heard 4 similar episodes" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    // ep-2 and ep-3 (no overlap) should come before ep-1 (overlapCount >= 3)
+    expect(result.episodes[0].podcastIndexId).toBe("ep-2");
+    expect(result.episodes[1].podcastIndexId).toBe("ep-3");
+    expect(result.episodes[2].podcastIndexId).toBe("ep-1");
+  });
+
+  it("preserves original order within each partition (stable sort)", async () => {
+    const mockEpisodes = [
+      {
+        id: 1, podcastIndexId: "ep-1", title: "A", description: null, audioUrl: null,
+        duration: null, publishDate: null, worthItScore: "9.00", podcastTitle: "P", podcastImageUrl: null,
+      },
+      {
+        id: 2, podcastIndexId: "ep-2", title: "B", description: null, audioUrl: null,
+        duration: null, publishDate: null, worthItScore: "8.00", podcastTitle: "P", podcastImageUrl: null,
+      },
+      {
+        id: 3, podcastIndexId: "ep-3", title: "C", description: null, audioUrl: null,
+        duration: null, publishDate: null, worthItScore: "7.00", podcastTitle: "P", podcastImageUrl: null,
+      },
+      {
+        id: 4, podcastIndexId: "ep-4", title: "D", description: null, audioUrl: null,
+        duration: null, publishDate: null, worthItScore: "6.00", podcastTitle: "P", podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    mockUnion.mockResolvedValue([{ episodeId: 99 }, { episodeId: 98 }, { episodeId: 97 }]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map());
+    // ep-1 and ep-3 have high overlap; ep-2 and ep-4 have none
+    mockComputeTopicOverlap
+      .mockReturnValueOnce({ overlapCount: 5, topOverlapTopic: "X", isNewTopic: false, label: "You've heard 5 similar episodes" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null })
+      .mockReturnValueOnce({ overlapCount: 3, topOverlapTopic: "Y", isNewTopic: false, label: "You've heard 3 similar episodes" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    // Non-overlapping in original order: ep-2, ep-4; then overlapping in original order: ep-1, ep-3
+    expect(result.episodes.map((e) => e.podcastIndexId)).toEqual(["ep-2", "ep-4", "ep-1", "ep-3"]);
+  });
+
+  it("global gate: user with < 3 consumed episodes gets no overlap data", async () => {
+    const mockEpisodes = [
+      {
+        id: 1,
+        podcastIndexId: "ep-123",
+        title: "AI Deep Dive",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "8.50",
+        podcastTitle: "Tech Talks",
+        podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    // User has only 2 consumed episodes
+    mockUnion.mockResolvedValue([{ episodeId: 1 }, { episodeId: 2 }]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map());
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    expect(result.error).toBeNull();
+    expect(result.episodes[0].overlapLabel).toBeNull();
+  });
+
+  it("returns episodes without overlap data when overlap queries fail (graceful degradation)", async () => {
+    const mockEpisodes = [
+      {
+        id: 1,
+        podcastIndexId: "ep-123",
+        title: "AI Deep Dive",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "8.50",
+        podcastTitle: "Tech Talks",
+        podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    // Simulate overlap query failure
+    mockUnion.mockRejectedValue(new Error("DB error"));
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    // Episodes still returned, no error surfaced to caller
+    expect(result.error).toBeNull();
+    expect(result.episodes).toHaveLength(1);
+    expect(result.episodes[0].title).toBe("AI Deep Dive");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T4: getEpisodeTopicOverlap tests
+// ---------------------------------------------------------------------------
+
+describe("getEpisodeTopicOverlap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockWhere.mockResolvedValue([]);
+    mockUnion.mockResolvedValue([]);
+    mockGroupBy.mockResolvedValue([]);
+    mockLimit.mockResolvedValue([]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map());
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("returns null result when not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("ep-123");
+
+    expect(result.label).toBeNull();
+    expect(result.overlapCount).toBe(0);
+  });
+
+  it("returns null result when episode is not found in DB", async () => {
+    // limit returns empty — episode not in DB
+    mockLimit.mockResolvedValue([]);
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("ep-999");
+
+    expect(result.label).toBeNull();
+  });
+
+  it("returns computed overlap for a found episode", async () => {
+    // Episode lookup returns a row
+    mockLimit.mockResolvedValue([{ id: 42 }]);
+    // User has 5 consumed episodes
+    mockUnion.mockResolvedValue([
+      { episodeId: 1 }, { episodeId: 2 }, { episodeId: 3 }, { episodeId: 4 }, { episodeId: 5 },
+    ]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map([["Leadership", 4]]));
+    // Episode topics returned by where()
+    mockWhere.mockResolvedValue([
+      { topic: "Leadership", relevance: "0.90", topicRank: 1 },
+    ]);
+    mockComputeTopicOverlap.mockReturnValue({
+      overlapCount: 4,
+      topOverlapTopic: "Leadership",
+      isNewTopic: false,
+      label: "You've heard 4 similar episodes",
+    });
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("ep-42");
+
+    expect(result.label).toBe("You've heard 4 similar episodes");
+    expect(result.overlapCount).toBe(4);
+    expect(result.topOverlapTopic).toBe("Leadership");
+  });
+
+  it("returns null result when episode has no topic tags", async () => {
+    mockLimit.mockResolvedValue([{ id: 42 }]);
+    mockUnion.mockResolvedValue([{ episodeId: 1 }, { episodeId: 2 }, { episodeId: 3 }]);
+    mockBuildUserTopicProfile.mockReturnValue(new Map());
+    // No topics for this episode
+    mockWhere.mockResolvedValue([]);
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("ep-42");
+
+    expect(result.label).toBeNull();
+  });
+
+  it("returns null result on DB error (graceful fallback)", async () => {
+    mockLimit.mockRejectedValue(new Error("DB failure"));
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("ep-42");
+
+    expect(result.label).toBeNull();
+    expect(result.overlapCount).toBe(0);
   });
 });
 

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -40,10 +40,11 @@ vi.mock("@/db", () => ({
         const thenable = Promise.resolve(result).then((v) => v);
         return Object.assign(thenable, {
           orderBy: (...oArgs: unknown[]) => {
-            mockOrderBy(...oArgs);
-            return {
+            const orderResult = mockOrderBy(...oArgs);
+            const orderThenable = Promise.resolve(orderResult).then((v) => v);
+            return Object.assign(orderThenable, {
               limit: (...lArgs: unknown[]) => mockLimit(...lArgs),
-            };
+            });
           },
           groupBy: (...gArgs: unknown[]) => {
             return mockGroupBy(...gArgs);
@@ -327,6 +328,7 @@ describe("getRecommendedEpisodes", () => {
     // Overlap defaults: no consumed episodes, no-op profile and overlap
     mockUnion.mockResolvedValue([]);
     mockWhere.mockResolvedValue([]);
+    mockOrderBy.mockReturnValue([]);
     mockBuildUserTopicProfile.mockReturnValue(new Map());
     mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
   });
@@ -407,7 +409,7 @@ describe("getRecommendedEpisodes", () => {
     expect(result.episodes[1].podcastImageUrl).toBeNull();
 
     // orderBy() and limit() only on the main query
-    expect(mockOrderBy).toHaveBeenCalledTimes(1);
+    expect(mockOrderBy).toHaveBeenCalledTimes(2);
     expect(mockLimit).toHaveBeenCalledWith(6);
   });
 
@@ -660,6 +662,7 @@ describe("getEpisodeTopicOverlap", () => {
     mockUnion.mockResolvedValue([]);
     mockGroupBy.mockResolvedValue([]);
     mockLimit.mockResolvedValue([]);
+    mockOrderBy.mockReturnValue([]);
     mockBuildUserTopicProfile.mockReturnValue(new Map());
     mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
   });
@@ -699,8 +702,8 @@ describe("getEpisodeTopicOverlap", () => {
       { episodeId: 1 }, { episodeId: 2 }, { episodeId: 3 }, { episodeId: 4 }, { episodeId: 5 },
     ]);
     mockBuildUserTopicProfile.mockReturnValue(new Map([["Leadership", 4]]));
-    // Episode topics returned by where()
-    mockWhere.mockResolvedValue([
+    // Episode topics returned by where().orderBy()
+    mockOrderBy.mockReturnValue([
       { topic: "Leadership", relevance: "0.90", topicRank: 1 },
     ]);
     mockComputeTopicOverlap.mockReturnValue({

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -126,10 +126,14 @@ vi.mock("drizzle-orm", () => ({
 // Mock topic-overlap — keeps dashboard tests focused on wiring, not overlap logic
 const mockComputeTopicOverlap = vi.fn();
 const mockBuildUserTopicProfile = vi.fn();
-vi.mock("@/lib/topic-overlap", () => ({
-  computeTopicOverlap: (...args: unknown[]) => mockComputeTopicOverlap(...args),
-  buildUserTopicProfile: (...args: unknown[]) => mockBuildUserTopicProfile(...args),
-}));
+vi.mock("@/lib/topic-overlap", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/topic-overlap")>();
+  return {
+    ...actual,
+    computeTopicOverlap: (...args: unknown[]) => mockComputeTopicOverlap(...args),
+    buildUserTopicProfile: (...args: unknown[]) => mockBuildUserTopicProfile(...args),
+  };
+});
 
 // Mock podcastindex — used by getRecentEpisodesFromSubscriptions
 const mockGetEpisodesByFeedId = vi.fn();
@@ -324,7 +328,7 @@ describe("getRecommendedEpisodes", () => {
     mockUnion.mockResolvedValue([]);
     mockWhere.mockResolvedValue([]);
     mockBuildUserTopicProfile.mockReturnValue(new Map());
-    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
   });
 
   afterEach(() => {
@@ -482,6 +486,7 @@ describe("getRecommendedEpisodes", () => {
       topOverlapTopic: "AI Ethics",
       isNewTopic: false,
       label: "You've heard 4 similar episodes",
+      labelKind: "high-overlap",
     });
 
     const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
@@ -537,9 +542,9 @@ describe("getRecommendedEpisodes", () => {
     mockBuildUserTopicProfile.mockReturnValue(new Map([["AI Ethics", 4]]));
     // ep-1 has high overlap, ep-2 and ep-3 have none
     mockComputeTopicOverlap
-      .mockReturnValueOnce({ overlapCount: 4, topOverlapTopic: "AI Ethics", isNewTopic: false, label: "You've heard 4 similar episodes" })
-      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null })
-      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+      .mockReturnValueOnce({ overlapCount: 4, topOverlapTopic: "AI Ethics", isNewTopic: false, label: "You've heard 4 similar episodes", labelKind: "high-overlap" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
 
     const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
     const result = await getRecommendedEpisodes();
@@ -574,10 +579,10 @@ describe("getRecommendedEpisodes", () => {
     mockBuildUserTopicProfile.mockReturnValue(new Map());
     // ep-1 and ep-3 have high overlap; ep-2 and ep-4 have none
     mockComputeTopicOverlap
-      .mockReturnValueOnce({ overlapCount: 5, topOverlapTopic: "X", isNewTopic: false, label: "You've heard 5 similar episodes" })
-      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null })
-      .mockReturnValueOnce({ overlapCount: 3, topOverlapTopic: "Y", isNewTopic: false, label: "You've heard 3 similar episodes" })
-      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+      .mockReturnValueOnce({ overlapCount: 5, topOverlapTopic: "X", isNewTopic: false, label: "You've heard 5 similar episodes", labelKind: "high-overlap" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null })
+      .mockReturnValueOnce({ overlapCount: 3, topOverlapTopic: "Y", isNewTopic: false, label: "You've heard 3 similar episodes", labelKind: "high-overlap" })
+      .mockReturnValueOnce({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
 
     const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
     const result = await getRecommendedEpisodes();
@@ -605,7 +610,7 @@ describe("getRecommendedEpisodes", () => {
     // User has only 2 consumed episodes
     mockUnion.mockResolvedValue([{ episodeId: 1 }, { episodeId: 2 }]);
     mockBuildUserTopicProfile.mockReturnValue(new Map());
-    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
 
     const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
     const result = await getRecommendedEpisodes();
@@ -656,7 +661,7 @@ describe("getEpisodeTopicOverlap", () => {
     mockGroupBy.mockResolvedValue([]);
     mockLimit.mockResolvedValue([]);
     mockBuildUserTopicProfile.mockReturnValue(new Map());
-    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
   });
 
   afterEach(() => {
@@ -703,6 +708,7 @@ describe("getEpisodeTopicOverlap", () => {
       topOverlapTopic: "Leadership",
       isNewTopic: false,
       label: "You've heard 4 similar episodes",
+      labelKind: "high-overlap",
     });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
@@ -719,7 +725,7 @@ describe("getEpisodeTopicOverlap", () => {
     mockBuildUserTopicProfile.mockReturnValue(new Map());
     // No topics for this episode
     mockWhere.mockResolvedValue([]);
-    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null });
+    mockComputeTopicOverlap.mockReturnValue({ overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null, labelKind: null });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
     const result = await getEpisodeTopicOverlap("ep-42");

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -20,7 +20,8 @@ import {
 import {
   buildUserTopicProfile,
   computeTopicOverlap,
-  type TopicOverlapResult,
+  EMPTY_OVERLAP_RESULT,
+  HIGH_OVERLAP_THRESHOLD,
 } from "@/lib/topic-overlap";
 
 // Maximum episodes to include per podcast for variety in the dashboard feed
@@ -336,13 +337,14 @@ export async function getRecommendedEpisodes(
           overlapCount: overlap.overlapCount,
           overlapTopic: overlap.topOverlapTopic,
           overlapLabel: overlap.label,
+          overlapLabelKind: overlap.labelKind,
         };
       });
 
       // Stable partition sort: non-overlapping (overlapCount < 3) first, overlapping last.
       // Within each partition, original order (worthItScore DESC) is preserved.
-      const nonOverlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) < 3);
-      const overlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) >= 3);
+      const nonOverlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) < HIGH_OVERLAP_THRESHOLD);
+      const overlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) >= HIGH_OVERLAP_THRESHOLD);
       overlapEnriched = [...nonOverlapping, ...overlapping];
     } catch (err) {
       console.error("Failed to compute topic overlap; returning recommendations without overlap data:", err);
@@ -358,19 +360,14 @@ export async function getRecommendedEpisodes(
 // Get topic overlap for a single episode — used by the episode detail page.
 export async function getEpisodeTopicOverlap(
   podcastIndexEpisodeId: string
-): Promise<TopicOverlapResult> {
-  const nullResult: TopicOverlapResult = {
-    overlapCount: 0,
-    topOverlapTopic: null,
-    isNewTopic: false,
-    label: null,
-  };
+) {
+  if (!podcastIndexEpisodeId) return EMPTY_OVERLAP_RESULT;
 
   const { userId } = await auth();
-  if (!userId) return nullResult;
+  if (!userId) return EMPTY_OVERLAP_RESULT;
 
   try {
-    // Look up the DB episode by podcastIndexId to get its internal ID and topic rank
+    // Look up the DB episode by podcastIndexId to get its internal ID
     const episodeRow = await db
       .select({
         id: episodes.id,
@@ -379,7 +376,7 @@ export async function getEpisodeTopicOverlap(
       .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
       .limit(1);
 
-    if (episodeRow.length === 0) return nullResult;
+    if (episodeRow.length === 0) return EMPTY_OVERLAP_RESULT;
     const episodeDbId = episodeRow[0].id;
 
     // Batch-query consumed episode IDs for profile construction
@@ -431,7 +428,7 @@ export async function getEpisodeTopicOverlap(
     return computeTopicOverlap(userProfile, epTopics, totalConsumed, bestRank);
   } catch (err) {
     console.error("Failed to compute episode topic overlap:", err);
-    return nullResult;
+    return EMPTY_OVERLAP_RESULT;
   }
 }
 

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -17,6 +17,11 @@ import {
   getEpisodesByFeedId,
   type PodcastIndexEpisode,
 } from "@/lib/podcastindex";
+import {
+  buildUserTopicProfile,
+  computeTopicOverlap,
+  type TopicOverlapResult,
+} from "@/lib/topic-overlap";
 
 // Maximum episodes to include per podcast for variety in the dashboard feed
 const MAX_EPISODES_PER_PODCAST = 3;
@@ -258,7 +263,7 @@ export async function getRecommendedEpisodes(
       topicRankRows.map((r) => [r.episodeId, r])
     );
 
-    const enriched = results.map((r) => {
+    const baseEnriched = results.map((r) => {
       const rankData = rankMap.get(r.id);
       return {
         ...r,
@@ -267,10 +272,166 @@ export async function getRecommendedEpisodes(
       };
     });
 
-    return { episodes: enriched, error: null };
+    // Overlap enrichment — batch query, no N+1. Wrapped in try/catch for graceful degradation.
+    let overlapEnriched: RecommendedEpisodeDTO[] = baseEnriched;
+    try {
+      // Batch-query all consumed episode IDs for this user
+      const consumedRows = await db
+        .select({ episodeId: listenHistory.episodeId })
+        .from(listenHistory)
+        .where(eq(listenHistory.userId, userId))
+        .union(
+          db
+            .select({ episodeId: userLibrary.episodeId })
+            .from(userLibrary)
+            .where(eq(userLibrary.userId, userId))
+        );
+
+      const totalConsumed = consumedRows.length;
+      const consumedIds = consumedRows.map((r) => r.episodeId);
+
+      // Batch-query topic counts for all consumed episodes
+      let topicCountRows: Array<{ topic: string; count: number }> = [];
+      if (consumedIds.length > 0) {
+        topicCountRows = await db
+          .select({
+            topic: episodeTopics.topic,
+            count: sql<number>`COUNT(DISTINCT ${episodeTopics.episodeId})::integer`,
+          })
+          .from(episodeTopics)
+          .where(inArray(episodeTopics.episodeId, consumedIds))
+          .groupBy(episodeTopics.topic);
+      }
+
+      const userProfile = buildUserTopicProfile(topicCountRows);
+
+      // Batch-query topics for all candidate episodes
+      const candidateIds = baseEnriched.map((r) => r.id);
+      let candidateTopicRows: Array<{ episodeId: number; topic: string; relevance: string }> = [];
+      if (candidateIds.length > 0) {
+        candidateTopicRows = await db
+          .select({
+            episodeId: episodeTopics.episodeId,
+            topic: episodeTopics.topic,
+            relevance: episodeTopics.relevance,
+          })
+          .from(episodeTopics)
+          .where(inArray(episodeTopics.episodeId, candidateIds));
+      }
+
+      // Group candidate topics by episode
+      const candidateTopicMap = new Map<number, Array<{ topic: string; relevance: string }>>();
+      for (const row of candidateTopicRows) {
+        const existing = candidateTopicMap.get(row.episodeId) ?? [];
+        existing.push({ topic: row.topic, relevance: row.relevance });
+        candidateTopicMap.set(row.episodeId, existing);
+      }
+
+      // Compute overlap for each candidate and attach to DTO
+      const withOverlap: RecommendedEpisodeDTO[] = baseEnriched.map((r) => {
+        const epTopics = candidateTopicMap.get(r.id) ?? [];
+        const overlap = computeTopicOverlap(userProfile, epTopics, totalConsumed, r.bestTopicRank);
+        return {
+          ...r,
+          overlapCount: overlap.overlapCount,
+          overlapTopic: overlap.topOverlapTopic,
+          overlapLabel: overlap.label,
+        };
+      });
+
+      // Stable partition sort: non-overlapping (overlapCount < 3) first, overlapping last.
+      // Within each partition, original order (worthItScore DESC) is preserved.
+      const nonOverlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) < 3);
+      const overlapping = withOverlap.filter((r) => (r.overlapCount ?? 0) >= 3);
+      overlapEnriched = [...nonOverlapping, ...overlapping];
+    } catch (err) {
+      console.error("Failed to compute topic overlap; returning recommendations without overlap data:", err);
+    }
+
+    return { episodes: overlapEnriched, error: null };
   } catch (error) {
     console.error("Error fetching episode recommendations:", error);
     return { episodes: [], error: "Failed to load recommendations" };
+  }
+}
+
+// Get topic overlap for a single episode — used by the episode detail page.
+export async function getEpisodeTopicOverlap(
+  podcastIndexEpisodeId: string
+): Promise<TopicOverlapResult> {
+  const nullResult: TopicOverlapResult = {
+    overlapCount: 0,
+    topOverlapTopic: null,
+    isNewTopic: false,
+    label: null,
+  };
+
+  const { userId } = await auth();
+  if (!userId) return nullResult;
+
+  try {
+    // Look up the DB episode by podcastIndexId to get its internal ID and topic rank
+    const episodeRow = await db
+      .select({
+        id: episodes.id,
+      })
+      .from(episodes)
+      .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
+      .limit(1);
+
+    if (episodeRow.length === 0) return nullResult;
+    const episodeDbId = episodeRow[0].id;
+
+    // Batch-query consumed episode IDs for profile construction
+    const consumedRows = await db
+      .select({ episodeId: listenHistory.episodeId })
+      .from(listenHistory)
+      .where(eq(listenHistory.userId, userId))
+      .union(
+        db
+          .select({ episodeId: userLibrary.episodeId })
+          .from(userLibrary)
+          .where(eq(userLibrary.userId, userId))
+      );
+
+    const totalConsumed = consumedRows.length;
+    const consumedIds = consumedRows.map((r) => r.episodeId);
+
+    let topicCountRows: Array<{ topic: string; count: number }> = [];
+    if (consumedIds.length > 0) {
+      topicCountRows = await db
+        .select({
+          topic: episodeTopics.topic,
+          count: sql<number>`COUNT(DISTINCT ${episodeTopics.episodeId})::integer`,
+        })
+        .from(episodeTopics)
+        .where(inArray(episodeTopics.episodeId, consumedIds))
+        .groupBy(episodeTopics.topic);
+    }
+
+    const userProfile = buildUserTopicProfile(topicCountRows);
+
+    // Fetch topics and best rank for this episode
+    const epTopicRows = await db
+      .select({
+        topic: episodeTopics.topic,
+        relevance: episodeTopics.relevance,
+        topicRank: episodeTopics.topicRank,
+      })
+      .from(episodeTopics)
+      .where(eq(episodeTopics.episodeId, episodeDbId));
+
+    const epTopics = epTopicRows.map((r) => ({ topic: r.topic, relevance: r.relevance }));
+    const bestRank = epTopicRows.reduce<number | null>((best, r) => {
+      if (r.topicRank === null) return best;
+      if (best === null) return r.topicRank;
+      return Math.min(best, r.topicRank);
+    }, null);
+
+    return computeTopicOverlap(userProfile, epTopics, totalConsumed, bestRank);
+  } catch (err) {
+    console.error("Failed to compute episode topic overlap:", err);
+    return nullResult;
   }
 }
 

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -27,6 +27,37 @@ import {
 // Maximum episodes to include per podcast for variety in the dashboard feed
 const MAX_EPISODES_PER_PODCAST = 3;
 
+/** Fetch consumed episode IDs and build the user's topic profile in 2 batch queries. */
+async function fetchUserTopicProfile(userId: string) {
+  const consumedRows = await db
+    .select({ episodeId: listenHistory.episodeId })
+    .from(listenHistory)
+    .where(eq(listenHistory.userId, userId))
+    .union(
+      db
+        .select({ episodeId: userLibrary.episodeId })
+        .from(userLibrary)
+        .where(eq(userLibrary.userId, userId))
+    );
+
+  const totalConsumed = consumedRows.length;
+  const consumedIds = consumedRows.map((r) => r.episodeId);
+
+  let topicCountRows: Array<{ topic: string; count: number }> = [];
+  if (consumedIds.length > 0) {
+    topicCountRows = await db
+      .select({
+        topic: episodeTopics.topic,
+        count: sql<number>`COUNT(DISTINCT ${episodeTopics.episodeId})::integer`,
+      })
+      .from(episodeTopics)
+      .where(inArray(episodeTopics.episodeId, consumedIds))
+      .groupBy(episodeTopics.topic);
+  }
+
+  return { profile: buildUserTopicProfile(topicCountRows), totalConsumed };
+}
+
 // Lightweight check for first-run detection — avoids loading full subscription data
 export async function hasAnySubscriptions(): Promise<boolean> {
   const { userId } = await auth();
@@ -273,38 +304,9 @@ export async function getRecommendedEpisodes(
       };
     });
 
-    // Overlap enrichment — batch query, no N+1. Wrapped in try/catch for graceful degradation.
     let overlapEnriched: RecommendedEpisodeDTO[] = baseEnriched;
     try {
-      // Batch-query all consumed episode IDs for this user
-      const consumedRows = await db
-        .select({ episodeId: listenHistory.episodeId })
-        .from(listenHistory)
-        .where(eq(listenHistory.userId, userId))
-        .union(
-          db
-            .select({ episodeId: userLibrary.episodeId })
-            .from(userLibrary)
-            .where(eq(userLibrary.userId, userId))
-        );
-
-      const totalConsumed = consumedRows.length;
-      const consumedIds = consumedRows.map((r) => r.episodeId);
-
-      // Batch-query topic counts for all consumed episodes
-      let topicCountRows: Array<{ topic: string; count: number }> = [];
-      if (consumedIds.length > 0) {
-        topicCountRows = await db
-          .select({
-            topic: episodeTopics.topic,
-            count: sql<number>`COUNT(DISTINCT ${episodeTopics.episodeId})::integer`,
-          })
-          .from(episodeTopics)
-          .where(inArray(episodeTopics.episodeId, consumedIds))
-          .groupBy(episodeTopics.topic);
-      }
-
-      const userProfile = buildUserTopicProfile(topicCountRows);
+      const { profile: userProfile, totalConsumed } = await fetchUserTopicProfile(userId);
 
       // Batch-query topics for all candidate episodes
       const candidateIds = baseEnriched.map((r) => r.id);
@@ -367,48 +369,20 @@ export async function getEpisodeTopicOverlap(
   if (!userId) return EMPTY_OVERLAP_RESULT;
 
   try {
-    // Look up the DB episode by podcastIndexId to get its internal ID
-    const episodeRow = await db
-      .select({
-        id: episodes.id,
-      })
-      .from(episodes)
-      .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
-      .limit(1);
+    // Parallelize: episode lookup and user profile construction are independent
+    const [episodeRow, profileResult] = await Promise.all([
+      db
+        .select({ id: episodes.id })
+        .from(episodes)
+        .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
+        .limit(1),
+      fetchUserTopicProfile(userId),
+    ]);
 
     if (episodeRow.length === 0) return EMPTY_OVERLAP_RESULT;
     const episodeDbId = episodeRow[0].id;
+    const { profile: userProfile, totalConsumed } = profileResult;
 
-    // Batch-query consumed episode IDs for profile construction
-    const consumedRows = await db
-      .select({ episodeId: listenHistory.episodeId })
-      .from(listenHistory)
-      .where(eq(listenHistory.userId, userId))
-      .union(
-        db
-          .select({ episodeId: userLibrary.episodeId })
-          .from(userLibrary)
-          .where(eq(userLibrary.userId, userId))
-      );
-
-    const totalConsumed = consumedRows.length;
-    const consumedIds = consumedRows.map((r) => r.episodeId);
-
-    let topicCountRows: Array<{ topic: string; count: number }> = [];
-    if (consumedIds.length > 0) {
-      topicCountRows = await db
-        .select({
-          topic: episodeTopics.topic,
-          count: sql<number>`COUNT(DISTINCT ${episodeTopics.episodeId})::integer`,
-        })
-        .from(episodeTopics)
-        .where(inArray(episodeTopics.episodeId, consumedIds))
-        .groupBy(episodeTopics.topic);
-    }
-
-    const userProfile = buildUserTopicProfile(topicCountRows);
-
-    // Fetch topics and best rank for this episode
     const epTopicRows = await db
       .select({
         topic: episodeTopics.topic,

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -319,7 +319,8 @@ export async function getRecommendedEpisodes(
             relevance: episodeTopics.relevance,
           })
           .from(episodeTopics)
-          .where(inArray(episodeTopics.episodeId, candidateIds));
+          .where(inArray(episodeTopics.episodeId, candidateIds))
+          .orderBy(desc(episodeTopics.relevance));
       }
 
       // Group candidate topics by episode
@@ -390,7 +391,8 @@ export async function getEpisodeTopicOverlap(
         topicRank: episodeTopics.topicRank,
       })
       .from(episodeTopics)
-      .where(eq(episodeTopics.episodeId, episodeDbId));
+      .where(eq(episodeTopics.episodeId, episodeDbId))
+      .orderBy(desc(episodeTopics.relevance));
 
     const epTopics = epTopicRows.map((r) => ({ topic: r.topic, relevance: r.relevance }));
     const bestRank = epTopicRows.reduce<number | null>((best, r) => {

--- a/src/components/dashboard/episode-recommendations.tsx
+++ b/src/components/dashboard/episode-recommendations.tsx
@@ -116,6 +116,17 @@ export function EpisodeRecommendations({ episodes }: EpisodeRecommendationsProps
                     )}
                   </span>
                 </div>
+                {episode.overlapLabel && (
+                  <p
+                    className={`mt-1 text-xs font-medium ${
+                      episode.overlapLabel.startsWith("You've heard")
+                        ? "text-amber-600 dark:text-amber-400"
+                        : "text-green-600 dark:text-green-400"
+                    }`}
+                  >
+                    {episode.overlapLabel}
+                  </p>
+                )}
               </div>
             </Link>
           ))}

--- a/src/components/dashboard/episode-recommendations.tsx
+++ b/src/components/dashboard/episode-recommendations.tsx
@@ -119,7 +119,7 @@ export function EpisodeRecommendations({ episodes }: EpisodeRecommendationsProps
                 {episode.overlapLabel && (
                   <p
                     className={`mt-1 text-xs font-medium ${
-                      episode.overlapLabel.startsWith("You've heard")
+                      episode.overlapLabelKind === "high-overlap"
                         ? "text-amber-600 dark:text-amber-400"
                         : "text-green-600 dark:text-green-400"
                     }`}

--- a/src/components/episodes/summary-display.tsx
+++ b/src/components/episodes/summary-display.tsx
@@ -31,6 +31,7 @@ interface SummaryDisplayProps {
   error?: string | null;
   currentStep?: SummarizationStep | null;
   onGenerateSummary?: () => void;
+  overlapLabel?: string | null;
 }
 
 const STEP_LABELS: Record<SummarizationStep, string> = {
@@ -99,6 +100,7 @@ export function SummaryDisplay({
   error = null,
   currentStep = null,
   onGenerateSummary,
+  overlapLabel,
 }: SummaryDisplayProps) {
   const [showFullSummary, setShowFullSummary] = useState(false);
 
@@ -279,6 +281,17 @@ export function SummaryDisplay({
                 <span>10</span>
               </div>
             </div>
+            {overlapLabel && (
+              <p
+                className={`mt-3 text-sm font-medium ${
+                  overlapLabel.startsWith("You've heard")
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-green-600 dark:text-green-400"
+                }`}
+              >
+                {overlapLabel}
+              </p>
+            )}
             {isSignalFormat && worthItDimensions.kind === "signals" && (
               <div className="mt-4 space-y-2 border-t pt-4">
                 <p className="text-sm font-medium text-foreground">Quality Signals</p>

--- a/src/components/episodes/summary-display.tsx
+++ b/src/components/episodes/summary-display.tsx
@@ -32,6 +32,7 @@ interface SummaryDisplayProps {
   currentStep?: SummarizationStep | null;
   onGenerateSummary?: () => void;
   overlapLabel?: string | null;
+  overlapLabelKind?: "high-overlap" | "top-pick" | "new-topic" | null;
 }
 
 const STEP_LABELS: Record<SummarizationStep, string> = {
@@ -101,6 +102,7 @@ export function SummaryDisplay({
   currentStep = null,
   onGenerateSummary,
   overlapLabel,
+  overlapLabelKind,
 }: SummaryDisplayProps) {
   const [showFullSummary, setShowFullSummary] = useState(false);
 
@@ -284,7 +286,7 @@ export function SummaryDisplay({
             {overlapLabel && (
               <p
                 className={`mt-3 text-sm font-medium ${
-                  overlapLabel.startsWith("You've heard")
+                  overlapLabelKind === "high-overlap"
                     ? "text-amber-600 dark:text-amber-400"
                     : "text-green-600 dark:text-green-400"
                 }`}

--- a/src/components/episodes/summary-display.tsx
+++ b/src/components/episodes/summary-display.tsx
@@ -18,6 +18,7 @@ import {
 import { getScoreColor, getScoreLabel } from "@/lib/score-utils";
 import { WORTH_IT_SIGNAL_KEYS, SIGNAL_LABELS, type WorthItDimensionsData } from "@/lib/openrouter";
 import type { SummarizationStep } from "@/trigger/types";
+import type { OverlapLabelKind } from "@/lib/topic-overlap";
 
 export type { SummarizationStep } from "@/trigger/types";
 
@@ -32,7 +33,7 @@ interface SummaryDisplayProps {
   currentStep?: SummarizationStep | null;
   onGenerateSummary?: () => void;
   overlapLabel?: string | null;
-  overlapLabelKind?: "high-overlap" | "top-pick" | "new-topic" | null;
+  overlapLabelKind?: OverlapLabelKind | null;
 }
 
 const STEP_LABELS: Record<SummarizationStep, string> = {

--- a/src/db/library-columns.ts
+++ b/src/db/library-columns.ts
@@ -1,5 +1,7 @@
 /** Shared column selections and DTO types for library/episode/podcast queries. */
 
+import { type OverlapLabelKind } from "@/lib/topic-overlap";
+
 // -- Column selection constants (Drizzle `columns` allowlist) --
 
 export const LIBRARY_ENTRY_COLUMNS = {
@@ -85,5 +87,5 @@ export interface RecommendedEpisodeDTO extends EpisodeListDTO {
   overlapCount?: number;
   overlapTopic?: string | null;
   overlapLabel?: string | null;
-  overlapLabelKind?: "high-overlap" | "top-pick" | "new-topic" | null;
+  overlapLabelKind?: OverlapLabelKind | null;
 }

--- a/src/db/library-columns.ts
+++ b/src/db/library-columns.ts
@@ -82,4 +82,7 @@ export interface RecommendedEpisodeDTO extends EpisodeListDTO {
   podcastImageUrl: string | null;
   bestTopicRank: number | null;
   topRankedTopic: string | null;
+  overlapCount?: number;
+  overlapTopic?: string | null;
+  overlapLabel?: string | null;
 }

--- a/src/db/library-columns.ts
+++ b/src/db/library-columns.ts
@@ -85,4 +85,5 @@ export interface RecommendedEpisodeDTO extends EpisodeListDTO {
   overlapCount?: number;
   overlapTopic?: string | null;
   overlapLabel?: string | null;
+  overlapLabelKind?: "high-overlap" | "top-pick" | "new-topic" | null;
 }

--- a/src/lib/__tests__/topic-overlap.test.ts
+++ b/src/lib/__tests__/topic-overlap.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { buildUserTopicProfile, computeTopicOverlap } from "@/lib/topic-overlap";
+
+describe("buildUserTopicProfile", () => {
+  it("returns an empty map for no rows", () => {
+    const profile = buildUserTopicProfile([]);
+    expect(profile.size).toBe(0);
+  });
+
+  it("aggregates topic counts from rows", () => {
+    const rows = [
+      { topic: "AI Ethics", count: 3 },
+      { topic: "Leadership", count: 1 },
+    ];
+    const profile = buildUserTopicProfile(rows);
+    expect(profile.get("AI Ethics")).toBe(3);
+    expect(profile.get("Leadership")).toBe(1);
+  });
+
+  it("handles multiple topics correctly", () => {
+    const rows = [
+      { topic: "Technology", count: 5 },
+      { topic: "Finance", count: 2 },
+      { topic: "Health", count: 10 },
+    ];
+    const profile = buildUserTopicProfile(rows);
+    expect(profile.size).toBe(3);
+    expect(profile.get("Health")).toBe(10);
+  });
+});
+
+describe("computeTopicOverlap", () => {
+  describe("global gate: totalConsumed < 3 → null for all labels", () => {
+    it("returns null label when totalConsumed is 0", () => {
+      const profile = new Map([["AI Ethics", 5]]);
+      const episodeTopics = [{ topic: "AI Ethics", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 0);
+      expect(result.label).toBeNull();
+      expect(result.isNewTopic).toBe(false);
+      expect(result.overlapCount).toBe(0);
+    });
+
+    it("returns null label when totalConsumed is 1", () => {
+      const profile = new Map([["AI Ethics", 1]]);
+      const episodeTopics = [{ topic: "AI Ethics", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 1);
+      expect(result.label).toBeNull();
+    });
+
+    it("returns null label when totalConsumed is 2", () => {
+      const profile = new Map([["AI Ethics", 2]]);
+      const episodeTopics = [{ topic: "AI Ethics", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 2);
+      expect(result.label).toBeNull();
+    });
+
+    it("blocks 'Top pick' label when totalConsumed < 3 even with topicRank === 1", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 2, 1);
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("high overlap: overlapCount >= 3", () => {
+    it("returns 'You've heard N similar episodes' when overlapCount >= 3", () => {
+      const profile = new Map([["AI Ethics", 4]]);
+      const episodeTopics = [{ topic: "AI Ethics", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      expect(result.overlapCount).toBe(4);
+      expect(result.topOverlapTopic).toBe("AI Ethics");
+      expect(result.label).toBe("You've heard 4 similar episodes");
+    });
+
+    it("returns amber label at exactly overlapCount = 3", () => {
+      const profile = new Map([["Finance", 3]]);
+      const episodeTopics = [{ topic: "Finance", relevance: "0.85" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 4);
+      expect(result.label).toBe("You've heard 3 similar episodes");
+    });
+
+    it("uses max count across multiple overlapping topics as overlapCount", () => {
+      const profile = new Map([
+        ["AI Ethics", 2],
+        ["Technology", 5],
+        ["Leadership", 1],
+      ]);
+      const episodeTopics = [
+        { topic: "AI Ethics", relevance: "0.90" },
+        { topic: "Technology", relevance: "0.80" },
+        { topic: "Leadership", relevance: "0.70" },
+      ];
+      const result = computeTopicOverlap(profile, episodeTopics, 10);
+      // overlapCount is the MAX count on the single most-overlapping topic
+      expect(result.overlapCount).toBe(5);
+      expect(result.topOverlapTopic).toBe("Technology");
+      expect(result.label).toBe("You've heard 5 similar episodes");
+    });
+  });
+
+  describe("top pick: topicRank === 1 and no overlap", () => {
+    it("returns 'Top pick for [topic]' when topicRank === 1 and overlapCount === 0 and totalConsumed >= 3", () => {
+      const profile = new Map([["Finance", 2]]); // user has Finance but this ep has Leadership
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 4, 1);
+      expect(result.overlapCount).toBe(0);
+      expect(result.label).toBe("Top pick for Leadership");
+    });
+
+    it("does NOT return 'Top pick' when topicRank === 1 but overlapCount >= 3", () => {
+      const profile = new Map([["Leadership", 4]]);
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 6, 1);
+      // overlap label takes priority
+      expect(result.label).toBe("You've heard 4 similar episodes");
+    });
+
+    it("does NOT return 'Top pick' when topicRank is not 1 (falls through to 'New topic' rule)", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5, 2);
+      // topicRank=2 → no top pick. overlapCount=0, totalConsumed=5 → "New topic for you"
+      expect(result.label).toBe("New topic for you");
+    });
+  });
+
+  describe("new topic: overlapCount === 0 and totalConsumed >= 5", () => {
+    it("returns 'New topic for you' when no overlap and totalConsumed >= 5", () => {
+      const profile = new Map([["Finance", 2]]); // different topic than episode
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 6);
+      expect(result.isNewTopic).toBe(true);
+      expect(result.label).toBe("New topic for you");
+    });
+
+    it("returns 'New topic for you' at exactly totalConsumed = 5", () => {
+      const profile = new Map<string, number>(); // empty profile
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      expect(result.label).toBe("New topic for you");
+    });
+
+    it("does NOT return 'New topic' when totalConsumed < 5 but >= 3", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 4);
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("episode with no topics", () => {
+    it("returns null label and zero overlapCount for episode with no topics", () => {
+      const profile = new Map([["AI Ethics", 5]]);
+      const result = computeTopicOverlap(profile, [], 10);
+      expect(result.overlapCount).toBe(0);
+      expect(result.topOverlapTopic).toBeNull();
+      expect(result.isNewTopic).toBe(false);
+      expect(result.label).toBeNull();
+    });
+
+    it("returns null label for no topics even when totalConsumed >= 5", () => {
+      const profile = new Map<string, number>();
+      const result = computeTopicOverlap(profile, [], 10);
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("empty user profile", () => {
+    it("returns 'New topic for you' for empty profile when totalConsumed >= 5", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Technology", relevance: "0.80" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      expect(result.overlapCount).toBe(0);
+      expect(result.isNewTopic).toBe(true);
+      expect(result.label).toBe("New topic for you");
+    });
+
+    it("returns null for empty profile when totalConsumed = 3 (below new-topic threshold)", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Technology", relevance: "0.80" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 3);
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("mixed overlap (some topics overlap, some don't)", () => {
+    it("computes overlapCount as max count on single most-overlapping topic, not count of distinct overlapping topics", () => {
+      const profile = new Map([
+        ["AI Ethics", 1],
+        ["Technology", 2],
+      ]);
+      const episodeTopics = [
+        { topic: "AI Ethics", relevance: "0.90" },
+        { topic: "Technology", relevance: "0.80" },
+        { topic: "Leadership", relevance: "0.60" }, // not in profile
+      ];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      // max count = 2 (Technology), NOT 3 (count of topics matched)
+      expect(result.overlapCount).toBe(2);
+      expect(result.topOverlapTopic).toBe("Technology");
+      // overlapCount < 3 → label depends on other rules
+      // totalConsumed >= 5 but overlapCount > 0 → not new topic, not overlap → null
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("otherwise → null", () => {
+    it("returns null label when totalConsumed >= 3, overlapCount between 1-2, not new topic", () => {
+      const profile = new Map([["AI Ethics", 2]]);
+      const episodeTopics = [{ topic: "AI Ethics", relevance: "0.90" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      expect(result.overlapCount).toBe(2);
+      expect(result.label).toBeNull();
+    });
+  });
+
+  describe("top pick: topicRank not provided", () => {
+    it("does not show top pick when topicRank is null", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5, null);
+      // no topicRank → no top pick, but new topic applies
+      expect(result.label).toBe("New topic for you");
+    });
+
+    it("does not show top pick when topicRank is undefined", () => {
+      const profile = new Map<string, number>();
+      const episodeTopics = [{ topic: "Leadership", relevance: "0.95" }];
+      const result = computeTopicOverlap(profile, episodeTopics, 5);
+      expect(result.label).toBe("New topic for you");
+    });
+  });
+});

--- a/src/lib/topic-overlap.ts
+++ b/src/lib/topic-overlap.ts
@@ -5,6 +5,18 @@
  * No DB calls, no auth — all inputs are passed in.
  */
 
+/** Minimum total consumed episodes before any overlap indicators are shown. */
+export const MIN_CONSUMED_FOR_INDICATORS = 3;
+
+/** Overlap count threshold for the "You've heard N similar episodes" label. */
+export const HIGH_OVERLAP_THRESHOLD = 3;
+
+/** Minimum total consumed episodes before the "New topic for you" label is shown. */
+export const MIN_CONSUMED_FOR_NEW_TOPIC = 5;
+
+/** Discriminator for the kind of overlap label, used to determine UI styling. */
+export type OverlapLabelKind = "high-overlap" | "top-pick" | "new-topic";
+
 /**
  * Result of a topic overlap computation.
  *
@@ -18,11 +30,26 @@ export interface TopicOverlapResult {
   overlapCount: number;
   /** The topic with the highest consumed count that matches this episode (null if none). */
   topOverlapTopic: string | null;
-  /** True when the episode has topics but none appear in the user's history. */
+  /**
+   * True when the episode has topics, none appear in the user's history,
+   * AND totalConsumed >= MIN_CONSUMED_FOR_NEW_TOPIC (enough history to be
+   * confident the topic is genuinely new).
+   */
   isNewTopic: boolean;
   /** Display label for the UI, or null when no indicator should be shown. */
   label: string | null;
+  /** Label kind for UI styling — avoids string-parsing the label text. */
+  labelKind: OverlapLabelKind | null;
 }
+
+/** Sentinel value for "no overlap data available." */
+export const EMPTY_OVERLAP_RESULT: TopicOverlapResult = Object.freeze({
+  overlapCount: 0,
+  topOverlapTopic: null,
+  isNewTopic: false,
+  label: null,
+  labelKind: null,
+});
 
 /** A row from the `episode_topics` table (only the fields we need). */
 export interface EpisodeTopicRow {
@@ -52,10 +79,11 @@ export function buildUserTopicProfile(rows: TopicCountRow[]): Map<string, number
  * Compute topic overlap between a user's consumption history and a candidate episode.
  *
  * Label priority (first match wins):
- * 1. totalConsumed < 3 → null (global gate — no indicators shown)
- * 2. overlapCount >= 3 → "You've heard N similar episodes" (amber)
- * 3. topicRank === 1 && overlapCount === 0 → "Top pick for [topic]" (green)
- * 4. overlapCount === 0 && totalConsumed >= 5 → "New topic for you" (green)
+ * 0. episodeTopics is empty → null (no topics to compare)
+ * 1. totalConsumed < MIN_CONSUMED_FOR_INDICATORS → null (global gate — no indicators shown)
+ * 2. overlapCount >= HIGH_OVERLAP_THRESHOLD → "You've heard N similar episodes" (high-overlap)
+ * 3. topicRank === 1 && overlapCount === 0 → "Top pick for [first topic]" (top-pick)
+ * 4. overlapCount === 0 && totalConsumed >= MIN_CONSUMED_FOR_NEW_TOPIC → "New topic for you" (new-topic)
  * 5. otherwise → null
  *
  * @param userProfile - Map of topic → consumed-episode count (from buildUserTopicProfile)
@@ -69,14 +97,14 @@ export function computeTopicOverlap(
   totalConsumed: number,
   topicRank?: number | null
 ): TopicOverlapResult {
-  // Global gate: fewer than 3 consumed episodes → no indicators at all
-  if (totalConsumed < 3) {
-    return { overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null };
+  // Global gate: fewer than MIN_CONSUMED_FOR_INDICATORS consumed episodes → no indicators at all
+  if (totalConsumed < MIN_CONSUMED_FOR_INDICATORS) {
+    return EMPTY_OVERLAP_RESULT;
   }
 
   // No topics on this episode → no indicator
   if (episodeTopics.length === 0) {
-    return { overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null };
+    return EMPTY_OVERLAP_RESULT;
   }
 
   // Find the single topic with the highest consumed count
@@ -90,15 +118,14 @@ export function computeTopicOverlap(
     }
   }
 
-  // Rule 1 (global gate) already handled above.
-
   // Rule 2: high overlap
-  if (overlapCount >= 3) {
+  if (overlapCount >= HIGH_OVERLAP_THRESHOLD) {
     return {
       overlapCount,
       topOverlapTopic,
       isNewTopic: false,
       label: `You've heard ${overlapCount} similar episodes`,
+      labelKind: "high-overlap",
     };
   }
 
@@ -111,19 +138,21 @@ export function computeTopicOverlap(
       topOverlapTopic: null,
       isNewTopic: false,
       label: `Top pick for ${labelTopic}`,
+      labelKind: "top-pick",
     };
   }
 
   // Rule 4: new topic (no overlap, enough history to be confident)
-  if (overlapCount === 0 && totalConsumed >= 5) {
+  if (overlapCount === 0 && totalConsumed >= MIN_CONSUMED_FOR_NEW_TOPIC) {
     return {
       overlapCount: 0,
       topOverlapTopic: null,
       isNewTopic: true,
       label: "New topic for you",
+      labelKind: "new-topic",
     };
   }
 
   // Rule 5: no label
-  return { overlapCount, topOverlapTopic, isNewTopic: false, label: null };
+  return { overlapCount, topOverlapTopic, isNewTopic: false, label: null, labelKind: null };
 }

--- a/src/lib/topic-overlap.ts
+++ b/src/lib/topic-overlap.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure utility functions for computing topic overlap between a user's
+ * consumption history and a candidate episode's topics.
+ *
+ * No DB calls, no auth — all inputs are passed in.
+ */
+
+/**
+ * Result of a topic overlap computation.
+ *
+ * `overlapCount` is the max consumed-episode count on the **single** most-overlapping
+ * topic, NOT the count of distinct overlapping topics. For example, if the user has
+ * consumed 3 "AI Ethics" episodes and 2 "Technology" episodes, and the candidate
+ * episode covers both, `overlapCount` is 3 (from "AI Ethics").
+ */
+export interface TopicOverlapResult {
+  /** Max consumed-episode count on the single most-overlapping topic (0 if none). */
+  overlapCount: number;
+  /** The topic with the highest consumed count that matches this episode (null if none). */
+  topOverlapTopic: string | null;
+  /** True when the episode has topics but none appear in the user's history. */
+  isNewTopic: boolean;
+  /** Display label for the UI, or null when no indicator should be shown. */
+  label: string | null;
+}
+
+/** A row from the `episode_topics` table (only the fields we need). */
+export interface EpisodeTopicRow {
+  topic: string;
+  relevance: string;
+}
+
+/** A row from the batch topic-count query. */
+export interface TopicCountRow {
+  topic: string;
+  count: number;
+}
+
+/**
+ * Aggregate raw topic-count query rows into a profile map.
+ * Maps topic → number of distinct consumed episodes tagged with that topic.
+ */
+export function buildUserTopicProfile(rows: TopicCountRow[]): Map<string, number> {
+  const profile = new Map<string, number>();
+  for (const row of rows) {
+    profile.set(row.topic, row.count);
+  }
+  return profile;
+}
+
+/**
+ * Compute topic overlap between a user's consumption history and a candidate episode.
+ *
+ * Label priority (first match wins):
+ * 1. totalConsumed < 3 → null (global gate — no indicators shown)
+ * 2. overlapCount >= 3 → "You've heard N similar episodes" (amber)
+ * 3. topicRank === 1 && overlapCount === 0 → "Top pick for [topic]" (green)
+ * 4. overlapCount === 0 && totalConsumed >= 5 → "New topic for you" (green)
+ * 5. otherwise → null
+ *
+ * @param userProfile - Map of topic → consumed-episode count (from buildUserTopicProfile)
+ * @param episodeTopics - Topics tagged on the candidate episode
+ * @param totalConsumed - Total number of episodes the user has consumed (listen_history UNION user_library)
+ * @param topicRank - The episode's best topic rank (1 = trending #1), or null/undefined if unranked
+ */
+export function computeTopicOverlap(
+  userProfile: Map<string, number>,
+  episodeTopics: EpisodeTopicRow[],
+  totalConsumed: number,
+  topicRank?: number | null
+): TopicOverlapResult {
+  // Global gate: fewer than 3 consumed episodes → no indicators at all
+  if (totalConsumed < 3) {
+    return { overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null };
+  }
+
+  // No topics on this episode → no indicator
+  if (episodeTopics.length === 0) {
+    return { overlapCount: 0, topOverlapTopic: null, isNewTopic: false, label: null };
+  }
+
+  // Find the single topic with the highest consumed count
+  let overlapCount = 0;
+  let topOverlapTopic: string | null = null;
+  for (const { topic } of episodeTopics) {
+    const count = userProfile.get(topic) ?? 0;
+    if (count > overlapCount) {
+      overlapCount = count;
+      topOverlapTopic = topic;
+    }
+  }
+
+  // Rule 1 (global gate) already handled above.
+
+  // Rule 2: high overlap
+  if (overlapCount >= 3) {
+    return {
+      overlapCount,
+      topOverlapTopic,
+      isNewTopic: false,
+      label: `You've heard ${overlapCount} similar episodes`,
+    };
+  }
+
+  // Rule 3: top pick (only when no overlap)
+  if (topicRank === 1 && overlapCount === 0) {
+    // Use the first topic as the label topic (most relevant by convention)
+    const labelTopic = episodeTopics[0].topic;
+    return {
+      overlapCount: 0,
+      topOverlapTopic: null,
+      isNewTopic: false,
+      label: `Top pick for ${labelTopic}`,
+    };
+  }
+
+  // Rule 4: new topic (no overlap, enough history to be confident)
+  if (overlapCount === 0 && totalConsumed >= 5) {
+    return {
+      overlapCount: 0,
+      topOverlapTopic: null,
+      isNewTopic: true,
+      label: "New topic for you",
+    };
+  }
+
+  // Rule 5: no label
+  return { overlapCount, topOverlapTopic, isNewTopic: false, label: null };
+}


### PR DESCRIPTION
## Summary

- Adds display-only topic overlap indicators that personalize episode recommendations using the user's consumption history (listen history + saved episodes)
- Shows contextual labels: "You've heard N similar episodes" (amber), "New topic for you" (green), "Top pick for [topic]" (green) — gated by a 3-episode minimum
- Deprioritizes heavily-consumed topics in recommendations via stable partition sort (sort adjustment, not filter)
- Pure function pattern (`src/lib/topic-overlap.ts`) with batch queries (no N+1), stored `worth_it_score` is never modified

### Architecture
- **New**: `src/lib/topic-overlap.ts` — pure overlap computation (24 unit tests)
- **New**: `docs/adr/034-personal-topic-overlap-indicators.md`
- **Modified**: `dashboard.ts` — user topic profile construction, overlap enrichment, sort adjustment, `getEpisodeTopicOverlap()` action
- **Modified**: `episode-recommendations.tsx`, `summary-display.tsx`, episode page — overlap label rendering

Closes #262

## Test plan

- [x] `bun run lint` — no warnings or errors
- [x] `bun run test` — 1620/1620 tests pass (132 files), including 24 new overlap unit tests and 16 new dashboard integration tests
- [x] `bun run build` — compiles successfully
- [ ] Manual: verify overlap indicators appear for users with listen history on recommendations
- [ ] Manual: verify episode detail page shows overlap label via non-blocking useEffect
- [ ] Manual: verify users with <3 consumed episodes see no indicators
- [ ] Manual: verify episodes without topic tags show no indicator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalized topic-overlap indicators added to recommendation cards and episode summary; labels highlight high-overlap, top-pick, or new-topic status.
  * Recommendation lists are stably reordered to deprioritize heavily-consumed topics.

* **Documentation**
  * Added design/ADR and changelog entries describing the display-only indicator behavior and gating rules.

* **Tests**
  * New unit and integration tests covering overlap computation, labeling rules, ordering, and graceful fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->