### PR TITLE
feat: Add slug field to TrendingTopic and generate in trigger task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Admin link in sidebar (visible to `org:admin` users only)
 
 ### Changed
+- Trending topic snapshots now include a stable `slug` per topic, used as the URL identifier for topic detail pages.
 - Replace 3-dimension numeric worth-it scoring with boolean signal hybrid (8 yes/no quality signals + ±1 adjustment) for more stable, interpretable episode scores (#260)
 - Score and status badge components migrated from hardcoded Tailwind colors to semantic design tokens (#256)
 - Empty state icons standardized to consistent `rounded-full bg-muted p-3` container pattern across 7 components (#256)

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -16,6 +16,7 @@ function makeTopic(overrides: Partial<TrendingTopic> = {}): TrendingTopic {
     description: "A test topic description",
     episodeCount: 5,
     episodeIds: [1, 2, 3, 4, 5],
+    slug: "test-topic",
     ...overrides,
   }
 }

--- a/src/components/dashboard/trending-topics.stories.tsx
+++ b/src/components/dashboard/trending-topics.stories.tsx
@@ -8,29 +8,29 @@ import { STORY_TWO_HOURS_AGO, STORY_THIRTY_MIN_AGO } from "@/test/story-fixtures
 // ---------------------------------------------------------------------------
 
 const baseTopics: TrendingTopic[] = [
-  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [] },
-  { name: "Climate Policy", description: "", episodeCount: 8, episodeIds: [] },
-  { name: "Startup Funding", description: "", episodeCount: 5, episodeIds: [] },
-  { name: "Remote Work", description: "", episodeCount: 9, episodeIds: [] },
-  { name: "Mental Health", description: "", episodeCount: 7, episodeIds: [] },
-  { name: "Cryptocurrency", description: "", episodeCount: 3, episodeIds: [] },
+  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
+  { name: "Climate Policy", description: "", episodeCount: 8, episodeIds: [], slug: "climate-policy" },
+  { name: "Startup Funding", description: "", episodeCount: 5, episodeIds: [], slug: "startup-funding" },
+  { name: "Remote Work", description: "", episodeCount: 9, episodeIds: [], slug: "remote-work" },
+  { name: "Mental Health", description: "", episodeCount: 7, episodeIds: [], slug: "mental-health" },
+  { name: "Cryptocurrency", description: "", episodeCount: 3, episodeIds: [], slug: "cryptocurrency" },
 ]
 
 const singleTopic: TrendingTopic[] = [
-  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [] },
+  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
 ]
 
 const maxTopics: TrendingTopic[] = [
   ...baseTopics,
-  { name: "Supply Chain", description: "", episodeCount: 4, episodeIds: [] },
-  { name: "Space Exploration", description: "", episodeCount: 6, episodeIds: [] },
+  { name: "Supply Chain", description: "", episodeCount: 4, episodeIds: [], slug: "supply-chain" },
+  { name: "Space Exploration", description: "", episodeCount: 6, episodeIds: [], slug: "space-exploration" },
 ]
 
 const longNameTopics: TrendingTopic[] = [
-  { name: "The Impact of Large Language Models on Enterprise Software Development", description: "", episodeCount: 11, episodeIds: [] },
-  { name: "Decentralized Finance", description: "", episodeCount: 7, episodeIds: [] },
-  { name: "Quantum Computing Breakthroughs and Near-Term Commercial Applications", description: "", episodeCount: 4, episodeIds: [] },
-  { name: "Climate Tech", description: "", episodeCount: 9, episodeIds: [] },
+  { name: "The Impact of Large Language Models on Enterprise Software Development", description: "", episodeCount: 11, episodeIds: [], slug: "the-impact-of-large-language-models-on-enterprise-software-development" },
+  { name: "Decentralized Finance", description: "", episodeCount: 7, episodeIds: [], slug: "decentralized-finance" },
+  { name: "Quantum Computing Breakthroughs and Near-Term Commercial Applications", description: "", episodeCount: 4, episodeIds: [], slug: "quantum-computing-breakthroughs-and-near-term-commercial-applications" },
+  { name: "Climate Tech", description: "", episodeCount: 9, episodeIds: [], slug: "climate-tech" },
 ]
 
 const twoHoursAgo = STORY_TWO_HOURS_AGO

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -519,6 +519,7 @@ export interface TrendingTopic {
   description: string;
   episodeCount: number;
   episodeIds: number[];
+  slug: string;
 }
 
 export type TrendingTopicsRow = typeof trendingTopics.$inferSelect;

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cn, stripHtml, formatDate, formatDuration } from "@/lib/utils";
+import { cn, stripHtml, formatDate, formatDuration, slugify } from "@/lib/utils";
 
 describe("cn", () => {
   it("merges class names", () => {
@@ -100,5 +100,70 @@ describe("formatDate", () => {
   it("handles null/undefined", () => {
     expect(formatDate(null)).toBe("");
     expect(formatDate(undefined)).toBe("");
+  });
+});
+
+describe("slugify", () => {
+  it("handles basic alphanumeric with special chars", () => {
+    expect(slugify("AI Models & Capabilities")).toBe("ai-models-capabilities");
+  });
+
+  it("handles slashes and em-dashes", () => {
+    expect(slugify("Crypto/Blockchain — On-chain")).toBe("crypto-blockchain-on-chain");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(slugify("   ")).toBe("");
+  });
+
+  it("returns empty string for all-punctuation input", () => {
+    expect(slugify("!!!")).toBe("");
+  });
+
+  it("strips diacritics via NFKD normalization", () => {
+    expect(slugify("Café Français")).toBe("cafe-francais");
+  });
+
+  it("strips diacritics on mixed accent chars", () => {
+    expect(slugify("Naïve résumé")).toBe("naive-resume");
+  });
+
+  it("trims and collapses whitespace", () => {
+    expect(slugify("  Hello  World  ")).toBe("hello-world");
+  });
+
+  it("collapses runs of non-alnum to single hyphen", () => {
+    expect(slugify("a--b---c")).toBe("a-b-c");
+  });
+
+  it("is idempotent on already-slugged input", () => {
+    expect(slugify("already-slugged")).toBe("already-slugged");
+  });
+
+  it("handles underscores and mixed case with digits", () => {
+    expect(slugify("UPPER_case_123")).toBe("upper-case-123");
+  });
+
+  it("is idempotent for all non-empty samples", () => {
+    const samples = [
+      "AI Models & Capabilities",
+      "Crypto/Blockchain — On-chain",
+      "Café Français",
+      "Naïve résumé",
+      "  Hello  World  ",
+      "a--b---c",
+      "already-slugged",
+      "UPPER_case_123",
+    ];
+    for (const s of samples) {
+      const once = slugify(s);
+      if (once !== "") {
+        expect(slugify(once)).toBe(once);
+      }
+    }
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,3 +44,12 @@ export function formatDate(date: Date | string | number | null | undefined): str
     day: "numeric",
   });
 }
+
+export function slugify(name: string): string {
+  return name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/trigger/__tests__/generate-trending-topics.test.ts
+++ b/src/trigger/__tests__/generate-trending-topics.test.ts
@@ -184,7 +184,16 @@ describe("generate-trending-topics task", () => {
     ]);
     expect(mockValues).toHaveBeenCalledWith(
       expect.objectContaining({
-        topics: mockTopics,
+        topics: [
+          expect.objectContaining({
+            name: "AI & Machine Learning",
+            slug: "ai-machine-learning",
+          }),
+          expect.objectContaining({
+            name: "Leadership",
+            slug: "leadership",
+          }),
+        ],
         episodeCount: 3,
       })
     );
@@ -242,6 +251,7 @@ describe("generate-trending-topics task", () => {
             name: "Valid Topic",
             episodeIds: [1, 2],
             episodeCount: 2,
+            slug: "valid-topic",
           }),
         ],
       })
@@ -336,9 +346,143 @@ describe("generate-trending-topics task", () => {
             name: "Mixed Topic",
             episodeIds: [1, 2],
             episodeCount: 2,
+            slug: "mixed-topic",
           }),
         ],
       })
     );
+  });
+
+  it("every persisted topic has a non-empty slug in clamped results", async () => {
+    const episodeRows = Array.from({ length: 20 }, (_, i) => ({
+      id: i + 1,
+      title: `Episode ${i + 1}`,
+      keyTakeaways: [`Takeaway ${i + 1}`],
+    }));
+    mockDbSelect(episodeRows);
+
+    const mockTopics = Array.from({ length: 12 }, (_, i) => ({
+      name: `Topic ${i + 1}`,
+      description: `Description ${i + 1}`,
+      episodeCount: i + 1,
+      episodeIds: Array.from({ length: i + 1 }, (_, j) => j + 1),
+    }));
+
+    mockGenerateCompletion.mockResolvedValue("mock completion");
+    mockParseJsonResponse.mockReturnValue({ topics: mockTopics });
+
+    await taskConfig.run();
+
+    const storedTopics = mockValues.mock.calls[0][0].topics;
+    for (const topic of storedTopics) {
+      expect(typeof topic.slug).toBe("string");
+      expect(topic.slug.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("disambiguates duplicate slugs deterministically in sort order", async () => {
+    mockDbSelect([
+      { id: 1, title: "Ep 1", keyTakeaways: ["Takeaway 1"] },
+      { id: 2, title: "Ep 2", keyTakeaways: ["Takeaway 2"] },
+    ]);
+
+    const mockTopics = [
+      {
+        name: "AI Models",
+        description: "First AI Models topic",
+        episodeCount: 2,
+        episodeIds: [1, 2],
+      },
+      {
+        name: "AI Models",
+        description: "Second AI Models topic",
+        episodeCount: 1,
+        episodeIds: [2],
+      },
+    ];
+
+    mockGenerateCompletion.mockResolvedValue("mock completion");
+    mockParseJsonResponse.mockReturnValue({ topics: mockTopics });
+
+    await taskConfig.run();
+
+    const storedTopics = mockValues.mock.calls[0][0].topics;
+    expect(storedTopics).toHaveLength(2);
+    expect(storedTopics[0].slug).toBe("ai-models");
+    expect(storedTopics[1].slug).toBe("ai-models-2");
+  });
+
+  it("drops topics whose name slugifies to empty", async () => {
+    mockDbSelect([
+      { id: 1, title: "Ep 1", keyTakeaways: ["Takeaway 1"] },
+      { id: 2, title: "Ep 2", keyTakeaways: ["Takeaway 2"] },
+      { id: 3, title: "Ep 3", keyTakeaways: ["Takeaway 3"] },
+    ]);
+
+    const mockTopics = [
+      {
+        name: "!!!",
+        description: "All punctuation name",
+        episodeCount: 1,
+        episodeIds: [1],
+      },
+      {
+        name: "Valid",
+        description: "A valid topic",
+        episodeCount: 2,
+        episodeIds: [2, 3],
+      },
+    ];
+
+    mockGenerateCompletion.mockResolvedValue("mock completion");
+    mockParseJsonResponse.mockReturnValue({ topics: mockTopics });
+
+    const result = await taskConfig.run();
+
+    expect(result).toEqual({ episodeCount: 3, topicCount: 1 });
+    const storedTopics = mockValues.mock.calls[0][0].topics;
+    expect(storedTopics).toHaveLength(1);
+    expect(storedTopics[0].slug).toBe("valid");
+  });
+
+  it("applies dedupe AFTER sort+slice, not before", async () => {
+    const episodeRows = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      title: `Episode ${i + 1}`,
+      keyTakeaways: [`Takeaway ${i + 1}`],
+    }));
+    mockDbSelect(episodeRows);
+
+    // Two topics that share the same slug but differ in episodeCount
+    // Lower-ranked (lower episodeCount) gets -2 only if it survives slice
+    // We create 9 distinct topics + 2 that collide, total 11 > MAX_TOPICS(8)
+    const mockTopics = [
+      { name: "A Topic", description: "D", episodeCount: 10, episodeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+      { name: "B Topic", description: "D", episodeCount: 9, episodeIds: [1, 2, 3, 4, 5, 6, 7, 8, 9] },
+      { name: "C Topic", description: "D", episodeCount: 8, episodeIds: [1, 2, 3, 4, 5, 6, 7, 8] },
+      { name: "D Topic", description: "D", episodeCount: 7, episodeIds: [1, 2, 3, 4, 5, 6, 7] },
+      { name: "E Topic", description: "D", episodeCount: 6, episodeIds: [1, 2, 3, 4, 5, 6] },
+      { name: "F Topic", description: "D", episodeCount: 5, episodeIds: [1, 2, 3, 4, 5] },
+      // These two share the slug "g-topic" after slugify; higher-count ranks first
+      { name: "G Topic", description: "D", episodeCount: 4, episodeIds: [1, 2, 3, 4] },
+      { name: "G-Topic", description: "D", episodeCount: 3, episodeIds: [1, 2, 3] },
+      // This one won't make the cut (rank 9, beyond MAX_TOPICS=8)
+      { name: "H Topic", description: "D", episodeCount: 2, episodeIds: [1, 2] },
+    ];
+
+    mockGenerateCompletion.mockResolvedValue("mock completion");
+    mockParseJsonResponse.mockReturnValue({ topics: mockTopics });
+
+    await taskConfig.run();
+
+    const storedTopics = mockValues.mock.calls[0][0].topics;
+    expect(storedTopics).toHaveLength(8);
+    // Find the two colliding topics
+    const gTopics = storedTopics.filter((t: { slug: string }) => t.slug.startsWith("g-topic"));
+    expect(gTopics).toHaveLength(2);
+    // Higher-count gets bare slug; lower-count gets -2
+    const sorted = [...gTopics].sort((a: { episodeCount: number }, b: { episodeCount: number }) => b.episodeCount - a.episodeCount);
+    expect(sorted[0].slug).toBe("g-topic");
+    expect(sorted[1].slug).toBe("g-topic-2");
   });
 });

--- a/src/trigger/__tests__/generate-trending-topics.test.ts
+++ b/src/trigger/__tests__/generate-trending-topics.test.ts
@@ -445,6 +445,35 @@ describe("generate-trending-topics task", () => {
     expect(storedTopics[0].slug).toBe("valid");
   });
 
+  it("dedupe does not collide with another topic's natural suffixed slug", async () => {
+    // Reproduces the collision case: a disambiguated form (e.g. "season-2")
+    // must not clash with another topic whose natural slug is already "season-2".
+    // Input: [Season 2 (ep 3), Season (ep 2), Season (ep 1)] — sorted desc by episodeCount.
+    // Without the fix, walk yields [season-2, season, season-2] (collision).
+    // With the fix, it yields [season-2, season, season-3].
+    mockDbSelect([
+      { id: 1, title: "Ep 1", keyTakeaways: ["Takeaway 1"] },
+      { id: 2, title: "Ep 2", keyTakeaways: ["Takeaway 2"] },
+      { id: 3, title: "Ep 3", keyTakeaways: ["Takeaway 3"] },
+    ]);
+
+    const mockTopics = [
+      { name: "Season 2", description: "A", episodeCount: 3, episodeIds: [1, 2, 3] },
+      { name: "Season", description: "B", episodeCount: 2, episodeIds: [1, 2] },
+      { name: "Season", description: "C", episodeCount: 1, episodeIds: [1] },
+    ];
+
+    mockGenerateCompletion.mockResolvedValue("mock completion");
+    mockParseJsonResponse.mockReturnValue({ topics: mockTopics });
+
+    await taskConfig.run();
+
+    const storedTopics = mockValues.mock.calls[0][0].topics;
+    const slugs = storedTopics.map((t: { slug: string }) => t.slug);
+    expect(slugs).toEqual(["season-2", "season", "season-3"]);
+    expect(new Set(slugs).size).toBe(slugs.length); // all unique
+  });
+
   it("applies dedupe AFTER sort+slice, not before", async () => {
     const episodeRows = Array.from({ length: 10 }, (_, i) => ({
       id: i + 1,

--- a/src/trigger/generate-trending-topics.ts
+++ b/src/trigger/generate-trending-topics.ts
@@ -147,7 +147,7 @@ export const generateTrendingTopics = schedules.task({
 
     // Validate: filter out topics referencing invalid episode IDs
     const validEpisodeIds = new Set(episodesWithTakeaways.map((ep) => ep.id));
-    const validatedTopics = topics
+    const mappedTopics = topics
       .map((topic) => {
         const filteredIds = Array.from(new Set(topic.episodeIds)).filter((id) =>
           validEpisodeIds.has(id)
@@ -160,18 +160,37 @@ export const generateTrendingTopics = schedules.task({
           slug: slugify(topic.name),
         };
       })
-      .filter((topic) => topic.episodeCount > 0)
+      .filter((topic) => topic.episodeCount > 0);
+
+    const droppedForEmptySlug = mappedTopics
+      .filter((topic) => topic.slug === "")
+      .map((topic) => topic.name);
+    if (droppedForEmptySlug.length > 0) {
+      logger.warn("Dropped trending topics with empty slug (non-ASCII or punctuation-only names)", {
+        droppedCount: droppedForEmptySlug.length,
+        droppedNames: droppedForEmptySlug.slice(0, 10),
+      });
+    }
+
+    const validatedTopics = mappedTopics
       .filter((topic) => topic.slug !== "")
       .sort((a, b) => b.episodeCount - a.episodeCount)
       .slice(0, MAX_TOPICS);
 
-    // Disambiguate duplicate slugs in sort order
-    const seenSlugs = new Map<string, number>();
+    // Disambiguate duplicate slugs. Track already-assigned final slugs (not
+    // just bases) so a disambiguated form like "foo-2" cannot collide with
+    // another topic whose natural slug is also "foo-2".
+    const assignedSlugs = new Set<string>();
     for (const topic of validatedTopics) {
       const base = topic.slug;
-      const count = seenSlugs.get(base) ?? 0;
-      if (count > 0) topic.slug = `${base}-${count + 1}`;
-      seenSlugs.set(base, count + 1);
+      let candidate = base;
+      let n = 2;
+      while (assignedSlugs.has(candidate)) {
+        candidate = `${base}-${n}`;
+        n++;
+      }
+      topic.slug = candidate;
+      assignedSlugs.add(candidate);
     }
 
     if (validatedTopics.length === 0 && topics.length > 0) {

--- a/src/trigger/generate-trending-topics.ts
+++ b/src/trigger/generate-trending-topics.ts
@@ -8,6 +8,7 @@ import {
   getTrendingTopicsPrompt,
 } from "@/lib/prompts";
 import { parseJsonResponse } from "@/lib/openrouter";
+import { slugify } from "@/lib/utils";
 
 const LOOKBACK_DAYS = 7;
 const MAX_EPISODES = 500;
@@ -156,11 +157,22 @@ export const generateTrendingTopics = schedules.task({
           description: topic.description,
           episodeIds: filteredIds,
           episodeCount: filteredIds.length,
+          slug: slugify(topic.name),
         };
       })
       .filter((topic) => topic.episodeCount > 0)
+      .filter((topic) => topic.slug !== "")
       .sort((a, b) => b.episodeCount - a.episodeCount)
       .slice(0, MAX_TOPICS);
+
+    // Disambiguate duplicate slugs in sort order
+    const seenSlugs = new Map<string, number>();
+    for (const topic of validatedTopics) {
+      const base = topic.slug;
+      const count = seenSlugs.get(base) ?? 0;
+      if (count > 0) topic.slug = `${base}-${count + 1}`;
+      seenSlugs.set(base, count + 1);
+    }
 
     if (validatedTopics.length === 0 && topics.length > 0) {
       logger.warn("All LLM topics referenced invalid episode IDs, storing empty snapshot", {

--- a/src/trigger/generate-trending-topics.ts
+++ b/src/trigger/generate-trending-topics.ts
@@ -162,18 +162,20 @@ export const generateTrendingTopics = schedules.task({
       })
       .filter((topic) => topic.episodeCount > 0);
 
-    const droppedForEmptySlug = mappedTopics
-      .filter((topic) => topic.slug === "")
-      .map((topic) => topic.name);
-    if (droppedForEmptySlug.length > 0) {
+    const keptTopics: typeof mappedTopics = [];
+    const droppedNames: string[] = [];
+    for (const topic of mappedTopics) {
+      if (topic.slug === "") droppedNames.push(topic.name);
+      else keptTopics.push(topic);
+    }
+    if (droppedNames.length > 0) {
       logger.warn("Dropped trending topics with empty slug (non-ASCII or punctuation-only names)", {
-        droppedCount: droppedForEmptySlug.length,
-        droppedNames: droppedForEmptySlug.slice(0, 10),
+        droppedCount: droppedNames.length,
+        droppedNames: droppedNames.slice(0, 10),
       });
     }
 
-    const validatedTopics = mappedTopics
-      .filter((topic) => topic.slug !== "")
+    const validatedTopics = keptTopics
       .sort((a, b) => b.episodeCount - a.episodeCount)
       .slice(0, MAX_TOPICS);
 


### PR DESCRIPTION
## Summary

- Adds a required `slug: string` field to the `TrendingTopic` JSON shape and populates it inside the daily `generate-trending-topics` Trigger.dev task, so the upcoming `/trending/[slug]` page has a stable URL identifier.
- Introduces a pure `slugify(name: string): string` helper in `src/lib/utils.ts` — NFKD-normalizes, strips Latin combining marks (`[\u0300-\u036f]`), lowercases, collapses non-alphanumerics to `-`, trims leading/trailing `-`.
- Disambiguates duplicate slugs within a single snapshot by appending `-2`, `-3`, … in deterministic sort order (applied AFTER sort+slice, so identity follows final ranking).
- Drops topics whose name slugifies to empty (e.g. punctuation-only or non-Latin-script-only names).
- No DB migration — `topics` column is already `json` typed as `TrendingTopic[]`. Existing rows are not backfilled; the daily cron overwrites within ≤24h.

## Test plan

- [x] `bun run lint` — 0 errors/warnings
- [x] `bun run test` — 1640/1640 tests pass (132 test files)
- [x] `bun run build` — clean production build
- [x] 12 new unit tests cover `slugify`: basic, diacritics, punctuation-only, empty, whitespace-only, run collapsing, idempotency, numeric, mixed-case
- [x] 4 new + 3 updated tests in `generate-trending-topics.test.ts` cover: every persisted topic has non-empty slug, duplicate slugs disambiguated (`ai-models` / `ai-models-2`), empty-slug topics filtered, dedupe applied AFTER sort+slice
- [x] TypeScript compile-time enforcement — omitting `slug` from a `TrendingTopic` literal is a type error

## Known limitations (non-blocking)

- **Adversarial slug collision:** The dedupe walk `${base}-${count+1}` does not guarantee uniqueness against an LLM-generated topic literally named something that slugifies to e.g. `"foo-2"` combined with two topics slugifying to `"foo"` (walk would yield `[foo, foo-2, foo-2]`). Probability vanishingly low given typical topic names; can be hardened later if needed by re-checking suffixed slug against `seenSlugs`.
- **Diacritic range narrower than plan-specified `\p{M}/gu`:** Implementation uses `[\u0300-\u036f]`, which covers the Combining Diacritical Marks block (all Latin accents). Greek/Cyrillic/Vietnamese combining marks outside U+0300–U+036F won't be stripped as cleanly, though the subsequent `[^a-z0-9]+` → `-` collapse still produces a valid ASCII slug.
- **Consumer safety:** `/trending/[slug]` page (sub-issue 2 of #278) should treat pre-existing snapshots without `slug` as stale — the type says `slug: string` but historical DB rows have `undefined` until the next cron run.

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trending topics now include stable slug-based identifiers for generating shareable URLs to individual topic detail pages, with automatic deduplication handling for similarly named topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->