### PR TITLE
chore: replace code-review plugin with ci-review multi-agent system

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -23,66 +17,36 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # Full history — required for git blame
 
-      - name: Run Claude Code Review
+      - name: Compute review flags
+        id: flags
+        env:
+          PR_ACTION: ${{ github.event.action }}
+        run: |
+          if [[ "$PR_ACTION" == "synchronize" ]]; then
+            echo "review_flags=--single" >> "$GITHUB_OUTPUT"
+          else
+            echo "review_flags=--agent" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run CI Review
         id: claude-review
-        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true # ✨ Enables tracking comments
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          track_progress: true
+          plugin_marketplaces: 'https://github.com/rube-de/cc-skills.git'
           plugins: |
-            code-review@claude-code-plugins
+            ci-review@rube-cc-skills
           prompt: |
-            /code-review:code-review
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Perform a comprehensive code review with the following focus areas:
-
-            1. **Code Quality**
-               - Clean code principles and best practices
-               - Proper error handling and edge cases
-               - Code readability and maintainability
-
-            2. **Security**
-               - Check for potential security vulnerabilities
-               - Validate input sanitization
-               - Review authentication/authorization logic
-
-            3. **Performance**
-               - Identify potential performance bottlenecks
-               - Review database queries for efficiency
-               - Check for memory leaks or resource issues
-
-            4. **Testing**
-               - Verify adequate test coverage
-               - Review test quality and edge cases
-               - Check for missing test scenarios
-
-            5. **Documentation**
-               - Ensure code is properly documented
-               - Verify README updates for new features
-               - Check API documentation accuracy
-
-            Note: The PR branch is already checked out in the current working directory.
-
-            Submit all feedback as a single atomic GitHub review:
-            1. Create a pending review with `mcp__github__pull_request_review_write` (method: "create", no event).
-            2. Add inline comments with `mcp__github__add_comment_to_pending_review` (path, line, body).
-            3. Submit the review with `mcp__github__pull_request_review_write` (method: "submit_pending", event: "COMMENT", body: summary).
-            IMPORTANT: Never use event "APPROVE" or "REQUEST_CHANGES" — always use "COMMENT".
-            Only post GitHub review comments — don't submit review text as messages.
-
+            /ci-review ${{ github.event.pull_request.number }} ${{ steps.flags.outputs.review_flags }}
           claude_args: |
-            --allowedTools "mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review,Bash(gh pr diff:*),Bash(gh pr view:*)"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+            --allowedTools "Read,Grep,Glob,Agent,Bash(gh auth status:*),Bash(gh pr:*),Bash(gh repo view:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git blame:*),Bash(jq:*),Bash(echo:*),Bash(cat:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
           plugin_marketplaces: 'https://github.com/rube-de/cc-skills.git'
           plugins: |
             ci-review@rube-cc-skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,9 @@ Podcast discovery, AI-powered summarization, and library management for busy pro
 
 ## Workflow
 
-- Before planning any work, always pull the latest `main` (`git fetch upstream && git merge upstream/main` or equivalent).
+- Before planning any work, always sync with `main` (`git fetch origin main && git rebase origin/main`). This works in worktrees and on feature branches with in-progress work.
 - Before editing any code, always create a new branch from an up-to-date `main`.
-- This is a fork. Remotes: `origin` = `rube-de/contentgenie`, `upstream` = `Chalet-Labs/contentgenie`.
-- Push feature branches to `upstream` and open PRs against `upstream/main`.
+- Push feature branches to `origin` and open PRs against `main`.
 
 ## Dev environment tips
 


### PR DESCRIPTION
## Summary

- Replace Anthropic's single-agent `code-review@claude-code-plugins` with `ci-review@rube-cc-skills` multi-agent review system (9 specialized agents, confidence scoring, deduplication, 3-tier error recovery)
- Use `--agent` profile on PR open, `--single` on push for cost-effective incremental reviews
- Switch from MCP GitHub tools to `gh api` for review posting
- Bump checkout action to v6, enable full git history for `git blame`
- Remove stale fork references from AGENTS.md (both remotes point to same repo)

## Test plan

- [ ] Open a test PR and verify `--agent` profile runs (9 agents in CI logs)
- [ ] Push a commit to same PR and verify `--single` profile runs (1 agent)
- [ ] Verify review is posted as atomic GitHub PR review with inline comments
- [ ] Check CI logs for: `gh auth status` pass, scoring stats, review URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration and action dependencies.
  * Refreshed developer contribution guidelines and repository workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->