### PR TITLE
fix: close mobile library sidebar sheet on collection tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Summarization step progress UI removes `"fetching-transcript"` and `"transcribing-audio"` steps — summarization no longer fetches transcripts
 
 ### Fixed
+- Close mobile library sidebar sheet when tapping a collection or "All Saved" link, matching the site header fix from #283 (#284)
 - Restore episode topic persistence on production by adding the missing `topic_rank`/`ranked_at` migration; PR #266 added the columns to the schema but never generated a migration, so production INSERTs into `episode_topics` failed (#275)
 - Mobile nav touch targets increased from `py-2` to `py-3` for WCAG 2.1 AA 44px minimum (#256)
 - Score badge contrast on yellow/orange backgrounds — foreground color now adapts per tier instead of hardcoded white (#256)

--- a/src/components/library/__tests__/library-sidebar.test.tsx
+++ b/src/components/library/__tests__/library-sidebar.test.tsx
@@ -25,10 +25,23 @@ vi.mock("@/components/ui/sheet", () => {
   // inside this closure. Do not convert to an `import` or the suite breaks.
   const { useState, createContext, useContext } = require("react") as typeof React
 
+  // Default context is null so any Sheet primitive rendered outside a Sheet
+  // provider throws — mirroring real Radix behaviour, which is the exact
+  // failure mode that broke the /library prerender on the first attempt at
+  // this fix. A silent no-op default would let a desktop regression (inSheet
+  // accidentally flipped to true) pass this suite.
   const SheetStateContext = createContext<{
     open: boolean
     setOpen: (v: boolean) => void
-  }>({ open: false, setOpen: () => {} })
+  } | null>(null)
+
+  const useSheetContext = () => {
+    const ctx = useContext(SheetStateContext)
+    if (ctx === null) {
+      throw new Error("Sheet primitive used outside <Sheet> provider")
+    }
+    return ctx
+  }
 
   const Sheet = ({ children }: { children: React.ReactNode }) => {
     const [open, setOpen] = useState(false)
@@ -40,7 +53,7 @@ vi.mock("@/components/ui/sheet", () => {
   }
 
   const SheetTrigger = ({ children }: { children: React.ReactNode; asChild?: boolean }) => {
-    const { setOpen } = useContext(SheetStateContext)
+    const { setOpen } = useSheetContext()
     return (
       <div data-testid="sheet-trigger" onClick={() => setOpen(true)}>
         {children}
@@ -49,7 +62,7 @@ vi.mock("@/components/ui/sheet", () => {
   }
 
   const SheetContent = ({ children }: { children: React.ReactNode }) => {
-    const { open } = useContext(SheetStateContext)
+    const { open } = useSheetContext()
     return open ? <div data-testid="sheet-content">{children}</div> : null
   }
 
@@ -60,7 +73,7 @@ vi.mock("@/components/ui/sheet", () => {
     children: React.ReactNode
     asChild?: boolean
   }) => {
-    const { setOpen } = useContext(SheetStateContext)
+    const { setOpen } = useSheetContext()
     const close = () => setOpen(false)
     if (asChild && React.isValidElement(children)) {
       const child = children as React.ReactElement<{ onClick?: (e: unknown) => void }>

--- a/src/components/library/__tests__/library-sidebar.test.tsx
+++ b/src/components/library/__tests__/library-sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, within, waitFor } from "@testing-library/react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import React from "react"
 import { LibrarySidebar } from "@/components/library/library-sidebar"
 
@@ -16,9 +16,9 @@ vi.mock("@/components/library/collection-dialog", () => ({
   CollectionDialog: () => null,
 }))
 
-// shadcn Sheet — stateful mock mirroring the header test pattern.
-// SheetClose with asChild cloneElement behaviour ensures the regression
-// test fails if the fix omits asChild.
+// Stateful Sheet mock mirroring the header test pattern. SheetClose honors
+// asChild via cloneElement so a regression dropping asChild would fail the
+// suite.
 vi.mock("@/components/ui/sheet", () => {
   const { useState, createContext, useContext } = require("react") as typeof React
 
@@ -79,7 +79,15 @@ vi.mock("@/components/ui/sheet", () => {
 })
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, onClick, ...rest }: { children: React.ReactNode; onClick?: () => void; [key: string]: unknown }) => (
+  Button: ({
+    children,
+    onClick,
+    ...rest
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+    [key: string]: unknown
+  }) => (
     <button onClick={onClick} {...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}>
       {children}
     </button>
@@ -90,7 +98,7 @@ vi.mock("@/components/ui/skeleton", () => ({
   Skeleton: () => <div data-testid="skeleton" />,
 }))
 
-describe("LibrarySidebar mobile sheet — closes on link tap (regression #284)", () => {
+describe("LibrarySidebar mobile sheet — closes on link tap", () => {
   beforeEach(() => {
     mockGetUserCollections.mockResolvedValue({
       collections: [
@@ -111,13 +119,9 @@ describe("LibrarySidebar mobile sheet — closes on link tap (regression #284)",
   it("closes the sheet when 'All Saved' is tapped", async () => {
     render(<LibrarySidebar />)
 
-    // Open the mobile sheet via the Collections trigger
-    const triggers = screen.getAllByTestId("sheet-trigger")
-    fireEvent.click(triggers[0])
+    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
 
     const sheetContent = screen.getByTestId("sheet-content")
-    // Await async getUserCollections resolution so the subsequent setState
-    // settles inside act before we assert.
     await within(sheetContent).findByRole("link", { name: /fake collection/i })
 
     const allSavedLink = within(sheetContent).getByRole("link", { name: /all saved/i })
@@ -132,7 +136,6 @@ describe("LibrarySidebar mobile sheet — closes on link tap (regression #284)",
     fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
 
     const sheetContent = screen.getByTestId("sheet-content")
-    // Collection list loads asynchronously after getUserCollections resolves.
     const collectionLink = await within(sheetContent).findByRole("link", {
       name: /fake collection/i,
     })
@@ -147,19 +150,65 @@ describe("LibrarySidebar mobile sheet — closes on link tap (regression #284)",
     fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
 
     const sheetContent = screen.getByTestId("sheet-content")
-    // Wait for collections to load so the '+' button is findable alongside them.
     await within(sheetContent).findByRole("link", { name: /fake collection/i })
 
-    // The '+' button is the only icon-only button inside the sheet (no accessible name
-    // beyond the Plus icon). Scope to the sheet and pick the single button that is NOT
-    // the SheetTrigger's outer wrapper.
-    const buttons = within(sheetContent).getAllByRole("button")
-    // The first button inside SheetContent is the "+" create button (Sheet trigger lives outside).
-    fireEvent.click(buttons[0])
-
-    // Sheet must remain open: SheetClose was not wrapped around the '+' control.
-    await waitFor(() => {
-      expect(screen.getByTestId("sheet-content")).toBeInTheDocument()
+    const newCollectionButtons = within(sheetContent).getAllByRole("button", {
+      name: /new collection/i,
     })
+    fireEvent.click(newCollectionButtons[0])
+
+    expect(screen.getByTestId("sheet-content")).toBeInTheDocument()
+  })
+})
+
+describe("LibrarySidebar desktop aside", () => {
+  beforeEach(() => {
+    mockGetUserCollections.mockResolvedValue({
+      collections: [
+        {
+          id: "col-1",
+          userId: "user-1",
+          name: "Fake Collection",
+          description: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          episodeCount: 3,
+        },
+      ],
+      error: null,
+    })
+  })
+
+  // The desktop aside renders SidebarNav with inSheet={false}, so no SheetClose
+  // wrapping. This guards against a regression that unconditionally wraps links
+  // with SheetClose — which would crash the /library prerender at build time
+  // (SheetClose throws outside a Radix Dialog context).
+  it("renders links with correct hrefs and clicking does not throw", async () => {
+    render(<LibrarySidebar />)
+
+    // Sheet starts closed, so the only mounted nav is the desktop aside.
+    const allSaved = await screen.findByRole("link", { name: /all saved/i })
+    expect(allSaved).toHaveAttribute("href", "/library")
+
+    const collection = screen.getByRole("link", { name: /fake collection/i })
+    expect(collection).toHaveAttribute("href", "/library/collection/col-1")
+
+    expect(() => fireEvent.click(allSaved)).not.toThrow()
+    expect(() => fireEvent.click(collection)).not.toThrow()
+  })
+})
+
+describe("LibrarySidebar error state", () => {
+  it("surfaces loadCollections error instead of rendering the empty state", async () => {
+    mockGetUserCollections.mockResolvedValue({
+      collections: [],
+      error: "Failed to load collections",
+    })
+
+    render(<LibrarySidebar />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent(/failed to load collections/i)
+    expect(screen.queryByText(/no collections yet/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/library/__tests__/library-sidebar.test.tsx
+++ b/src/components/library/__tests__/library-sidebar.test.tsx
@@ -20,6 +20,9 @@ vi.mock("@/components/library/collection-dialog", () => ({
 // asChild via cloneElement so a regression dropping asChild would fail the
 // suite.
 vi.mock("@/components/ui/sheet", () => {
+  // require("react") is intentional — Vitest hoists vi.mock factories above
+  // the top-level imports, so the module-level React binding isn't available
+  // inside this closure. Do not convert to an `import` or the suite breaks.
   const { useState, createContext, useContext } = require("react") as typeof React
 
   const SheetStateContext = createContext<{

--- a/src/components/library/__tests__/library-sidebar.test.tsx
+++ b/src/components/library/__tests__/library-sidebar.test.tsx
@@ -119,7 +119,7 @@ describe("LibrarySidebar mobile sheet — closes on link tap", () => {
   it("closes the sheet when 'All Saved' is tapped", async () => {
     render(<LibrarySidebar />)
 
-    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
+    fireEvent.click(screen.getByRole("button", { name: /collections/i }))
 
     const sheetContent = screen.getByTestId("sheet-content")
     await within(sheetContent).findByRole("link", { name: /fake collection/i })
@@ -133,7 +133,7 @@ describe("LibrarySidebar mobile sheet — closes on link tap", () => {
   it("closes the sheet when a collection row is tapped", async () => {
     render(<LibrarySidebar />)
 
-    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
+    fireEvent.click(screen.getByRole("button", { name: /collections/i }))
 
     const sheetContent = screen.getByTestId("sheet-content")
     const collectionLink = await within(sheetContent).findByRole("link", {
@@ -147,15 +147,14 @@ describe("LibrarySidebar mobile sheet — closes on link tap", () => {
   it("does NOT close the sheet when the '+' new-collection button is tapped", async () => {
     render(<LibrarySidebar />)
 
-    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
+    fireEvent.click(screen.getByRole("button", { name: /collections/i }))
 
     const sheetContent = screen.getByTestId("sheet-content")
     await within(sheetContent).findByRole("link", { name: /fake collection/i })
 
-    const newCollectionButtons = within(sheetContent).getAllByRole("button", {
-      name: /new collection/i,
-    })
-    fireEvent.click(newCollectionButtons[0])
+    fireEvent.click(
+      within(sheetContent).getByRole("button", { name: /new collection/i })
+    )
 
     expect(screen.getByTestId("sheet-content")).toBeInTheDocument()
   })

--- a/src/components/library/__tests__/library-sidebar.test.tsx
+++ b/src/components/library/__tests__/library-sidebar.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react"
+import React from "react"
+import { LibrarySidebar } from "@/components/library/library-sidebar"
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/library",
+}))
+
+const mockGetUserCollections = vi.fn()
+vi.mock("@/app/actions/collections", () => ({
+  getUserCollections: () => mockGetUserCollections(),
+}))
+
+vi.mock("@/components/library/collection-dialog", () => ({
+  CollectionDialog: () => null,
+}))
+
+// shadcn Sheet — stateful mock mirroring the header test pattern.
+// SheetClose with asChild cloneElement behaviour ensures the regression
+// test fails if the fix omits asChild.
+vi.mock("@/components/ui/sheet", () => {
+  const { useState, createContext, useContext } = require("react") as typeof React
+
+  const SheetStateContext = createContext<{
+    open: boolean
+    setOpen: (v: boolean) => void
+  }>({ open: false, setOpen: () => {} })
+
+  const Sheet = ({ children }: { children: React.ReactNode }) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <SheetStateContext.Provider value={{ open, setOpen }}>
+        {children}
+      </SheetStateContext.Provider>
+    )
+  }
+
+  const SheetTrigger = ({ children }: { children: React.ReactNode; asChild?: boolean }) => {
+    const { setOpen } = useContext(SheetStateContext)
+    return (
+      <div data-testid="sheet-trigger" onClick={() => setOpen(true)}>
+        {children}
+      </div>
+    )
+  }
+
+  const SheetContent = ({ children }: { children: React.ReactNode }) => {
+    const { open } = useContext(SheetStateContext)
+    return open ? <div data-testid="sheet-content">{children}</div> : null
+  }
+
+  const SheetClose = ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode
+    asChild?: boolean
+  }) => {
+    const { setOpen } = useContext(SheetStateContext)
+    const close = () => setOpen(false)
+    if (asChild && React.isValidElement(children)) {
+      const child = children as React.ReactElement<{ onClick?: (e: unknown) => void }>
+      return React.cloneElement(child, {
+        onClick: (e: unknown) => {
+          child.props.onClick?.(e)
+          close()
+        },
+      })
+    }
+    return (
+      <div data-testid="sheet-close" onClick={close}>
+        {children}
+      </div>
+    )
+  }
+
+  return { Sheet, SheetTrigger, SheetContent, SheetClose }
+})
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: { children: React.ReactNode; onClick?: () => void; [key: string]: unknown }) => (
+    <button onClick={onClick} {...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+describe("LibrarySidebar mobile sheet — closes on link tap (regression #284)", () => {
+  beforeEach(() => {
+    mockGetUserCollections.mockResolvedValue({
+      collections: [
+        {
+          id: "col-1",
+          userId: "user-1",
+          name: "Fake Collection",
+          description: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          episodeCount: 3,
+        },
+      ],
+      error: null,
+    })
+  })
+
+  it("closes the sheet when 'All Saved' is tapped", async () => {
+    render(<LibrarySidebar />)
+
+    // Open the mobile sheet via the Collections trigger
+    const triggers = screen.getAllByTestId("sheet-trigger")
+    fireEvent.click(triggers[0])
+
+    const sheetContent = screen.getByTestId("sheet-content")
+    // Await async getUserCollections resolution so the subsequent setState
+    // settles inside act before we assert.
+    await within(sheetContent).findByRole("link", { name: /fake collection/i })
+
+    const allSavedLink = within(sheetContent).getByRole("link", { name: /all saved/i })
+    fireEvent.click(allSavedLink)
+
+    expect(screen.queryByTestId("sheet-content")).not.toBeInTheDocument()
+  })
+
+  it("closes the sheet when a collection row is tapped", async () => {
+    render(<LibrarySidebar />)
+
+    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
+
+    const sheetContent = screen.getByTestId("sheet-content")
+    // Collection list loads asynchronously after getUserCollections resolves.
+    const collectionLink = await within(sheetContent).findByRole("link", {
+      name: /fake collection/i,
+    })
+    fireEvent.click(collectionLink)
+
+    expect(screen.queryByTestId("sheet-content")).not.toBeInTheDocument()
+  })
+
+  it("does NOT close the sheet when the '+' new-collection button is tapped", async () => {
+    render(<LibrarySidebar />)
+
+    fireEvent.click(screen.getAllByTestId("sheet-trigger")[0])
+
+    const sheetContent = screen.getByTestId("sheet-content")
+    // Wait for collections to load so the '+' button is findable alongside them.
+    await within(sheetContent).findByRole("link", { name: /fake collection/i })
+
+    // The '+' button is the only icon-only button inside the sheet (no accessible name
+    // beyond the Plus icon). Scope to the sheet and pick the single button that is NOT
+    // the SheetTrigger's outer wrapper.
+    const buttons = within(sheetContent).getAllByRole("button")
+    // The first button inside SheetContent is the "+" create button (Sheet trigger lives outside).
+    fireEvent.click(buttons[0])
+
+    // Sheet must remain open: SheetClose was not wrapped around the '+' control.
+    await waitFor(() => {
+      expect(screen.getByTestId("sheet-content")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/library/library-sidebar.tsx
+++ b/src/components/library/library-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { Fragment, useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Folder, Plus, Bookmark, Library } from "lucide-react";
@@ -14,35 +14,30 @@ import { cn } from "@/lib/utils";
 
 type CollectionWithCount = Collection & { episodeCount: number };
 
-// SheetClose relies on Radix Dialog context and throws outside of one. Since
-// SidebarNav renders in both the mobile Sheet and the desktop aside, the mobile
-// path passes SheetCloseWrapper to auto-dismiss on nav tap while the desktop
-// path gets the identity wrapper.
-type LinkWrapperProps = { children: React.ReactElement };
-type LinkWrapperComponent = React.ComponentType<LinkWrapperProps>;
-
-const IdentityWrapper: LinkWrapperComponent = ({ children }) => children;
-
-const SheetCloseWrapper: LinkWrapperComponent = ({ children }) => (
-  <SheetClose asChild>{children}</SheetClose>
-);
-
 function SidebarNav({
   pathname,
   collections,
   isLoading,
+  loadError,
   onCreateClick,
-  LinkWrapper = IdentityWrapper,
+  inSheet,
 }: {
   pathname: string;
   collections: CollectionWithCount[];
   isLoading: boolean;
+  loadError: string | null;
   onCreateClick: () => void;
-  LinkWrapper?: LinkWrapperComponent;
+  inSheet: boolean;
 }) {
+  // SheetClose is Radix DialogPrimitive.Close — it throws outside a Sheet/Dialog
+  // context. This component renders in both the mobile Sheet and the desktop
+  // aside, so only the mobile path opts into SheetClose wrapping.
+  const wrap = (link: React.ReactElement) =>
+    inSheet ? <SheetClose asChild>{link}</SheetClose> : link;
+
   return (
     <nav className="space-y-1">
-      <LinkWrapper>
+      {wrap(
         <Link
           href="/library"
           className={cn(
@@ -53,7 +48,7 @@ function SidebarNav({
           <Bookmark className="h-4 w-4" />
           All Saved
         </Link>
-      </LinkWrapper>
+      )}
 
       <div className="pt-4">
         <div className="mb-2 flex items-center justify-between px-3">
@@ -65,6 +60,7 @@ function SidebarNav({
             size="icon"
             className="h-6 w-6"
             onClick={onCreateClick}
+            aria-label="New collection"
           >
             <Plus className="h-4 w-4" />
           </Button>
@@ -79,6 +75,10 @@ function SidebarNav({
               </div>
             ))}
           </div>
+        ) : loadError ? (
+          <p role="alert" className="px-3 py-2 text-xs text-destructive">
+            {loadError}
+          </p>
         ) : collections.length === 0 ? (
           <p className="px-3 py-2 text-xs text-muted-foreground">
             No collections yet. Create one to organize your episodes.
@@ -86,24 +86,26 @@ function SidebarNav({
         ) : (
           <div className="space-y-1">
             {collections.map((collection) => (
-              <LinkWrapper key={collection.id}>
-                <Link
-                  href={`/library/collection/${collection.id}`}
-                  className={cn(
-                    "flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
-                    pathname === `/library/collection/${collection.id}` &&
-                      "bg-accent font-medium"
-                  )}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <Folder className="h-4 w-4 shrink-0" />
-                    <span className="truncate">{collection.name}</span>
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {collection.episodeCount}
-                  </span>
-                </Link>
-              </LinkWrapper>
+              <Fragment key={collection.id}>
+                {wrap(
+                  <Link
+                    href={`/library/collection/${collection.id}`}
+                    className={cn(
+                      "flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
+                      pathname === `/library/collection/${collection.id}` &&
+                        "bg-accent font-medium"
+                    )}
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Folder className="h-4 w-4 shrink-0" />
+                      <span className="truncate">{collection.name}</span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {collection.episodeCount}
+                    </span>
+                  </Link>
+                )}
+              </Fragment>
             ))}
           </div>
         )}
@@ -116,12 +118,19 @@ export function LibrarySidebar() {
   const pathname = usePathname();
   const [collections, setCollections] = useState<CollectionWithCount[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
 
   const loadCollections = useCallback(async () => {
     setIsLoading(true);
     const result = await getUserCollections();
-    setCollections(result.collections as CollectionWithCount[]);
+    if (result.error) {
+      setLoadError(result.error);
+      setCollections([]);
+    } else {
+      setLoadError(null);
+      setCollections(result.collections);
+    }
     setIsLoading(false);
   }, []);
 
@@ -150,8 +159,9 @@ export function LibrarySidebar() {
                 pathname={pathname}
                 collections={collections}
                 isLoading={isLoading}
+                loadError={loadError}
                 onCreateClick={() => setShowCreateDialog(true)}
-                LinkWrapper={SheetCloseWrapper}
+                inSheet
               />
             </div>
           </SheetContent>
@@ -164,7 +174,9 @@ export function LibrarySidebar() {
           pathname={pathname}
           collections={collections}
           isLoading={isLoading}
+          loadError={loadError}
           onCreateClick={() => setShowCreateDialog(true)}
+          inSheet={false}
         />
       </aside>
 

--- a/src/components/library/library-sidebar.tsx
+++ b/src/components/library/library-sidebar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { Folder, Plus, Bookmark, Library } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetClose, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { CollectionDialog } from "./collection-dialog";
 import { getUserCollections } from "@/app/actions/collections";
 import type { Collection } from "@/db/schema";
@@ -14,29 +14,46 @@ import { cn } from "@/lib/utils";
 
 type CollectionWithCount = Collection & { episodeCount: number };
 
+// SheetClose relies on Radix Dialog context and throws outside of one. Since
+// SidebarNav renders in both the mobile Sheet and the desktop aside, the mobile
+// path passes SheetCloseWrapper to auto-dismiss on nav tap while the desktop
+// path gets the identity wrapper.
+type LinkWrapperProps = { children: React.ReactElement };
+type LinkWrapperComponent = React.ComponentType<LinkWrapperProps>;
+
+const IdentityWrapper: LinkWrapperComponent = ({ children }) => children;
+
+const SheetCloseWrapper: LinkWrapperComponent = ({ children }) => (
+  <SheetClose asChild>{children}</SheetClose>
+);
+
 function SidebarNav({
   pathname,
   collections,
   isLoading,
   onCreateClick,
+  LinkWrapper = IdentityWrapper,
 }: {
   pathname: string;
   collections: CollectionWithCount[];
   isLoading: boolean;
   onCreateClick: () => void;
+  LinkWrapper?: LinkWrapperComponent;
 }) {
   return (
     <nav className="space-y-1">
-      <Link
-        href="/library"
-        className={cn(
-          "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
-          pathname === "/library" && "bg-accent font-medium"
-        )}
-      >
-        <Bookmark className="h-4 w-4" />
-        All Saved
-      </Link>
+      <LinkWrapper>
+        <Link
+          href="/library"
+          className={cn(
+            "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
+            pathname === "/library" && "bg-accent font-medium"
+          )}
+        >
+          <Bookmark className="h-4 w-4" />
+          All Saved
+        </Link>
+      </LinkWrapper>
 
       <div className="pt-4">
         <div className="mb-2 flex items-center justify-between px-3">
@@ -69,23 +86,24 @@ function SidebarNav({
         ) : (
           <div className="space-y-1">
             {collections.map((collection) => (
-              <Link
-                key={collection.id}
-                href={`/library/collection/${collection.id}`}
-                className={cn(
-                  "flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
-                  pathname === `/library/collection/${collection.id}` &&
-                    "bg-accent font-medium"
-                )}
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <Folder className="h-4 w-4 shrink-0" />
-                  <span className="truncate">{collection.name}</span>
-                </div>
-                <span className="text-xs text-muted-foreground">
-                  {collection.episodeCount}
-                </span>
-              </Link>
+              <LinkWrapper key={collection.id}>
+                <Link
+                  href={`/library/collection/${collection.id}`}
+                  className={cn(
+                    "flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm transition-colors hover:bg-accent",
+                    pathname === `/library/collection/${collection.id}` &&
+                      "bg-accent font-medium"
+                  )}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Folder className="h-4 w-4 shrink-0" />
+                    <span className="truncate">{collection.name}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {collection.episodeCount}
+                  </span>
+                </Link>
+              </LinkWrapper>
             ))}
           </div>
         )}
@@ -133,6 +151,7 @@ export function LibrarySidebar() {
                 collections={collections}
                 isLoading={isLoading}
                 onCreateClick={() => setShowCreateDialog(true)}
+                LinkWrapper={SheetCloseWrapper}
               />
             </div>
           </SheetContent>

--- a/src/components/library/library-sidebar.tsx
+++ b/src/components/library/library-sidebar.tsx
@@ -121,6 +121,10 @@ export function LibrarySidebar() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
 
+  const handleCreateClick = useCallback(() => {
+    setShowCreateDialog(true);
+  }, []);
+
   const loadCollections = useCallback(async () => {
     setIsLoading(true);
     const result = await getUserCollections();
@@ -144,7 +148,6 @@ export function LibrarySidebar() {
 
   return (
     <>
-      {/* Mobile: Sheet trigger */}
       <div className="md:hidden mb-4">
         <Sheet>
           <SheetTrigger asChild>
@@ -160,7 +163,7 @@ export function LibrarySidebar() {
                 collections={collections}
                 isLoading={isLoading}
                 loadError={loadError}
-                onCreateClick={() => setShowCreateDialog(true)}
+                onCreateClick={handleCreateClick}
                 inSheet
               />
             </div>
@@ -168,7 +171,6 @@ export function LibrarySidebar() {
         </Sheet>
       </div>
 
-      {/* Desktop: inline sidebar */}
       <aside className="hidden md:block w-64 shrink-0 border-r pr-6">
         <SidebarNav
           pathname={pathname}

--- a/src/components/library/library-sidebar.tsx
+++ b/src/components/library/library-sidebar.tsx
@@ -127,15 +127,21 @@ export function LibrarySidebar() {
 
   const loadCollections = useCallback(async () => {
     setIsLoading(true);
-    const result = await getUserCollections();
-    if (result.error) {
-      setLoadError(result.error);
+    try {
+      const result = await getUserCollections();
+      if (result.error) {
+        setLoadError(result.error);
+        setCollections([]);
+      } else {
+        setLoadError(null);
+        setCollections(result.collections);
+      }
+    } catch {
+      setLoadError("Failed to load collections");
       setCollections([]);
-    } else {
-      setLoadError(null);
-      setCollections(result.collections);
+    } finally {
+      setIsLoading(false);
     }
-    setIsLoading(false);
   }, []);
 
   useEffect(() => {

--- a/src/components/library/library-sidebar.tsx
+++ b/src/components/library/library-sidebar.tsx
@@ -177,7 +177,7 @@ export function LibrarySidebar() {
           collections={collections}
           isLoading={isLoading}
           loadError={loadError}
-          onCreateClick={() => setShowCreateDialog(true)}
+          onCreateClick={handleCreateClick}
           inSheet={false}
         />
       </aside>


### PR DESCRIPTION
## Summary

- Wrap the library sidebar's mobile nav `<Link>` elements with `<SheetClose asChild>` so tapping "All Saved" or a collection row closes the overlay in the same gesture that navigates — matching the fix applied to the site header in #283.
- `SidebarNav` renders in both the mobile Sheet and the desktop aside, and `SheetClose` throws outside a Sheet/Dialog context, so the wrapping is applied via an optional `LinkWrapper` prop (defaults to identity; mobile passes `SheetCloseWrapper`).
- Adds a regression test mirroring `header.test.tsx`'s stateful Sheet mock (with `asChild` cloneElement behaviour, so the test fails if `asChild` is dropped).

Closes #284

## Test plan

- [x] `bun run lint` passes
- [x] `bun run test` passes (1628 tests, 3 new)
- [x] `bun run build` passes (previously failed on `/library` prerender before the LinkWrapper split)
- [ ] Manual: viewport <768px, `/library`, open Collections sheet, tap "All Saved" — sheet closes and route changes in one tap
- [ ] Manual: tap a collection row — sheet closes and navigates
- [ ] Manual: tap the `+` (new collection) — opens the dialog, sheet stays open
- [ ] Manual: desktop inline sidebar (≥768px) renders and navigates unchanged
- [ ] Manual: Esc / tap-outside still dismisses the sheet (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile library sidebar now automatically closes when tapping a collection or the "All Saved" link
  * Error messages display when collection loading fails

* **Tests**
  * Added test coverage for library sidebar mobile and desktop functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->