### PR TITLE
fix: close mobile sidebar menu on nav item tap

### DIFF
--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import { Header } from "@/components/layout/header"
 import React from "react"
 
@@ -74,13 +74,24 @@ vi.mock("@/components/ui/sheet", () => {
 
   const SheetClose = ({
     children,
+    asChild,
   }: {
     children: React.ReactNode
     asChild?: boolean
   }) => {
     const { setOpen } = useContext(SheetStateContext)
+    const close = () => setOpen(false)
+    if (asChild && React.isValidElement(children)) {
+      const child = children as React.ReactElement<{ onClick?: (e: unknown) => void }>
+      return React.cloneElement(child, {
+        onClick: (e: unknown) => {
+          child.props.onClick?.(e)
+          close()
+        },
+      })
+    }
     return (
-      <div data-testid="sheet-close" onClick={() => setOpen(false)}>
+      <div data-testid="sheet-close" onClick={close}>
         {children}
       </div>
     )
@@ -128,8 +139,7 @@ describe("Header mobile menu — sheet closes on nav tap (regression #276)", () 
     const sheetContent = screen.getByTestId("sheet-content")
     expect(sheetContent).toBeInTheDocument()
 
-    // Click a nav link inside the sheet (scope to avoid matching the desktop nav)
-    const dashboardLink = sheetContent.querySelector("a[href='/dashboard']")!
+    const dashboardLink = within(sheetContent).getByRole("link", { name: /dashboard/i })
     fireEvent.click(dashboardLink)
 
     // The sheet must close — sheet-content should no longer be in the DOM

--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import { Header } from "@/components/layout/header"
+import React from "react"
 
 const mockUseSidebarCounts = vi.fn()
 vi.mock("@/contexts/sidebar-counts-context", () => ({
@@ -32,14 +33,74 @@ vi.mock("@/components/notifications/notification-bell", () => ({
   NotificationBell: () => null,
 }))
 
-// shadcn Sheet — render SheetContent inline so mobile nav is visible in tests
-vi.mock("@/components/ui/sheet", () => ({
-  Sheet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SheetTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SheetContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="sheet-content">{children}</div>
-  ),
-}))
+// shadcn Sheet — stateful mock so open/close behaviour can be asserted.
+// Sheet owns internal useState; SheetTrigger opens it, SheetClose closes it.
+// SheetContent renders only when open. This mirrors real Radix Dialog behaviour.
+vi.mock("@/components/ui/sheet", () => {
+  const { useState, createContext, useContext } = require("react") as typeof React
+
+  const SheetStateContext = createContext<{
+    open: boolean
+    setOpen: (v: boolean) => void
+  }>({ open: true, setOpen: () => {} })
+
+  const Sheet = ({
+    children,
+    open: controlledOpen,
+    onOpenChange,
+  }: {
+    children: React.ReactNode
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    const [internalOpen, setInternalOpen] = useState(false)
+    const isOpen = controlledOpen !== undefined ? controlledOpen : internalOpen
+    const setOpen = (v: boolean) => {
+      setInternalOpen(v)
+      onOpenChange?.(v)
+    }
+    return (
+      <SheetStateContext.Provider value={{ open: isOpen, setOpen }}>
+        {children}
+      </SheetStateContext.Provider>
+    )
+  }
+
+  const SheetTrigger = ({
+    children,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => {
+    const { setOpen } = useContext(SheetStateContext)
+    return (
+      <div data-testid="sheet-trigger" onClick={() => setOpen(true)}>
+        {children}
+      </div>
+    )
+  }
+
+  const SheetContent = ({ children }: { children: React.ReactNode }) => {
+    const { open } = useContext(SheetStateContext)
+    return open ? <div data-testid="sheet-content">{children}</div> : null
+  }
+
+  const SheetClose = ({
+    children,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => {
+    const { setOpen } = useContext(SheetStateContext)
+    return (
+      <div data-testid="sheet-close" onClick={() => setOpen(false)}>
+        {children}
+      </div>
+    )
+  }
+
+  return { Sheet, SheetTrigger, SheetContent, SheetClose }
+})
 
 vi.mock("@/components/ui/button", () => ({
   Button: ({ children, ...rest }: { children: React.ReactNode; [key: string]: unknown }) => (
@@ -60,6 +121,35 @@ vi.mock("@/components/ui/separator", () => ({
   Separator: () => <hr />,
 }))
 
+describe("Header mobile menu — sheet closes on nav tap (regression #276)", () => {
+  beforeEach(() => {
+    mockUseSidebarCounts.mockReturnValue({
+      subscriptionCount: 0,
+      savedCount: 0,
+      isLoading: false,
+    })
+  })
+
+  it("closes the sheet when a nav link inside the mobile menu is tapped", () => {
+    render(<Header />)
+
+    // Open the sheet by clicking the hamburger trigger
+    const trigger = screen.getByTestId("sheet-trigger")
+    fireEvent.click(trigger)
+
+    // Sheet should now be open and show nav content
+    const sheetContent = screen.getByTestId("sheet-content")
+    expect(sheetContent).toBeInTheDocument()
+
+    // Click a nav link inside the sheet (scope to avoid matching the desktop nav)
+    const dashboardLink = sheetContent.querySelector("a[href='/dashboard']")!
+    fireEvent.click(dashboardLink)
+
+    // The sheet must close — sheet-content should no longer be in the DOM
+    expect(screen.queryByTestId("sheet-content")).not.toBeInTheDocument()
+  })
+})
+
 describe("Header mobile menu", () => {
   beforeEach(() => {
     mockUseSidebarCounts.mockReturnValue({
@@ -77,6 +167,7 @@ describe("Header mobile menu", () => {
     })
 
     render(<Header />)
+    fireEvent.click(screen.getByTestId("sheet-trigger"))
 
     const sheet = screen.getByTestId("sheet-content")
     const links = sheet.querySelectorAll("a")
@@ -96,6 +187,7 @@ describe("Header mobile menu", () => {
     })
 
     render(<Header />)
+    fireEvent.click(screen.getByTestId("sheet-trigger"))
 
     const sheet = screen.getByTestId("sheet-content")
     const links = sheet.querySelectorAll("a")
@@ -115,6 +207,7 @@ describe("Header mobile menu", () => {
     })
 
     render(<Header />)
+    fireEvent.click(screen.getByTestId("sheet-trigger"))
 
     const sheet = screen.getByTestId("sheet-content")
     const links = sheet.querySelectorAll("a")
@@ -138,6 +231,7 @@ describe("Header mobile menu", () => {
     })
 
     render(<Header />)
+    fireEvent.click(screen.getByTestId("sheet-trigger"))
 
     const sheet = screen.getByTestId("sheet-content")
     const links = sheet.querySelectorAll("a")

--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -42,25 +42,12 @@ vi.mock("@/components/ui/sheet", () => {
   const SheetStateContext = createContext<{
     open: boolean
     setOpen: (v: boolean) => void
-  }>({ open: true, setOpen: () => {} })
+  }>({ open: false, setOpen: () => {} })
 
-  const Sheet = ({
-    children,
-    open: controlledOpen,
-    onOpenChange,
-  }: {
-    children: React.ReactNode
-    open?: boolean
-    onOpenChange?: (open: boolean) => void
-  }) => {
-    const [internalOpen, setInternalOpen] = useState(false)
-    const isOpen = controlledOpen !== undefined ? controlledOpen : internalOpen
-    const setOpen = (v: boolean) => {
-      setInternalOpen(v)
-      onOpenChange?.(v)
-    }
+  const Sheet = ({ children }: { children: React.ReactNode }) => {
+    const [open, setOpen] = useState(false)
     return (
-      <SheetStateContext.Provider value={{ open: isOpen, setOpen }}>
+      <SheetStateContext.Provider value={{ open, setOpen }}>
         {children}
       </SheetStateContext.Provider>
     )

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { Sheet, SheetClose, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Separator } from "@/components/ui/separator"
 import { Menu, Moon, Sun, Headphones } from "lucide-react"
 import { NotificationBell } from "@/components/notifications/notification-bell"
@@ -51,23 +51,26 @@ export function Header() {
                 const badge = getBadgeCount(link.href, counts)
 
                 return (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="flex items-center px-3 py-3 text-sm font-medium rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-                  >
-                    {link.label}
-                    {badge !== null && <NavBadge count={badge} />}
-                  </Link>
+                  <SheetClose key={link.href} asChild>
+                    <Link
+                      href={link.href}
+                      className="flex items-center px-3 py-3 text-sm font-medium rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+                    >
+                      {link.label}
+                      {badge !== null && <NavBadge count={badge} />}
+                    </Link>
+                  </SheetClose>
                 )
               })}
               <Separator className="my-2" />
-              <Link
-                href="/settings"
-                className="flex items-center px-3 py-3 text-sm font-medium rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
-                Settings
-              </Link>
+              <SheetClose asChild>
+                <Link
+                  href="/settings"
+                  className="flex items-center px-3 py-3 text-sm font-medium rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+                >
+                  Settings
+                </Link>
+              </SheetClose>
               <Separator className="my-2" />
               <OrganizationSwitcher
                 hidePersonal={false}


### PR DESCRIPTION
## Summary
- Wraps each mobile nav `<Link>` (the four `navLinks` entries + standalone `/settings`) in `src/components/layout/header.tsx` with `<SheetClose asChild>` so activating the link also fires Radix Dialog's close action.
- Adds a regression test with an upgraded stateful `Sheet` mock that asserts the sheet content is removed from the DOM after a nav link click.
- OrganizationSwitcher is intentionally left unwrapped (its existing `afterSelectOrganizationUrl` redirect behavior is preserved).

**Root cause:** The mobile `Sheet` is uncontrolled; plain `<Link>` clicks trigger client-side navigation but never signal Radix Dialog to close, so the overlay stayed open after route change.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun run test` — all suites green (new regression test + existing 4 header tests pass)
- [ ] Manual mobile check (Chrome DevTools 390×844): open hamburger → tap each nav entry → sheet closes and route changes in one tap
- [ ] Verify desktop nav (≥ 768px) unchanged
- [ ] Verify Esc / tap-outside still dismiss the sheet

## Follow-up (out of scope for this PR)
- `src/components/library/library-sidebar.tsx` has the same class of bug for collection `<Link>` items inside its mobile Sheet — worth a separate issue/PR.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Mobile navigation menu now closes when you click on a navigation link or settings option, providing a smoother user experience on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->