### PR TITLE
feat: Build /trending/[slug] detail page with switcher and episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Trending topic detail page at /trending/<slug> with horizontal topic switcher and ranked episode list sorted by worth-it score (#280)
 - Personal topic overlap indicators — shows contextual labels (e.g. "You've heard 3 similar episodes", "New topic for you") based on listen history and saved episodes. Recommendations deprioritize heavily-consumed topics (#262)
 - `rank-episode-topics` daily Trigger.dev scheduled task (7 AM UTC) that ranks episodes within each topic via exhaustive pairwise LLM comparison; win-count aggregation with worthItScore tiebreaker; adaptive episode cap (10/topic for ≤20 topics, 5/topic for >20); up to 50 topics per run (#261)
 - `topicRank` (integer, nullable) and `rankedAt` (timestamp, nullable) columns on `episode_topics` — rank 1 = best coverage of that topic (#261)

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { QueueSection } from "@/components/dashboard/queue-section";
 import { TrendingTopics, TrendingTopicsLoading } from "@/components/dashboard/trending-topics";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { isTrendingSnapshotStale } from "@/lib/trending";
 
 // Loading skeleton for recent episodes (inline — presentational file is "use client")
 function RecentEpisodesLoading() {
@@ -67,15 +68,12 @@ async function RecentEpisodesSection() {
   );
 }
 
-const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
-
 // Server component for trending topics
 async function TrendingTopicsSection() {
   const { topics, error } = await getTrendingTopics();
   if (error) console.error("[TrendingTopicsSection]", error);
   if (!topics || topics.items.length === 0) return null;
-  const isStale = Date.now() - topics.generatedAt.getTime() > STALE_THRESHOLD_MS;
-  if (isStale) return null;
+  if (isTrendingSnapshotStale(topics.generatedAt)) return null;
   return <TrendingTopics topics={topics.items} generatedAt={topics.generatedAt} />;
 }
 

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -8,7 +8,8 @@ vi.mock("@/app/actions/dashboard", () => ({
   getTrendingTopicBySlug: (slug: string) => mockGetTrendingTopicBySlug(slug),
 }));
 
-import { TrendingDetailContent, STALE_THRESHOLD_MS } from "../trending-detail-content";
+import { TrendingDetailContent } from "../trending-detail-content";
+import { STALE_THRESHOLD_MS } from "@/lib/trending";
 
 const aiTopic: TrendingTopic = {
   name: "Artificial Intelligence",
@@ -41,12 +42,6 @@ const mockEpisode: RecommendedEpisodeDTO = {
   topRankedTopic: null,
 };
 
-// Helper — render an async server component
-async function renderAsync(slug: string) {
-  const ui = await TrendingDetailContent({ slug });
-  return render(ui);
-}
-
 describe("TrendingDetailContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,7 +60,7 @@ describe("TrendingDetailContent", () => {
       error: "Failed to load topic",
     });
 
-    await renderAsync("artificial-intelligence");
+    render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
     expect(screen.getByRole("heading", { name: "Trending topics unavailable" })).toBeInTheDocument();
     expect(screen.getByText(/refresh the page or try again/i)).toBeInTheDocument();
@@ -73,7 +68,6 @@ describe("TrendingDetailContent", () => {
       "href",
       "/dashboard",
     );
-    // The empty-state heading must NOT appear when an error is surfaced.
     expect(screen.queryByRole("heading", { name: "No trending topics right now" })).not.toBeInTheDocument();
   });
 
@@ -86,7 +80,7 @@ describe("TrendingDetailContent", () => {
       error: null,
     });
 
-    await renderAsync("anything");
+    render(await TrendingDetailContent({ slug: "anything" }));
 
     expect(screen.getByRole("heading", { name: "No trending topics right now" })).toBeInTheDocument();
     expect(screen.getByText(/new trending topics are generated daily/i)).toBeInTheDocument();
@@ -105,13 +99,12 @@ describe("TrendingDetailContent", () => {
       error: null,
     });
 
-    await renderAsync("unknown-slug");
+    render(await TrendingDetailContent({ slug: "unknown-slug" }));
 
     expect(
       screen.getByRole("heading", { name: "This topic is no longer trending" }),
     ).toBeInTheDocument();
     expect(screen.getByText(/didn't make the latest trending snapshot/i)).toBeInTheDocument();
-    // Both topics appear in the switcher.
     expect(screen.getByRole("link", { name: "Artificial Intelligence" })).toHaveAttribute(
       "href",
       "/trending/artificial-intelligence",
@@ -123,7 +116,7 @@ describe("TrendingDetailContent", () => {
   });
 
   it("renders happy path without stale notice for a fresh snapshot", async () => {
-    const freshGeneratedAt = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    const freshGeneratedAt = new Date(Date.now() - 60 * 60 * 1000);
     mockGetTrendingTopicBySlug.mockResolvedValue({
       topic: aiTopic,
       allTopics: [aiTopic, climateTopic],
@@ -132,7 +125,7 @@ describe("TrendingDetailContent", () => {
       error: null,
     });
 
-    await renderAsync("artificial-intelligence");
+    render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
     expect(screen.getByRole("heading", { level: 1, name: aiTopic.name })).toBeInTheDocument();
     expect(screen.queryByText(/may be out of date/i)).not.toBeInTheDocument();
@@ -142,7 +135,7 @@ describe("TrendingDetailContent", () => {
   });
 
   it("renders stale notice when snapshot is older than STALE_THRESHOLD_MS", async () => {
-    const staleGeneratedAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000); // just past threshold
+    const staleGeneratedAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000);
     mockGetTrendingTopicBySlug.mockResolvedValue({
       topic: aiTopic,
       allTopics: [aiTopic],
@@ -151,7 +144,7 @@ describe("TrendingDetailContent", () => {
       error: null,
     });
 
-    await renderAsync("artificial-intelligence");
+    render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
     expect(screen.getByText(/these trending topics may be out of date/i)).toBeInTheDocument();
   });
@@ -165,7 +158,7 @@ describe("TrendingDetailContent", () => {
       error: null,
     });
 
-    await renderAsync("artificial-intelligence");
+    render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
     expect(screen.getByText(/no episodes available for this topic yet/i)).toBeInTheDocument();
   });

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -51,14 +51,8 @@ describe("TrendingDetailContent", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders error card when action returns error", async () => {
-    mockGetTrendingTopicBySlug.mockResolvedValue({
-      topic: null,
-      allTopics: [],
-      episodes: [],
-      generatedAt: null,
-      error: "Failed to load topic",
-    });
+  it("renders error card when action returns kind=error", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({ kind: "error", message: "Failed to load topic" });
 
     render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
@@ -71,14 +65,8 @@ describe("TrendingDetailContent", () => {
     expect(screen.queryByRole("heading", { name: "No trending topics right now" })).not.toBeInTheDocument();
   });
 
-  it("renders empty-snapshot fallback when allTopics is empty", async () => {
-    mockGetTrendingTopicBySlug.mockResolvedValue({
-      topic: null,
-      allTopics: [],
-      episodes: [],
-      generatedAt: null,
-      error: null,
-    });
+  it("renders no-snapshot fallback without a switcher", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({ kind: "no-snapshot" });
 
     render(await TrendingDetailContent({ slug: "anything" }));
 
@@ -88,15 +76,14 @@ describe("TrendingDetailContent", () => {
       "href",
       "/dashboard",
     );
+    expect(screen.queryByRole("navigation", { name: "Trending topics" })).not.toBeInTheDocument();
   });
 
-  it("renders unknown-slug fallback with switcher when snapshot has other topics", async () => {
+  it("renders unknown-slug fallback with switcher", async () => {
     mockGetTrendingTopicBySlug.mockResolvedValue({
-      topic: null,
+      kind: "unknown-slug",
       allTopics: [aiTopic, climateTopic],
-      episodes: [],
       generatedAt: new Date(),
-      error: null,
     });
 
     render(await TrendingDetailContent({ slug: "unknown-slug" }));
@@ -115,14 +102,14 @@ describe("TrendingDetailContent", () => {
     );
   });
 
-  it("renders happy path without stale notice for a fresh snapshot", async () => {
+  it("renders found happy path without stale notice for a fresh snapshot", async () => {
     const freshGeneratedAt = new Date(Date.now() - 60 * 60 * 1000);
     mockGetTrendingTopicBySlug.mockResolvedValue({
+      kind: "found",
       topic: aiTopic,
       allTopics: [aiTopic, climateTopic],
       episodes: [mockEpisode],
       generatedAt: freshGeneratedAt,
-      error: null,
     });
 
     render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
@@ -134,14 +121,14 @@ describe("TrendingDetailContent", () => {
     expect(screen.getByText(mockEpisode.title)).toBeInTheDocument();
   });
 
-  it("renders stale notice when snapshot is older than STALE_THRESHOLD_MS", async () => {
+  it("renders found + stale notice when snapshot is older than STALE_THRESHOLD_MS", async () => {
     const staleGeneratedAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000);
     mockGetTrendingTopicBySlug.mockResolvedValue({
+      kind: "found",
       topic: aiTopic,
       allTopics: [aiTopic],
       episodes: [mockEpisode],
       generatedAt: staleGeneratedAt,
-      error: null,
     });
 
     render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
@@ -149,13 +136,13 @@ describe("TrendingDetailContent", () => {
     expect(screen.getByText(/these trending topics may be out of date/i)).toBeInTheDocument();
   });
 
-  it("renders happy path with empty-episodes message when episodes is []", async () => {
+  it("renders found + empty-episodes message when episodes is []", async () => {
     mockGetTrendingTopicBySlug.mockResolvedValue({
+      kind: "found",
       topic: aiTopic,
       allTopics: [aiTopic],
       episodes: [],
       generatedAt: new Date(),
-      error: null,
     });
 
     render(await TrendingDetailContent({ slug: "artificial-intelligence" }));

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { TrendingTopic } from "@/db/schema";
+import type { RecommendedEpisodeDTO } from "@/db/library-columns";
+
+const mockGetTrendingTopicBySlug = vi.fn();
+vi.mock("@/app/actions/dashboard", () => ({
+  getTrendingTopicBySlug: (slug: string) => mockGetTrendingTopicBySlug(slug),
+}));
+
+import { TrendingDetailContent, STALE_THRESHOLD_MS } from "../trending-detail-content";
+
+const aiTopic: TrendingTopic = {
+  name: "Artificial Intelligence",
+  description: "AI trends",
+  episodeCount: 3,
+  episodeIds: [10, 20, 30],
+  slug: "artificial-intelligence",
+};
+
+const climateTopic: TrendingTopic = {
+  name: "Climate Policy",
+  description: "Climate news",
+  episodeCount: 2,
+  episodeIds: [40, 50],
+  slug: "climate-policy",
+};
+
+const mockEpisode: RecommendedEpisodeDTO = {
+  id: 10,
+  podcastIndexId: "pod-10",
+  title: "AI Episode",
+  description: "About AI",
+  audioUrl: "https://example.com/ai.mp3",
+  duration: 3600,
+  publishDate: new Date("2026-04-01T00:00:00Z"),
+  worthItScore: "8.50",
+  podcastTitle: "AI Podcast",
+  podcastImageUrl: "https://example.com/ai.jpg",
+  bestTopicRank: null,
+  topRankedTopic: null,
+};
+
+// Helper — render an async server component
+async function renderAsync(slug: string) {
+  const ui = await TrendingDetailContent({ slug });
+  return render(ui);
+}
+
+describe("TrendingDetailContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders error card when action returns error", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: null,
+      allTopics: [],
+      episodes: [],
+      generatedAt: null,
+      error: "Failed to load topic",
+    });
+
+    await renderAsync("artificial-intelligence");
+
+    expect(screen.getByRole("heading", { name: "Trending topics unavailable" })).toBeInTheDocument();
+    expect(screen.getByText(/refresh the page or try again/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    // The empty-state heading must NOT appear when an error is surfaced.
+    expect(screen.queryByRole("heading", { name: "No trending topics right now" })).not.toBeInTheDocument();
+  });
+
+  it("renders empty-snapshot fallback when allTopics is empty", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: null,
+      allTopics: [],
+      episodes: [],
+      generatedAt: null,
+      error: null,
+    });
+
+    await renderAsync("anything");
+
+    expect(screen.getByRole("heading", { name: "No trending topics right now" })).toBeInTheDocument();
+    expect(screen.getByText(/new trending topics are generated daily/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+
+  it("renders unknown-slug fallback with switcher when snapshot has other topics", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: null,
+      allTopics: [aiTopic, climateTopic],
+      episodes: [],
+      generatedAt: new Date(),
+      error: null,
+    });
+
+    await renderAsync("unknown-slug");
+
+    expect(
+      screen.getByRole("heading", { name: "This topic is no longer trending" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/didn't make the latest trending snapshot/i)).toBeInTheDocument();
+    // Both topics appear in the switcher.
+    expect(screen.getByRole("link", { name: "Artificial Intelligence" })).toHaveAttribute(
+      "href",
+      "/trending/artificial-intelligence",
+    );
+    expect(screen.getByRole("link", { name: "Climate Policy" })).toHaveAttribute(
+      "href",
+      "/trending/climate-policy",
+    );
+  });
+
+  it("renders happy path without stale notice for a fresh snapshot", async () => {
+    const freshGeneratedAt = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: aiTopic,
+      allTopics: [aiTopic, climateTopic],
+      episodes: [mockEpisode],
+      generatedAt: freshGeneratedAt,
+      error: null,
+    });
+
+    await renderAsync("artificial-intelligence");
+
+    expect(screen.getByRole("heading", { level: 1, name: aiTopic.name })).toBeInTheDocument();
+    expect(screen.queryByText(/may be out of date/i)).not.toBeInTheDocument();
+    expect(screen.getByText(aiTopic.description)).toBeInTheDocument();
+    expect(screen.getByText(/past 7 days/i)).toBeInTheDocument();
+    expect(screen.getByText(mockEpisode.title)).toBeInTheDocument();
+  });
+
+  it("renders stale notice when snapshot is older than STALE_THRESHOLD_MS", async () => {
+    const staleGeneratedAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000); // just past threshold
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: aiTopic,
+      allTopics: [aiTopic],
+      episodes: [mockEpisode],
+      generatedAt: staleGeneratedAt,
+      error: null,
+    });
+
+    await renderAsync("artificial-intelligence");
+
+    expect(screen.getByText(/these trending topics may be out of date/i)).toBeInTheDocument();
+  });
+
+  it("renders happy path with empty-episodes message when episodes is []", async () => {
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      topic: aiTopic,
+      allTopics: [aiTopic],
+      episodes: [],
+      generatedAt: new Date(),
+      error: null,
+    });
+
+    await renderAsync("artificial-intelligence");
+
+    expect(screen.getByText(/no episodes available for this topic yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -102,6 +102,19 @@ describe("TrendingDetailContent", () => {
     );
   });
 
+  it("appends stale notice to unknown-slug fallback when snapshot is stale", async () => {
+    const staleGeneratedAt = new Date(Date.now() - STALE_THRESHOLD_MS - 60_000);
+    mockGetTrendingTopicBySlug.mockResolvedValue({
+      kind: "unknown-slug",
+      allTopics: [aiTopic],
+      generatedAt: staleGeneratedAt,
+    });
+
+    render(await TrendingDetailContent({ slug: "unknown-slug" }));
+
+    expect(screen.getByText(/may be out of date/i)).toBeInTheDocument();
+  });
+
   it("renders found happy path without stale notice for a fresh snapshot", async () => {
     const freshGeneratedAt = new Date(Date.now() - 60 * 60 * 1000);
     mockGetTrendingTopicBySlug.mockResolvedValue({

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -133,7 +133,7 @@ describe("TrendingDetailContent", () => {
 
     render(await TrendingDetailContent({ slug: "artificial-intelligence" }));
 
-    expect(screen.getByText(/these trending topics may be out of date/i)).toBeInTheDocument();
+    expect(screen.getByText(/this trending topic may be out of date/i)).toBeInTheDocument();
   });
 
   it("renders found + empty-episodes message when episodes is []", async () => {

--- a/src/app/(app)/trending/[slug]/page.tsx
+++ b/src/app/(app)/trending/[slug]/page.tsx
@@ -2,6 +2,12 @@ import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TrendingDetailContent } from "./trending-detail-content";
 
+interface TrendingDetailPageProps {
+  params: {
+    slug: string;
+  };
+}
+
 function TrendingDetailLoading() {
   return (
     <div className="space-y-6">
@@ -26,7 +32,7 @@ function TrendingDetailLoading() {
   );
 }
 
-export default async function TrendingDetailPage({ params }: { params: { slug: string } }) {
+export default async function TrendingDetailPage({ params }: TrendingDetailPageProps) {
   return (
     <div className="space-y-6">
       <Suspense fallback={<TrendingDetailLoading />}>

--- a/src/app/(app)/trending/[slug]/page.tsx
+++ b/src/app/(app)/trending/[slug]/page.tsx
@@ -1,16 +1,6 @@
 import { Suspense } from "react";
-import Image from "next/image";
-import Link from "next/link";
-import { Rss } from "lucide-react";
-import { getTrendingTopicBySlug } from "@/app/actions/dashboard";
-import { TopicSwitcher } from "@/components/trending/topic-switcher";
-import { WorthItBadge } from "@/components/episodes/worth-it-badge";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatDate, formatDuration, formatRelativeTime, stripHtml } from "@/lib/utils";
-import type { RecommendedEpisodeDTO } from "@/db/library-columns";
-
-const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+import { TrendingDetailContent } from "./trending-detail-content";
 
 function TrendingDetailLoading() {
   return (
@@ -32,112 +22,6 @@ function TrendingDetailLoading() {
           </div>
         ))}
       </div>
-    </div>
-  );
-}
-
-function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
-  return (
-    <Link
-      href={`/episode/${episode.podcastIndexId}`}
-      className="flex gap-3 rounded-lg p-2 transition-colors hover:bg-accent"
-    >
-      <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
-        {episode.podcastImageUrl ? (
-          <Image
-            src={episode.podcastImageUrl}
-            alt={episode.podcastTitle}
-            fill
-            className="object-cover"
-            sizes="56px"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <Rss className="h-6 w-6" />
-          </div>
-        )}
-      </div>
-      <div className="min-w-0 flex-1">
-        <h4 className="line-clamp-1 text-sm font-medium">{episode.title}</h4>
-        <p className="line-clamp-1 text-xs text-muted-foreground">{episode.podcastTitle}</p>
-        {episode.description && (
-          <p className="line-clamp-2 text-xs text-muted-foreground">
-            {stripHtml(episode.description)}
-          </p>
-        )}
-        <div className="mt-1 flex flex-wrap items-center gap-2">
-          <WorthItBadge score={episode.worthItScore != null ? Number(episode.worthItScore) : null} />
-          <span className="text-xs text-muted-foreground">
-            {formatDuration(episode.duration)}
-            {episode.publishDate && <> &middot; {formatDate(episode.publishDate)}</>}
-          </span>
-        </div>
-      </div>
-    </Link>
-  );
-}
-
-async function TrendingDetailContent({ slug }: { slug: string }) {
-  const { topic, allTopics, episodes, generatedAt, error } = await getTrendingTopicBySlug(slug);
-
-  if (error) {
-    console.error("[TrendingDetailContent]", error);
-  }
-
-  // No snapshot or unknown slug
-  if (!topic) {
-    const heading = allTopics.length === 0 ? "No trending topics right now" : "This topic is no longer trending";
-    const body =
-      allTopics.length === 0
-        ? "Check back soon — new trending topics are generated daily."
-        : "This topic didn't make the latest trending snapshot. Browse other topics below.";
-
-    return (
-      <div className="space-y-6">
-        <h1 className="text-3xl font-bold tracking-tight">{heading}</h1>
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <p className="text-sm text-muted-foreground">{body}</p>
-            <TopicSwitcher topics={allTopics} activeSlug={slug} />
-            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
-              Back to dashboard
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  const isStale = generatedAt != null && Date.now() - generatedAt.getTime() > STALE_THRESHOLD_MS;
-
-  return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
-
-      {isStale && (
-        <p className="text-sm text-muted-foreground">
-          These trending topics may be out of date.
-        </p>
-      )}
-
-      <TopicSwitcher topics={allTopics} activeSlug={slug} />
-
-      <div>
-        <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
-        <p className="text-sm text-muted-foreground">
-          Past 7 days &middot; Updated {generatedAt ? formatRelativeTime(generatedAt) : "unknown"}
-        </p>
-      </div>
-
-      {episodes.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No episodes available for this topic yet.</p>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {episodes.map((episode) => (
-            <EpisodeCard key={episode.id} episode={episode} />
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/app/(app)/trending/[slug]/page.tsx
+++ b/src/app/(app)/trending/[slug]/page.tsx
@@ -1,0 +1,157 @@
+import { Suspense } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Rss } from "lucide-react";
+import { getTrendingTopicBySlug } from "@/app/actions/dashboard";
+import { TopicSwitcher } from "@/components/trending/topic-switcher";
+import { WorthItBadge } from "@/components/episodes/worth-it-badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatDate, formatDuration, formatRelativeTime, stripHtml } from "@/lib/utils";
+import type { RecommendedEpisodeDTO } from "@/db/library-columns";
+
+const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+function TrendingDetailLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-2 overflow-x-auto pb-2">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-8 w-28 shrink-0 rounded-full" />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="flex gap-3 p-2">
+            <Skeleton className="h-14 w-14 shrink-0 rounded-md" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
+  return (
+    <Link
+      href={`/episode/${episode.podcastIndexId}`}
+      className="flex gap-3 rounded-lg p-2 transition-colors hover:bg-accent"
+    >
+      <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
+        {episode.podcastImageUrl ? (
+          <Image
+            src={episode.podcastImageUrl}
+            alt={episode.podcastTitle}
+            fill
+            className="object-cover"
+            sizes="56px"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <Rss className="h-6 w-6" />
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <h4 className="line-clamp-1 text-sm font-medium">{episode.title}</h4>
+        <p className="line-clamp-1 text-xs text-muted-foreground">{episode.podcastTitle}</p>
+        {episode.description && (
+          <p className="line-clamp-2 text-xs text-muted-foreground">
+            {stripHtml(episode.description)}
+          </p>
+        )}
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <WorthItBadge score={episode.worthItScore != null ? Number(episode.worthItScore) : null} />
+          <span className="text-xs text-muted-foreground">
+            {formatDuration(episode.duration)}
+            {episode.publishDate && <> &middot; {formatDate(episode.publishDate)}</>}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+async function TrendingDetailContent({ slug }: { slug: string }) {
+  const { topic, allTopics, episodes, generatedAt, error } = await getTrendingTopicBySlug(slug);
+
+  if (error) {
+    console.error("[TrendingDetailContent]", error);
+  }
+
+  // No snapshot or unknown slug
+  if (!topic) {
+    const heading = allTopics.length === 0 ? "No trending topics right now" : "This topic is no longer trending";
+    const body =
+      allTopics.length === 0
+        ? "Check back soon — new trending topics are generated daily."
+        : "This topic didn't make the latest trending snapshot. Browse other topics below.";
+
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{heading}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">{body}</p>
+            <TopicSwitcher topics={allTopics} activeSlug={slug} />
+            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const isStale = generatedAt != null && Date.now() - generatedAt.getTime() > STALE_THRESHOLD_MS;
+
+  return (
+    <div className="space-y-6">
+      {isStale && (
+        <p className="text-sm text-muted-foreground">
+          These trending topics may be out of date.
+        </p>
+      )}
+
+      <TopicSwitcher topics={allTopics} activeSlug={slug} />
+
+      <div>
+        <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
+        <p className="text-sm text-muted-foreground">
+          Past 7 days &middot; Updated {generatedAt ? formatRelativeTime(generatedAt) : "unknown"}
+        </p>
+      </div>
+
+      {episodes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No episodes available for this topic yet.</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {episodes.map((episode) => (
+            <EpisodeCard key={episode.id} episode={episode} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default async function TrendingDetailPage({ params }: { params: { slug: string } }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight capitalize">
+          {params.slug.replace(/-/g, " ")}
+        </h1>
+      </div>
+      <Suspense fallback={<TrendingDetailLoading />}>
+        <TrendingDetailContent slug={params.slug} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(app)/trending/[slug]/page.tsx
+++ b/src/app/(app)/trending/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { Rss } from "lucide-react";
 import { getTrendingTopicBySlug } from "@/app/actions/dashboard";
 import { TopicSwitcher } from "@/components/trending/topic-switcher";
 import { WorthItBadge } from "@/components/episodes/worth-it-badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, formatDuration, formatRelativeTime, stripHtml } from "@/lib/utils";
 import type { RecommendedEpisodeDTO } from "@/db/library-columns";
@@ -15,6 +15,7 @@ const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
 function TrendingDetailLoading() {
   return (
     <div className="space-y-6">
+      <Skeleton className="h-9 w-64" />
       <div className="flex gap-2 overflow-x-auto pb-2">
         {[1, 2, 3, 4, 5].map((i) => (
           <Skeleton key={i} className="h-8 w-28 shrink-0 rounded-full" />
@@ -93,11 +94,9 @@ async function TrendingDetailContent({ slug }: { slug: string }) {
 
     return (
       <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">{heading}</h1>
         <Card>
-          <CardHeader>
-            <CardTitle>{heading}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-4 pt-6">
             <p className="text-sm text-muted-foreground">{body}</p>
             <TopicSwitcher topics={allTopics} activeSlug={slug} />
             <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
@@ -113,6 +112,8 @@ async function TrendingDetailContent({ slug }: { slug: string }) {
 
   return (
     <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
+
       {isStale && (
         <p className="text-sm text-muted-foreground">
           These trending topics may be out of date.
@@ -144,11 +145,6 @@ async function TrendingDetailContent({ slug }: { slug: string }) {
 export default async function TrendingDetailPage({ params }: { params: { slug: string } }) {
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight capitalize">
-          {params.slug.replace(/-/g, " ")}
-        </h1>
-      </div>
       <Suspense fallback={<TrendingDetailLoading />}>
         <TrendingDetailContent slug={params.slug} />
       </Suspense>

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -60,8 +60,12 @@ function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
         <div className="mt-1 flex flex-wrap items-center gap-2">
           <WorthItBadge score={episode.worthItScore != null ? Number(episode.worthItScore) : null} />
           <span className="text-xs text-muted-foreground">
-            {formatDuration(episode.duration)}
-            {episode.publishDate && <> &middot; {formatDate(episode.publishDate)}</>}
+            {[
+              formatDuration(episode.duration),
+              episode.publishDate ? formatDate(episode.publishDate) : "",
+            ]
+              .filter(Boolean)
+              .join(" · ")}
           </span>
         </div>
       </div>

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -38,7 +38,7 @@ function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
         {episode.podcastImageUrl ? (
           <Image
             src={episode.podcastImageUrl}
-            alt={episode.podcastTitle}
+            alt=""
             fill
             className="object-cover"
             sizes="56px"
@@ -94,15 +94,19 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
         />
       );
 
-    case "unknown-slug":
+    case "unknown-slug": {
+      const staleNotice = isTrendingSnapshotStale(result.generatedAt)
+        ? " These trending topics may be out of date."
+        : "";
       return (
         <FallbackCard
           heading="This topic is no longer trending"
-          body="This topic didn't make the latest trending snapshot. Browse other topics below."
+          body={`This topic didn't make the latest trending snapshot. Browse other topics below.${staleNotice}`}
         >
           <TopicSwitcher topics={result.allTopics} activeSlug={slug} />
         </FallbackCard>
       );
+    }
 
     case "found": {
       const { topic, allTopics, episodes, generatedAt } = result;
@@ -119,7 +123,7 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
             </p>
             {isTrendingSnapshotStale(generatedAt) && (
               <p className="text-sm text-muted-foreground">
-                These trending topics may be out of date.
+                This trending topic may be out of date.
               </p>
             )}
           </div>

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -31,6 +31,7 @@ function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
   return (
     <Link
       href={`/episode/${episode.podcastIndexId}`}
+      aria-label={`${episode.title} from ${episode.podcastTitle}`}
       className="flex gap-3 rounded-lg p-2 transition-colors hover:bg-accent"
     >
       <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
@@ -72,7 +73,7 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
   const { topic, allTopics, episodes, generatedAt, error } = await getTrendingTopicBySlug(slug);
 
   if (error) {
-    console.error("[TrendingDetailContent] slug=%s error=%s", slug, error);
+    // Action already logs the underlying error with full context; no duplicate log here.
     return (
       <FallbackCard
         heading="Trending topics unavailable"
@@ -99,11 +100,15 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
     );
   }
 
+  // Invariant: when topic is non-null, the action returns it with the same
+  // snapshot row's generatedAt, so generatedAt is guaranteed non-null here.
+  const snapshotTime = generatedAt as Date;
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
 
-      {isTrendingSnapshotStale(generatedAt) && (
+      {isTrendingSnapshotStale(snapshotTime) && (
         <p className="text-sm text-muted-foreground">
           These trending topics may be out of date.
         </p>
@@ -113,11 +118,9 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
 
       <div>
         <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
-        {generatedAt && (
-          <p className="text-sm text-muted-foreground">
-            Past 7 days &middot; Updated {formatRelativeTime(generatedAt)}
-          </p>
-        )}
+        <p className="text-sm text-muted-foreground">
+          Past 7 days &middot; Updated {formatRelativeTime(snapshotTime)}
+        </p>
       </div>
 
       {episodes.length === 0 ? (

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -110,12 +110,6 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
         <div className="space-y-6">
           <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
 
-          {isTrendingSnapshotStale(generatedAt) && (
-            <p className="text-sm text-muted-foreground">
-              These trending topics may be out of date.
-            </p>
-          )}
-
           <TopicSwitcher topics={allTopics} activeSlug={slug} />
 
           <div>
@@ -123,6 +117,11 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
             <p className="text-sm text-muted-foreground">
               Past 7 days &middot; Updated {formatRelativeTime(generatedAt)}
             </p>
+            {isTrendingSnapshotStale(generatedAt) && (
+              <p className="text-sm text-muted-foreground">
+                These trending topics may be out of date.
+              </p>
+            )}
           </div>
 
           {episodes.length === 0 ? (
@@ -136,6 +135,13 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
           )}
         </div>
       );
+    }
+
+    default: {
+      // Exhaustiveness guard: if TrendingTopicDetailResult gains a new kind,
+      // TypeScript will reject this assignment so the case gets handled.
+      const _exhaustive: never = result;
+      return _exhaustive;
     }
   }
 }

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -1,0 +1,136 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Rss } from "lucide-react";
+import { getTrendingTopicBySlug } from "@/app/actions/dashboard";
+import { TopicSwitcher } from "@/components/trending/topic-switcher";
+import { WorthItBadge } from "@/components/episodes/worth-it-badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatDate, formatDuration, formatRelativeTime, stripHtml } from "@/lib/utils";
+import type { RecommendedEpisodeDTO } from "@/db/library-columns";
+
+// Two daily-cron cycles missed; trending snapshots are generated once per day.
+export const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
+  return (
+    <Link
+      href={`/episode/${episode.podcastIndexId}`}
+      className="flex gap-3 rounded-lg p-2 transition-colors hover:bg-accent"
+    >
+      <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
+        {episode.podcastImageUrl ? (
+          <Image
+            src={episode.podcastImageUrl}
+            alt={episode.podcastTitle}
+            fill
+            className="object-cover"
+            sizes="56px"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <Rss className="h-6 w-6" />
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <h4 className="line-clamp-1 text-sm font-medium">{episode.title}</h4>
+        <p className="line-clamp-1 text-xs text-muted-foreground">{episode.podcastTitle}</p>
+        {episode.description && (
+          <p className="line-clamp-2 text-xs text-muted-foreground">
+            {stripHtml(episode.description)}
+          </p>
+        )}
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <WorthItBadge score={episode.worthItScore != null ? Number(episode.worthItScore) : null} />
+          <span className="text-xs text-muted-foreground">
+            {formatDuration(episode.duration)}
+            {episode.publishDate && <> &middot; {formatDate(episode.publishDate)}</>}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export async function TrendingDetailContent({ slug }: { slug: string }) {
+  const { topic, allTopics, episodes, generatedAt, error } = await getTrendingTopicBySlug(slug);
+
+  if (error) {
+    console.error("[TrendingDetailContent] slug=%s error=%s", slug, error);
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Trending topics unavailable</h1>
+        <Card>
+          <CardContent className="space-y-4 pt-6">
+            <p className="text-sm text-muted-foreground">
+              We couldn&apos;t load trending topics right now. Refresh the page or try again in a moment.
+            </p>
+            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!topic) {
+    // Two empty states: no snapshot at all vs. a current snapshot that just
+    // doesn't include this slug (e.g. the topic fell out of the latest run).
+    const heading = allTopics.length === 0 ? "No trending topics right now" : "This topic is no longer trending";
+    const body =
+      allTopics.length === 0
+        ? "Check back soon — new trending topics are generated daily."
+        : "This topic didn't make the latest trending snapshot. Browse other topics below.";
+
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">{heading}</h1>
+        <Card>
+          <CardContent className="space-y-4 pt-6">
+            <p className="text-sm text-muted-foreground">{body}</p>
+            <TopicSwitcher topics={allTopics} activeSlug={slug} />
+            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const isStale = generatedAt != null && Date.now() - generatedAt.getTime() > STALE_THRESHOLD_MS;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
+
+      {isStale && (
+        <p className="text-sm text-muted-foreground">
+          These trending topics may be out of date.
+        </p>
+      )}
+
+      <TopicSwitcher topics={allTopics} activeSlug={slug} />
+
+      <div>
+        <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
+        {generatedAt && (
+          <p className="text-sm text-muted-foreground">
+            Past 7 days &middot; Updated {formatRelativeTime(generatedAt)}
+          </p>
+        )}
+      </div>
+
+      {episodes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No episodes available for this topic yet.</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {episodes.map((episode) => (
+            <EpisodeCard key={episode.id} episode={episode} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -144,8 +144,10 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
     default: {
       // Exhaustiveness guard: if TrendingTopicDetailResult gains a new kind,
       // TypeScript will reject this assignment so the case gets handled.
+      // Throw rather than return so any bypass of type-checking fails loudly
+      // at runtime instead of rendering nothing.
       const _exhaustive: never = result;
-      return _exhaustive;
+      throw new Error(`Unhandled TrendingTopicDetailResult kind: ${JSON.stringify(_exhaustive)}`);
     }
   }
 }

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Rss } from "lucide-react";
@@ -6,10 +7,25 @@ import { TopicSwitcher } from "@/components/trending/topic-switcher";
 import { WorthItBadge } from "@/components/episodes/worth-it-badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatDate, formatDuration, formatRelativeTime, stripHtml } from "@/lib/utils";
+import { isTrendingSnapshotStale } from "@/lib/trending";
 import type { RecommendedEpisodeDTO } from "@/db/library-columns";
 
-// Two daily-cron cycles missed; trending snapshots are generated once per day.
-export const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+function FallbackCard({ heading, body, children }: { heading: string; body: string; children?: ReactNode }) {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">{heading}</h1>
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <p className="text-sm text-muted-foreground">{body}</p>
+          {children}
+          <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
+            Back to dashboard
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
   return (
@@ -58,54 +74,36 @@ export async function TrendingDetailContent({ slug }: { slug: string }) {
   if (error) {
     console.error("[TrendingDetailContent] slug=%s error=%s", slug, error);
     return (
-      <div className="space-y-6">
-        <h1 className="text-3xl font-bold tracking-tight">Trending topics unavailable</h1>
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <p className="text-sm text-muted-foreground">
-              We couldn&apos;t load trending topics right now. Refresh the page or try again in a moment.
-            </p>
-            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
-              Back to dashboard
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
+      <FallbackCard
+        heading="Trending topics unavailable"
+        body="We couldn't load trending topics right now. Refresh the page or try again in a moment."
+      />
     );
   }
 
   if (!topic) {
-    // Two empty states: no snapshot at all vs. a current snapshot that just
-    // doesn't include this slug (e.g. the topic fell out of the latest run).
-    const heading = allTopics.length === 0 ? "No trending topics right now" : "This topic is no longer trending";
-    const body =
-      allTopics.length === 0
-        ? "Check back soon — new trending topics are generated daily."
-        : "This topic didn't make the latest trending snapshot. Browse other topics below.";
-
+    // Two empty states: no snapshot at all (allTopics empty) vs. a current
+    // snapshot that just doesn't include this slug (topic fell out of the run).
+    const isEmpty = allTopics.length === 0;
     return (
-      <div className="space-y-6">
-        <h1 className="text-3xl font-bold tracking-tight">{heading}</h1>
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <p className="text-sm text-muted-foreground">{body}</p>
-            <TopicSwitcher topics={allTopics} activeSlug={slug} />
-            <Link href="/dashboard" className="text-sm text-primary underline-offset-4 hover:underline">
-              Back to dashboard
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
+      <FallbackCard
+        heading={isEmpty ? "No trending topics right now" : "This topic is no longer trending"}
+        body={
+          isEmpty
+            ? "Check back soon — new trending topics are generated daily."
+            : "This topic didn't make the latest trending snapshot. Browse other topics below."
+        }
+      >
+        <TopicSwitcher topics={allTopics} activeSlug={slug} />
+      </FallbackCard>
     );
   }
-
-  const isStale = generatedAt != null && Date.now() - generatedAt.getTime() > STALE_THRESHOLD_MS;
 
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
 
-      {isStale && (
+      {isTrendingSnapshotStale(generatedAt) && (
         <p className="text-sm text-muted-foreground">
           These trending topics may be out of date.
         </p>

--- a/src/app/(app)/trending/[slug]/trending-detail-content.tsx
+++ b/src/app/(app)/trending/[slug]/trending-detail-content.tsx
@@ -70,68 +70,68 @@ function EpisodeCard({ episode }: { episode: RecommendedEpisodeDTO }) {
 }
 
 export async function TrendingDetailContent({ slug }: { slug: string }) {
-  const { topic, allTopics, episodes, generatedAt, error } = await getTrendingTopicBySlug(slug);
+  const result = await getTrendingTopicBySlug(slug);
 
-  if (error) {
-    // Action already logs the underlying error with full context; no duplicate log here.
-    return (
-      <FallbackCard
-        heading="Trending topics unavailable"
-        body="We couldn't load trending topics right now. Refresh the page or try again in a moment."
-      />
-    );
-  }
+  switch (result.kind) {
+    case "error":
+      // Action already logs the underlying error with full context.
+      return (
+        <FallbackCard
+          heading="Trending topics unavailable"
+          body="We couldn't load trending topics right now. Refresh the page or try again in a moment."
+        />
+      );
 
-  if (!topic) {
-    // Two empty states: no snapshot at all (allTopics empty) vs. a current
-    // snapshot that just doesn't include this slug (topic fell out of the run).
-    const isEmpty = allTopics.length === 0;
-    return (
-      <FallbackCard
-        heading={isEmpty ? "No trending topics right now" : "This topic is no longer trending"}
-        body={
-          isEmpty
-            ? "Check back soon — new trending topics are generated daily."
-            : "This topic didn't make the latest trending snapshot. Browse other topics below."
-        }
-      >
-        <TopicSwitcher topics={allTopics} activeSlug={slug} />
-      </FallbackCard>
-    );
-  }
+    case "no-snapshot":
+      return (
+        <FallbackCard
+          heading="No trending topics right now"
+          body="Check back soon — new trending topics are generated daily."
+        />
+      );
 
-  // Invariant: when topic is non-null, the action returns it with the same
-  // snapshot row's generatedAt, so generatedAt is guaranteed non-null here.
-  const snapshotTime = generatedAt as Date;
+    case "unknown-slug":
+      return (
+        <FallbackCard
+          heading="This topic is no longer trending"
+          body="This topic didn't make the latest trending snapshot. Browse other topics below."
+        >
+          <TopicSwitcher topics={result.allTopics} activeSlug={slug} />
+        </FallbackCard>
+      );
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
+    case "found": {
+      const { topic, allTopics, episodes, generatedAt } = result;
+      return (
+        <div className="space-y-6">
+          <h1 className="text-3xl font-bold tracking-tight">{topic.name}</h1>
 
-      {isTrendingSnapshotStale(snapshotTime) && (
-        <p className="text-sm text-muted-foreground">
-          These trending topics may be out of date.
-        </p>
-      )}
+          {isTrendingSnapshotStale(generatedAt) && (
+            <p className="text-sm text-muted-foreground">
+              These trending topics may be out of date.
+            </p>
+          )}
 
-      <TopicSwitcher topics={allTopics} activeSlug={slug} />
+          <TopicSwitcher topics={allTopics} activeSlug={slug} />
 
-      <div>
-        <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
-        <p className="text-sm text-muted-foreground">
-          Past 7 days &middot; Updated {formatRelativeTime(snapshotTime)}
-        </p>
-      </div>
+          <div>
+            <p className="mb-1 text-sm text-muted-foreground">{topic.description}</p>
+            <p className="text-sm text-muted-foreground">
+              Past 7 days &middot; Updated {formatRelativeTime(generatedAt)}
+            </p>
+          </div>
 
-      {episodes.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No episodes available for this topic yet.</p>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {episodes.map((episode) => (
-            <EpisodeCard key={episode.id} episode={episode} />
-          ))}
+          {episodes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No episodes available for this topic yet.</p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {episodes.map((episode) => (
+                <EpisodeCard key={episode.id} episode={episode} />
+              ))}
+            </div>
+          )}
         </div>
-      )}
-    </div>
-  );
+      );
+    }
+  }
 }

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -19,6 +19,7 @@ const mockSelect = vi.fn();
 // The select chain must handle these shapes:
 //   Subqueries:       select().from().where()                  (return value unused)
 //   Main query:       select().from().innerJoin().where().orderBy().limit()
+//   Trending by-slug: select().from().innerJoin().where().orderBy()   → Promise<row[]>
 //   Score lookup:     select().from().where()  → Promise<row[]>
 //   Rank lookup:      select().from().where().groupBy()        → Promise<row[]>
 //   Union query:      select().from().where().union(select().from().where())
@@ -121,7 +122,13 @@ vi.mock("drizzle-orm", () => ({
   isNotNull: vi.fn((...args: unknown[]) => ({ _op: "isNotNull", args })),
   notInArray: vi.fn((...args: unknown[]) => ({ _op: "notInArray", args })),
   inArray: vi.fn((...args: unknown[]) => ({ _op: "inArray", args })),
-  sql: vi.fn((_strings: TemplateStringsArray, ..._values: unknown[]) => ({ _op: "sql" })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    _op: "sql",
+    // Join the raw template parts so tests can assert the generated SQL text
+    // (e.g. `DESC NULLS LAST` can't be derived from Drizzle's desc() helper).
+    raw: Array.from(strings).join("?"),
+    values,
+  })),
 }));
 
 // Mock topic-overlap — keeps dashboard tests focused on wiring, not overlap logic
@@ -1034,8 +1041,18 @@ describe("getTrendingTopicBySlug", () => {
     expect(result.episodes).toHaveLength(2);
     expect(result.episodes[0].bestTopicRank).toBeNull();
     expect(result.episodes[0].topRankedTopic).toBeNull();
-    // null-score row should still be returned (ordering is DB-side)
     expect(result.episodes[1].worthItScore).toBeNull();
+
+    // Guard against regression to plain desc(): pg defaults DESC to NULLS FIRST,
+    // so unscored episodes would float to the top without the raw-SQL override.
+    const orderArgs = mockOrderBy.mock.calls[0];
+    expect(orderArgs).toBeDefined();
+    const rawSqlClauses = orderArgs
+      .filter((arg: unknown): arg is { _op: "sql"; raw: string } =>
+        typeof arg === "object" && arg !== null && (arg as { _op?: string })._op === "sql",
+      )
+      .map((arg) => arg.raw);
+    expect(rawSqlClauses.join(" ")).toContain("DESC NULLS LAST");
   });
 
   it("returns topic with empty episodes when matched topic has no episodeIds", async () => {

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -1099,9 +1099,10 @@ describe("getTrendingTopicBySlug", () => {
     expect(result.error).toBeNull();
   });
 
-  it("returns error on DB failure", async () => {
+  it("returns error on DB failure and logs the slug context", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockRejectedValue(new Error("DB connection failed"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
@@ -1111,5 +1112,11 @@ describe("getTrendingTopicBySlug", () => {
     expect(result.episodes).toEqual([]);
     expect(result.generatedAt).toBeNull();
     expect(result.error).toMatch(/failed to load/i);
+
+    // The log must carry the slug so ops can correlate failures to requests.
+    const loggedSlug = errorSpy.mock.calls.some((args) =>
+      args.some((arg) => typeof arg === "object" && arg !== null && (arg as { slug?: string }).slug === "artificial-intelligence"),
+    );
+    expect(loggedSlug).toBe(true);
   });
 });

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -136,7 +136,8 @@ vi.mock("drizzle-orm", () => ({
     _op: "sql",
     // Join the raw template parts so tests can assert the generated SQL text
     // (e.g. `DESC NULLS LAST` can't be derived from Drizzle's desc() helper).
-    raw: Array.from(strings).join("?"),
+    // Placeholder `$_` avoids collisions with literal `?` characters in templates.
+    raw: Array.from(strings).join("$_"),
     values,
   })),
 }));

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -1015,7 +1015,21 @@ describe("getTrendingTopicBySlug", () => {
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
 
     await expect(getTrendingTopicBySlug("artificial-intelligence")).rejects.toThrow(/NEXT_REDIRECT/);
-    expect(mockRedirect).toHaveBeenCalledWith("/sign-in?redirect_url=/trending/artificial-intelligence");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      `/sign-in?redirect_url=${encodeURIComponent("/trending/artificial-intelligence")}`,
+    );
+  });
+
+  it("encodes the slug in the sign-in redirect URL to prevent query-param injection", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+
+    // A slug with reserved URL chars: `&` would break the /sign-in querystring without encoding.
+    await expect(getTrendingTopicBySlug("foo&evil=injected")).rejects.toThrow(/NEXT_REDIRECT/);
+    const redirectedTo = mockRedirect.mock.calls[0][0] as string;
+    expect(redirectedTo).not.toContain("&evil=injected");
+    expect(redirectedTo).toBe(`/sign-in?redirect_url=${encodeURIComponent("/trending/foo&evil=injected")}`);
   });
 
   it("returns { kind: 'no-snapshot' } when no snapshot exists", async () => {

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -1046,7 +1046,9 @@ describe("getTrendingTopicBySlug", () => {
   it("returns { kind: 'found', ... } with episodes when slug matches a topic", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockResolvedValue(makeSnapshot([aiTopic, climateTopic]));
-    mockOrderBy.mockResolvedValue([mockEpisodeRow, mockEpisodeRowNullScore]);
+    // Chain now terminates with .limit() at the DB layer so the display cap
+    // respects sort order over the full candidate set.
+    mockLimit.mockResolvedValue([mockEpisodeRow, mockEpisodeRowNullScore]);
 
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
@@ -1071,6 +1073,10 @@ describe("getTrendingTopicBySlug", () => {
       )
       .map((arg) => arg.raw);
     expect(rawSqlClauses.join(" ")).toContain("DESC NULLS LAST");
+
+    // Display cap must run at the DB layer (after orderBy) so top-scored
+    // episodes can't be silently dropped by an LLM-order truncation.
+    expect(mockLimit).toHaveBeenCalledWith(50);
   });
 
   it("returns { kind: 'found', episodes: [] } when matched topic has no episodeIds", async () => {

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -932,3 +932,167 @@ describe("getRecentEpisodesFromSubscriptions", () => {
     expect(result.error).toMatch(/failed to load/i);
   });
 });
+
+describe("getTrendingTopicBySlug", () => {
+  const GENERATED_AT = new Date("2026-04-17T06:00:00Z");
+
+  const makeSnapshot = (topics: object[]) => ({
+    id: 1,
+    topics,
+    generatedAt: GENERATED_AT,
+    periodStart: new Date("2026-04-10T06:00:00Z"),
+    periodEnd: GENERATED_AT,
+    episodeCount: topics.length,
+    createdAt: GENERATED_AT,
+  });
+
+  const aiTopic = {
+    name: "Artificial Intelligence",
+    description: "AI trends",
+    episodeCount: 3,
+    episodeIds: [10, 20, 30],
+    slug: "artificial-intelligence",
+  };
+
+  const climateTopic = {
+    name: "Climate Policy",
+    description: "Climate news",
+    episodeCount: 2,
+    episodeIds: [40, 50],
+    slug: "climate-policy",
+  };
+
+  const mockEpisodeRow = {
+    id: 10,
+    podcastIndexId: "pod-10",
+    title: "AI Episode",
+    description: "About AI",
+    audioUrl: "https://example.com/ai.mp3",
+    duration: 3600,
+    publishDate: new Date("2026-04-01T00:00:00Z"),
+    worthItScore: "8.50",
+    podcastTitle: "AI Podcast",
+    podcastImageUrl: "https://example.com/ai.jpg",
+  };
+
+  const mockEpisodeRowNullScore = {
+    ...mockEpisodeRow,
+    id: 20,
+    worthItScore: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("returns signed-in error when userId is null", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("artificial-intelligence");
+
+    expect(result.topic).toBeNull();
+    expect(result.allTopics).toEqual([]);
+    expect(result.episodes).toEqual([]);
+    expect(result.generatedAt).toBeNull();
+    expect(result.error).toMatch(/signed in/i);
+  });
+
+  it("returns empty result when no snapshot exists", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockResolvedValue(undefined);
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("artificial-intelligence");
+
+    expect(result.topic).toBeNull();
+    expect(result.allTopics).toEqual([]);
+    expect(result.episodes).toEqual([]);
+    expect(result.generatedAt).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it("returns topic and episodes when slug matches a topic with episodeIds", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockResolvedValue(makeSnapshot([aiTopic, climateTopic]));
+    mockOrderBy.mockResolvedValue([mockEpisodeRow, mockEpisodeRowNullScore]);
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("artificial-intelligence");
+
+    expect(result.error).toBeNull();
+    expect(result.topic).toMatchObject({ name: "Artificial Intelligence", slug: "artificial-intelligence" });
+    expect(result.allTopics).toHaveLength(2);
+    expect(result.generatedAt).toEqual(GENERATED_AT);
+    expect(result.episodes).toHaveLength(2);
+    expect(result.episodes[0].bestTopicRank).toBeNull();
+    expect(result.episodes[0].topRankedTopic).toBeNull();
+    // null-score row should still be returned (ordering is DB-side)
+    expect(result.episodes[1].worthItScore).toBeNull();
+  });
+
+  it("returns topic with empty episodes when matched topic has no episodeIds", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    const emptyTopic = { ...aiTopic, episodeIds: [] };
+    mockFindFirst.mockResolvedValue(makeSnapshot([emptyTopic, climateTopic]));
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("artificial-intelligence");
+
+    expect(result.error).toBeNull();
+    expect(result.topic).toMatchObject({ name: "Artificial Intelligence" });
+    expect(result.episodes).toEqual([]);
+  });
+
+  it("returns topic:null and allTopics when slug is unknown", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockResolvedValue(makeSnapshot([aiTopic, climateTopic]));
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("unknown-slug-garbage");
+
+    expect(result.topic).toBeNull();
+    expect(result.allTopics).toHaveLength(2);
+    expect(result.episodes).toEqual([]);
+    expect(result.error).toBeNull();
+  });
+
+  it("matches legacy topic without slug via slugify(name)", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    // Legacy row: no slug field
+    const legacyTopic = {
+      name: "Space Exploration",
+      description: "Space news",
+      episodeCount: 1,
+      episodeIds: [],
+    };
+    mockFindFirst.mockResolvedValue(makeSnapshot([legacyTopic]));
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("space-exploration");
+
+    expect(result.topic).toMatchObject({ name: "Space Exploration" });
+    expect(result.error).toBeNull();
+  });
+
+  it("returns error on DB failure", async () => {
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+    mockFindFirst.mockRejectedValue(new Error("DB connection failed"));
+
+    const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
+    const result = await getTrendingTopicBySlug("artificial-intelligence");
+
+    expect(result.topic).toBeNull();
+    expect(result.allTopics).toEqual([]);
+    expect(result.episodes).toEqual([]);
+    expect(result.generatedAt).toBeNull();
+    expect(result.error).toMatch(/failed to load/i);
+  });
+});

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -6,6 +6,16 @@ vi.mock("@clerk/nextjs/server", () => ({
   auth: () => mockAuth(),
 }));
 
+// Mock next/navigation — mirrors Next's behavior (redirect throws NEXT_REDIRECT).
+const mockRedirect = vi.fn((url: string) => {
+  const err = new Error(`NEXT_REDIRECT: ${url}`);
+  (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;${url}`;
+  throw err;
+});
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+}));
+
 // Mock DB select chain
 const mockLimit = vi.fn();
 const mockOrderBy = vi.fn();
@@ -999,34 +1009,26 @@ describe("getTrendingTopicBySlug", () => {
     vi.resetModules();
   });
 
-  it("returns signed-in error when userId is null", async () => {
+  it("redirects to /sign-in when userId is null", async () => {
     mockAuth.mockResolvedValue({ userId: null });
 
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
-    const result = await getTrendingTopicBySlug("artificial-intelligence");
 
-    expect(result.topic).toBeNull();
-    expect(result.allTopics).toEqual([]);
-    expect(result.episodes).toEqual([]);
-    expect(result.generatedAt).toBeNull();
-    expect(result.error).toMatch(/signed in/i);
+    await expect(getTrendingTopicBySlug("artificial-intelligence")).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(mockRedirect).toHaveBeenCalledWith("/sign-in?redirect_url=/trending/artificial-intelligence");
   });
 
-  it("returns empty result when no snapshot exists", async () => {
+  it("returns { kind: 'no-snapshot' } when no snapshot exists", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockResolvedValue(undefined);
 
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
 
-    expect(result.topic).toBeNull();
-    expect(result.allTopics).toEqual([]);
-    expect(result.episodes).toEqual([]);
-    expect(result.generatedAt).toBeNull();
-    expect(result.error).toBeNull();
+    expect(result).toEqual({ kind: "no-snapshot" });
   });
 
-  it("returns topic and episodes when slug matches a topic with episodeIds", async () => {
+  it("returns { kind: 'found', ... } with episodes when slug matches a topic", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockResolvedValue(makeSnapshot([aiTopic, climateTopic]));
     mockOrderBy.mockResolvedValue([mockEpisodeRow, mockEpisodeRowNullScore]);
@@ -1034,7 +1036,8 @@ describe("getTrendingTopicBySlug", () => {
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
 
-    expect(result.error).toBeNull();
+    expect(result.kind).toBe("found");
+    if (result.kind !== "found") throw new Error("expected found");
     expect(result.topic).toMatchObject({ name: "Artificial Intelligence", slug: "artificial-intelligence" });
     expect(result.allTopics).toHaveLength(2);
     expect(result.generatedAt).toEqual(GENERATED_AT);
@@ -1055,7 +1058,7 @@ describe("getTrendingTopicBySlug", () => {
     expect(rawSqlClauses.join(" ")).toContain("DESC NULLS LAST");
   });
 
-  it("returns topic with empty episodes when matched topic has no episodeIds", async () => {
+  it("returns { kind: 'found', episodes: [] } when matched topic has no episodeIds", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     const emptyTopic = { ...aiTopic, episodeIds: [] };
     mockFindFirst.mockResolvedValue(makeSnapshot([emptyTopic, climateTopic]));
@@ -1063,27 +1066,27 @@ describe("getTrendingTopicBySlug", () => {
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
 
-    expect(result.error).toBeNull();
+    expect(result.kind).toBe("found");
+    if (result.kind !== "found") throw new Error("expected found");
     expect(result.topic).toMatchObject({ name: "Artificial Intelligence" });
     expect(result.episodes).toEqual([]);
   });
 
-  it("returns topic:null and allTopics when slug is unknown", async () => {
+  it("returns { kind: 'unknown-slug' } when slug is unknown", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockResolvedValue(makeSnapshot([aiTopic, climateTopic]));
 
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("unknown-slug-garbage");
 
-    expect(result.topic).toBeNull();
+    expect(result.kind).toBe("unknown-slug");
+    if (result.kind !== "unknown-slug") throw new Error("expected unknown-slug");
     expect(result.allTopics).toHaveLength(2);
-    expect(result.episodes).toEqual([]);
-    expect(result.error).toBeNull();
+    expect(result.generatedAt).toEqual(GENERATED_AT);
   });
 
   it("matches legacy topic without slug via slugify(name)", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
-    // Legacy row: no slug field
     const legacyTopic = {
       name: "Space Exploration",
       description: "Space news",
@@ -1095,11 +1098,12 @@ describe("getTrendingTopicBySlug", () => {
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("space-exploration");
 
+    expect(result.kind).toBe("found");
+    if (result.kind !== "found") throw new Error("expected found");
     expect(result.topic).toMatchObject({ name: "Space Exploration" });
-    expect(result.error).toBeNull();
   });
 
-  it("returns error on DB failure and logs the slug context", async () => {
+  it("returns { kind: 'error' } on DB failure and logs the slug context", async () => {
     mockAuth.mockResolvedValue({ userId: "user_123" });
     mockFindFirst.mockRejectedValue(new Error("DB connection failed"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -1107,11 +1111,9 @@ describe("getTrendingTopicBySlug", () => {
     const { getTrendingTopicBySlug } = await import("@/app/actions/dashboard");
     const result = await getTrendingTopicBySlug("artificial-intelligence");
 
-    expect(result.topic).toBeNull();
-    expect(result.allTopics).toEqual([]);
-    expect(result.episodes).toEqual([]);
-    expect(result.generatedAt).toBeNull();
-    expect(result.error).toMatch(/failed to load/i);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected error");
+    expect(result.message).toMatch(/failed to load/i);
 
     // The log must carry the slug so ops can correlate failures to requests.
     const loggedSlug = errorSpy.mock.calls.some((args) =>

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -513,9 +513,10 @@ export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopi
       return { kind: "found", topic, allTopics, episodes: [], generatedAt: latest.generatedAt };
     }
 
-    // Cap to defend against a corrupted/malicious snapshot blowing up the IN clause.
-    // Upstream trending generation is bounded near 500 per topic.
-    const episodeIds = topic.episodeIds.slice(0, 500);
+    // Display cap for the page (tighter than the upstream 500-candidate ceiling):
+    // 50 is plenty for a scroll-without-pagination view and bounds both the IN clause
+    // and the render cost against corrupted snapshots with huge episodeIds arrays.
+    const episodeIds = topic.episodeIds.slice(0, 50);
 
     const rows = await db
       .select({

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -490,7 +490,9 @@ export type TrendingTopicDetailResult =
 export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopicDetailResult> {
   const { userId } = await auth();
   if (!userId) {
-    redirect(`/sign-in?redirect_url=/trending/${slug}`);
+    // Encode the slug so a value like `foo&evil=injected` can't smuggle extra
+    // query parameters into the /sign-in URL.
+    redirect(`/sign-in?redirect_url=${encodeURIComponent(`/trending/${slug}`)}`);
   }
 
   try {

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { eq, desc, and, gte, isNotNull, notInArray, inArray, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
@@ -265,7 +266,9 @@ export async function getRecommendedEpisodes(
           notInArray(episodes.id, listenedEpisodeIds)
         )
       )
-      .orderBy(desc(episodes.worthItScore), desc(episodes.publishDate))
+      // isNotNull above filters null scores, but NULLS LAST is used for consistency
+      // with the rest of the codebase and to stay correct if the filter is ever dropped.
+      .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate))
       .limit(limit);
 
     // Separate query to avoid aggregation expanding the outer LIMIT result set
@@ -472,17 +475,22 @@ export async function getTrendingTopics() {
   }
 }
 
-export async function getTrendingTopicBySlug(slug: string): Promise<{
-  topic: TrendingTopic | null;
-  allTopics: TrendingTopic[];
-  episodes: RecommendedEpisodeDTO[];
-  generatedAt: Date | null;
-  error: string | null;
-}> {
-  const { userId } = await auth();
+export type TrendingTopicDetailResult =
+  | { kind: "no-snapshot" }
+  | { kind: "unknown-slug"; allTopics: TrendingTopic[]; generatedAt: Date }
+  | {
+      kind: "found";
+      topic: TrendingTopic;
+      allTopics: TrendingTopic[];
+      episodes: RecommendedEpisodeDTO[];
+      generatedAt: Date;
+    }
+  | { kind: "error"; message: string };
 
+export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopicDetailResult> {
+  const { userId } = await auth();
   if (!userId) {
-    return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: "You must be signed in" };
+    redirect(`/sign-in?redirect_url=/trending/${slug}`);
   }
 
   try {
@@ -490,15 +498,17 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
       orderBy: [desc(trendingTopics.generatedAt), desc(trendingTopics.id)],
     });
 
-    if (!latest) {
-      return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: null };
-    }
+    if (!latest) return { kind: "no-snapshot" };
 
     const allTopics = latest.topics;
-    const topic = allTopics.find((t) => getTopicSlug(t) === slug) ?? null;
+    const topic = allTopics.find((t) => getTopicSlug(t) === slug);
 
-    if (!topic || topic.episodeIds.length === 0) {
-      return { topic, allTopics, episodes: [], generatedAt: latest.generatedAt, error: null };
+    if (!topic) {
+      return { kind: "unknown-slug", allTopics, generatedAt: latest.generatedAt };
+    }
+
+    if (topic.episodeIds.length === 0) {
+      return { kind: "found", topic, allTopics, episodes: [], generatedAt: latest.generatedAt };
     }
 
     // Cap to defend against a corrupted/malicious snapshot blowing up the IN clause.
@@ -525,16 +535,16 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
       // bottom, and drizzle's desc() helper doesn't expose the nulls-ordering flag.
       .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate));
 
-    const episodeResults: RecommendedEpisodeDTO[] = rows.map((r) => ({
+    const episodesList: RecommendedEpisodeDTO[] = rows.map((r) => ({
       ...r,
       bestTopicRank: null,
       topRankedTopic: null,
     }));
 
-    return { topic, allTopics, episodes: episodeResults, generatedAt: latest.generatedAt, error: null };
+    return { kind: "found", topic, allTopics, episodes: episodesList, generatedAt: latest.generatedAt };
   } catch (error) {
     console.error("Error fetching trending topic by slug:", { slug, error });
-    return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: "Failed to load topic" };
+    return { kind: "error", message: "Failed to load topic" };
   }
 }
 

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -517,6 +517,13 @@ export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopi
     // The display limit below runs at the DB layer so ordering applies to the full
     // candidate set — truncating by LLM-output order here would silently drop
     // high-scored episodes at positions beyond the cap.
+    if (topic.episodeIds.length > 500) {
+      console.warn("Trending topic exceeded 500-episode safety cap:", {
+        slug,
+        name: topic.name,
+        actualLength: topic.episodeIds.length,
+      });
+    }
     const episodeIds = topic.episodeIds.slice(0, 500);
 
     const rows = await db

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -11,8 +11,10 @@ import {
   podcasts,
   trendingTopics,
   episodeTopics,
+  type TrendingTopic,
 } from "@/db/schema";
 import { type RecommendedEpisodeDTO } from "@/db/library-columns";
+import { slugify } from "@/lib/utils";
 import {
   getEpisodesByFeedId,
   type PodcastIndexEpisode,
@@ -467,6 +469,66 @@ export async function getTrendingTopics() {
   } catch (error) {
     console.error("Error fetching trending topics:", error);
     return { topics: null, error: "Failed to load trending topics" };
+  }
+}
+
+export async function getTrendingTopicBySlug(slug: string): Promise<{
+  topic: TrendingTopic | null;
+  allTopics: TrendingTopic[];
+  episodes: RecommendedEpisodeDTO[];
+  generatedAt: Date | null;
+  error: string | null;
+}> {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: "You must be signed in" };
+  }
+
+  try {
+    const latest = await db.query.trendingTopics.findFirst({
+      orderBy: [desc(trendingTopics.generatedAt), desc(trendingTopics.id)],
+    });
+
+    if (!latest) {
+      return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: null };
+    }
+
+    const allTopics = latest.topics;
+    const topic = allTopics.find((t) => (t.slug ?? slugify(t.name)) === slug) ?? null;
+
+    if (!topic || topic.episodeIds.length === 0) {
+      return { topic, allTopics, episodes: [], generatedAt: latest.generatedAt, error: null };
+    }
+
+    const rows = await db
+      .select({
+        id: episodes.id,
+        podcastIndexId: episodes.podcastIndexId,
+        title: episodes.title,
+        description: episodes.description,
+        audioUrl: episodes.audioUrl,
+        duration: episodes.duration,
+        publishDate: episodes.publishDate,
+        worthItScore: episodes.worthItScore,
+        podcastTitle: podcasts.title,
+        podcastImageUrl: podcasts.imageUrl,
+      })
+      .from(episodes)
+      .innerJoin(podcasts, eq(episodes.podcastId, podcasts.id))
+      .where(inArray(episodes.id, topic.episodeIds))
+      .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate));
+
+    const episodeResults: RecommendedEpisodeDTO[] = rows.map((r) => ({
+      ...r,
+      bestTopicRank: null,
+      topRankedTopic: null,
+    }));
+
+    return { topic, allTopics, episodes: episodeResults, generatedAt: latest.generatedAt, error: null };
+  } catch (error) {
+    console.error("Error fetching trending topic by slug:", error);
+    return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: "Failed to load topic" };
   }
 }
 

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -513,10 +513,11 @@ export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopi
       return { kind: "found", topic, allTopics, episodes: [], generatedAt: latest.generatedAt };
     }
 
-    // Display cap for the page (tighter than the upstream 500-candidate ceiling):
-    // 50 is plenty for a scroll-without-pagination view and bounds both the IN clause
-    // and the render cost against corrupted snapshots with huge episodeIds arrays.
-    const episodeIds = topic.episodeIds.slice(0, 50);
+    // Safety cap against corrupted/malicious snapshots with huge episodeIds arrays.
+    // The display limit below runs at the DB layer so ordering applies to the full
+    // candidate set — truncating by LLM-output order here would silently drop
+    // high-scored episodes at positions beyond the cap.
+    const episodeIds = topic.episodeIds.slice(0, 500);
 
     const rows = await db
       .select({
@@ -536,7 +537,10 @@ export async function getTrendingTopicBySlug(slug: string): Promise<TrendingTopi
       .where(inArray(episodes.id, episodeIds))
       // Postgres defaults DESC to NULLS FIRST; we want unscored episodes at the
       // bottom, and drizzle's desc() helper doesn't expose the nulls-ordering flag.
-      .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate));
+      .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate))
+      // Display cap — bounds page render cost. Sort runs over the full candidate
+      // set above so top-scored episodes can't be missed beyond this limit.
+      .limit(50);
 
     const episodesList: RecommendedEpisodeDTO[] = rows.map((r) => ({
       ...r,

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -495,6 +495,8 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
     }
 
     const allTopics = latest.topics;
+    // Pre-#279 snapshot rows don't have a slug key in the JSON payload even
+    // though the TS type says string; fall back to deriving it from the name.
     const topic = allTopics.find((t) => (t.slug ?? slugify(t.name)) === slug) ?? null;
 
     if (!topic || topic.episodeIds.length === 0) {
@@ -517,6 +519,8 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
       .from(episodes)
       .innerJoin(podcasts, eq(episodes.podcastId, podcasts.id))
       .where(inArray(episodes.id, topic.episodeIds))
+      // Postgres defaults DESC to NULLS FIRST; we want unscored episodes at the
+      // bottom, and drizzle's desc() helper doesn't expose the nulls-ordering flag.
       .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate));
 
     const episodeResults: RecommendedEpisodeDTO[] = rows.map((r) => ({
@@ -527,7 +531,7 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
 
     return { topic, allTopics, episodes: episodeResults, generatedAt: latest.generatedAt, error: null };
   } catch (error) {
-    console.error("Error fetching trending topic by slug:", error);
+    console.error("Error fetching trending topic by slug:", { slug, error });
     return { topic: null, allTopics: [], episodes: [], generatedAt: null, error: "Failed to load topic" };
   }
 }

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -14,7 +14,7 @@ import {
   type TrendingTopic,
 } from "@/db/schema";
 import { type RecommendedEpisodeDTO } from "@/db/library-columns";
-import { slugify } from "@/lib/utils";
+import { getTopicSlug } from "@/lib/trending";
 import {
   getEpisodesByFeedId,
   type PodcastIndexEpisode,
@@ -495,9 +495,7 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
     }
 
     const allTopics = latest.topics;
-    // Pre-#279 snapshot rows don't have a slug key in the JSON payload even
-    // though the TS type says string; fall back to deriving it from the name.
-    const topic = allTopics.find((t) => (t.slug ?? slugify(t.name)) === slug) ?? null;
+    const topic = allTopics.find((t) => getTopicSlug(t) === slug) ?? null;
 
     if (!topic || topic.episodeIds.length === 0) {
       return { topic, allTopics, episodes: [], generatedAt: latest.generatedAt, error: null };

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -501,6 +501,10 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
       return { topic, allTopics, episodes: [], generatedAt: latest.generatedAt, error: null };
     }
 
+    // Cap to defend against a corrupted/malicious snapshot blowing up the IN clause.
+    // Upstream trending generation is bounded near 500 per topic.
+    const episodeIds = topic.episodeIds.slice(0, 500);
+
     const rows = await db
       .select({
         id: episodes.id,
@@ -516,7 +520,7 @@ export async function getTrendingTopicBySlug(slug: string): Promise<{
       })
       .from(episodes)
       .innerJoin(podcasts, eq(episodes.podcastId, podcasts.id))
-      .where(inArray(episodes.id, topic.episodeIds))
+      .where(inArray(episodes.id, episodeIds))
       // Postgres defaults DESC to NULLS FIRST; we want unscored episodes at the
       // bottom, and drizzle's desc() helper doesn't expose the nulls-ordering flag.
       .orderBy(sql`${episodes.worthItScore} DESC NULLS LAST`, desc(episodes.publishDate));

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -46,9 +46,12 @@ export async function GET(
         );
       }
 
-      // Map to the shape the episode detail page expects
+      // Map to the shape the episode detail page expects.
+      // Use podcastIndexId ("rss-...") as the id so save/library lookups —
+      // which key off podcastIndexId — match the API response. Matches the
+      // pattern in src/app/(app)/podcast/[id]/page.tsx:91.
       const episode = {
-        id: dbEpisode.id,
+        id: dbEpisode.podcastIndexId,
         title: dbEpisode.title,
         link: "",
         description: dbEpisode.description ?? "",
@@ -115,7 +118,7 @@ export async function GET(
     try {
       episodeResponse = await getEpisodeById(episodeId);
     } catch (error) {
-      console.error(`Error fetching episode ${episodeId} from PodcastIndex:`, error);
+      console.error("Error fetching episode from PodcastIndex:", { episodeId, error });
       return NextResponse.json(
         { error: "Episode not found" },
         { status: 404 }

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { TrendingTopics, TrendingTopicsLoading } from "@/components/dashboard/trending-topics"
+import { slugify } from "@/lib/utils"
 import type { TrendingTopic } from "@/db/schema"
 
 // ---------------------------------------------------------------------------
@@ -10,13 +11,16 @@ import type { TrendingTopic } from "@/db/schema"
 const MOCK_NOW = new Date("2026-03-15T12:00:00.000Z")
 const fixedDate = new Date(MOCK_NOW.getTime() - 10 * 60 * 1000) // 10 minutes before MOCK_NOW
 
+// Slug defaults to slugify(name) so tests with distinct names get distinct
+// slugs (dedupe-by-slug would otherwise collapse them).
 function makeTopic(overrides: Partial<TrendingTopic> = {}): TrendingTopic {
+  const name = overrides.name ?? "Test Topic"
   return {
-    name: "Test Topic",
+    name,
     description: "A test topic description",
     episodeCount: 5,
     episodeIds: [1, 2, 3, 4, 5],
-    slug: "test-topic",
+    slug: slugify(name),
     ...overrides,
   }
 }

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -3,11 +3,12 @@ import { TrendingUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
+import { getTopicSlug } from "@/lib/trending";
 import type { TrendingTopic } from "@/db/schema";
 
 function TopicPill({ topic }: { topic: TrendingTopic }) {
   return (
-    <Link href={`/discover?q=${encodeURIComponent(topic.name)}`}>
+    <Link href={`/trending/${getTopicSlug(topic)}`}>
       <Badge variant="secondary" className="px-3 py-1 max-w-[200px] hover:bg-secondary/80 transition-colors">
         <span className="min-w-0 flex-1 truncate text-sm" title={topic.name}>{topic.name}</span>
         <span className="ml-1.5 text-muted-foreground font-normal shrink-0">({topic.episodeCount})</span>
@@ -23,6 +24,7 @@ interface TrendingTopicsProps {
 
 export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
   const updatedAgo = formatRelativeTime(generatedAt);
+  const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
 
   return (
     <div>
@@ -33,8 +35,8 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
         </span>
       </div>
       <div className="flex flex-wrap gap-2">
-        {Array.from(new Map(topics.map((t) => [t.name, t])).values()).map((topic) => (
-          <TopicPill key={topic.name} topic={topic} />
+        {deduped.map((topic) => (
+          <TopicPill key={getTopicSlug(topic)} topic={topic} />
         ))}
       </div>
     </div>

--- a/src/components/trending/__tests__/topic-switcher.test.tsx
+++ b/src/components/trending/__tests__/topic-switcher.test.tsx
@@ -65,14 +65,17 @@ describe("TopicSwitcher", () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it("dedupes topics with the same name", () => {
-    const duped = [
-      makeTopic({ name: "AI", slug: "ai-1" }),
-      makeTopic({ name: "AI", slug: "ai-2" }),
+  it("dedupes topics with the same slug and keeps distinct slugs separate", () => {
+    const topics = [
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "AI", slug: "ai" }), // same slug → dedupe
+      makeTopic({ name: "AI", slug: "ai-regulation" }), // same name, different slug → keep
       makeTopic({ name: "Climate", slug: "climate" }),
     ]
-    render(<TopicSwitcher topics={duped} activeSlug="climate" />)
+    render(<TopicSwitcher topics={topics} activeSlug="climate" />)
     const aiLinks = screen.getAllByRole("link", { name: "AI" })
-    expect(aiLinks).toHaveLength(1)
+    expect(aiLinks).toHaveLength(2)
+    expect(aiLinks[0]).toHaveAttribute("href", "/trending/ai")
+    expect(aiLinks[1]).toHaveAttribute("href", "/trending/ai-regulation")
   })
 })

--- a/src/components/trending/__tests__/topic-switcher.test.tsx
+++ b/src/components/trending/__tests__/topic-switcher.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { TopicSwitcher } from "@/components/trending/topic-switcher"
+import type { TrendingTopic } from "@/db/schema"
+
+function makeTopic(overrides: Partial<TrendingTopic> = {}): TrendingTopic {
+  return {
+    name: "Test Topic",
+    description: "A test description",
+    episodeCount: 5,
+    episodeIds: [1, 2, 3],
+    slug: "test-topic",
+    ...overrides,
+  }
+}
+
+const topics: TrendingTopic[] = [
+  makeTopic({ name: "Artificial Intelligence", slug: "artificial-intelligence" }),
+  makeTopic({ name: "Climate Policy", slug: "climate-policy" }),
+  makeTopic({ name: "Startup Funding", slug: "startup-funding" }),
+]
+
+describe("TopicSwitcher", () => {
+  it("renders one pill per topic", () => {
+    render(<TopicSwitcher topics={topics} activeSlug="artificial-intelligence" />)
+    expect(screen.getByText("Artificial Intelligence")).toBeInTheDocument()
+    expect(screen.getByText("Climate Policy")).toBeInTheDocument()
+    expect(screen.getByText("Startup Funding")).toBeInTheDocument()
+  })
+
+  it("active pill has bg-primary class", () => {
+    render(<TopicSwitcher topics={topics} activeSlug="climate-policy" />)
+    const activeLink = screen.getByRole("link", { name: "Climate Policy" })
+    expect(activeLink.className).toContain("bg-primary")
+  })
+
+  it("inactive pills have bg-muted class", () => {
+    render(<TopicSwitcher topics={topics} activeSlug="climate-policy" />)
+    const inactiveLink = screen.getByRole("link", { name: "Artificial Intelligence" })
+    expect(inactiveLink.className).toContain("bg-muted")
+  })
+
+  it("hrefs resolve to /trending/{slug}", () => {
+    render(<TopicSwitcher topics={topics} activeSlug="artificial-intelligence" />)
+    const link = screen.getByRole("link", { name: "Climate Policy" })
+    expect(link).toHaveAttribute("href", "/trending/climate-policy")
+  })
+
+  it("legacy topic missing slug uses slugify(name) for href", () => {
+    const legacyTopic = makeTopic({ name: "Space Exploration", slug: undefined as unknown as string })
+    render(<TopicSwitcher topics={[legacyTopic]} activeSlug="space-exploration" />)
+    const link = screen.getByRole("link", { name: "Space Exploration" })
+    expect(link).toHaveAttribute("href", "/trending/space-exploration")
+  })
+
+  it("legacy topic missing slug is matched as active via slugify(name)", () => {
+    const legacyTopic = makeTopic({ name: "Space Exploration", slug: undefined as unknown as string })
+    render(<TopicSwitcher topics={[legacyTopic]} activeSlug="space-exploration" />)
+    const link = screen.getByRole("link", { name: "Space Exploration" })
+    expect(link.className).toContain("bg-primary")
+  })
+
+  it("empty topics array renders nothing", () => {
+    const { container } = render(<TopicSwitcher topics={[]} activeSlug="anything" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("dedupes topics with the same name", () => {
+    const duped = [
+      makeTopic({ name: "AI", slug: "ai-1" }),
+      makeTopic({ name: "AI", slug: "ai-2" }),
+      makeTopic({ name: "Climate", slug: "climate" }),
+    ]
+    render(<TopicSwitcher topics={duped} activeSlug="climate" />)
+    const aiLinks = screen.getAllByRole("link", { name: "AI" })
+    expect(aiLinks).toHaveLength(1)
+  })
+})

--- a/src/components/trending/topic-switcher.stories.tsx
+++ b/src/components/trending/topic-switcher.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { TopicSwitcher } from "@/components/trending/topic-switcher"
+import type { TrendingTopic } from "@/db/schema"
+
+const baseTopics: TrendingTopic[] = [
+  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
+  { name: "Climate Policy", description: "", episodeCount: 8, episodeIds: [], slug: "climate-policy" },
+  { name: "Startup Funding", description: "", episodeCount: 5, episodeIds: [], slug: "startup-funding" },
+  { name: "Remote Work", description: "", episodeCount: 9, episodeIds: [], slug: "remote-work" },
+  { name: "Mental Health", description: "", episodeCount: 7, episodeIds: [], slug: "mental-health" },
+]
+
+const longNameTopics: TrendingTopic[] = [
+  { name: "The Impact of Large Language Models on Enterprise Software Development", description: "", episodeCount: 11, episodeIds: [], slug: "the-impact-of-large-language-models-on-enterprise-software-development" },
+  { name: "Decentralized Finance and the Future of Banking", description: "", episodeCount: 7, episodeIds: [], slug: "decentralized-finance-and-the-future-of-banking" },
+  { name: "Quantum Computing Breakthroughs and Near-Term Commercial Applications", description: "", episodeCount: 4, episodeIds: [], slug: "quantum-computing-breakthroughs-and-near-term-commercial-applications" },
+  { name: "Climate Tech", description: "", episodeCount: 9, episodeIds: [], slug: "climate-tech" },
+]
+
+const meta: Meta<typeof TopicSwitcher> = {
+  title: "Trending/TopicSwitcher",
+  component: TopicSwitcher,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof TopicSwitcher>
+
+export const Default: Story = {
+  args: {
+    topics: baseTopics,
+    activeSlug: "startup-funding",
+  },
+}
+
+export const ActiveFirst: Story = {
+  args: {
+    topics: baseTopics,
+    activeSlug: "artificial-intelligence",
+  },
+}
+
+export const SingleTopic: Story = {
+  args: {
+    topics: [{ name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" }],
+    activeSlug: "artificial-intelligence",
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    topics: [],
+    activeSlug: "anything",
+  },
+}
+
+export const LongNames: Story = {
+  args: {
+    topics: longNameTopics,
+    activeSlug: "climate-tech",
+  },
+}

--- a/src/components/trending/topic-switcher.tsx
+++ b/src/components/trending/topic-switcher.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { cn, slugify } from "@/lib/utils";
+import type { TrendingTopic } from "@/db/schema";
+
+interface TopicSwitcherProps {
+  topics: TrendingTopic[];
+  activeSlug: string;
+}
+
+export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
+  const deduped = Array.from(new Map(topics.map((t) => [t.name, t])).values());
+
+  if (deduped.length === 0) return null;
+
+  return (
+    <nav className="overflow-x-auto">
+      <div className="flex gap-2 whitespace-nowrap pb-2">
+        {deduped.map((t) => {
+          const slug = t.slug ?? slugify(t.name);
+          const isActive = slug === activeSlug;
+          return (
+            <Link
+              key={t.name}
+              href={`/trending/${slug}`}
+              className={cn(
+                "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              )}
+            >
+              {t.name}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/trending/topic-switcher.tsx
+++ b/src/components/trending/topic-switcher.tsx
@@ -16,6 +16,8 @@ export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
     <nav className="overflow-x-auto">
       <div className="flex gap-2 whitespace-nowrap pb-2">
         {deduped.map((t) => {
+          // Mirrors the fallback in getTrendingTopicBySlug: legacy JSON rows may
+          // lack a slug key even though the TS type claims it is required.
           const slug = t.slug ?? slugify(t.name);
           const isActive = slug === activeSlug;
           return (

--- a/src/components/trending/topic-switcher.tsx
+++ b/src/components/trending/topic-switcher.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { cn, slugify } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+import { getTopicSlug } from "@/lib/trending";
 import type { TrendingTopic } from "@/db/schema";
 
 interface TopicSwitcherProps {
@@ -16,9 +17,7 @@ export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
     <nav className="overflow-x-auto">
       <div className="flex gap-2 whitespace-nowrap pb-2">
         {deduped.map((t) => {
-          // Mirrors the fallback in getTrendingTopicBySlug: legacy JSON rows may
-          // lack a slug key even though the TS type claims it is required.
-          const slug = t.slug ?? slugify(t.name);
+          const slug = getTopicSlug(t);
           const isActive = slug === activeSlug;
           return (
             <Link

--- a/src/components/trending/topic-switcher.tsx
+++ b/src/components/trending/topic-switcher.tsx
@@ -9,20 +9,23 @@ interface TopicSwitcherProps {
 }
 
 export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
-  const deduped = Array.from(new Map(topics.map((t) => [t.name, t])).values());
+  // Dedupe by resolved slug so two topics sharing a display name but distinct
+  // slugs both remain reachable from the switcher.
+  const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
 
   if (deduped.length === 0) return null;
 
   return (
-    <nav className="overflow-x-auto">
+    <nav aria-label="Trending topics" className="overflow-x-auto">
       <div className="flex gap-2 whitespace-nowrap pb-2">
         {deduped.map((t) => {
           const slug = getTopicSlug(t);
           const isActive = slug === activeSlug;
           return (
             <Link
-              key={t.name}
+              key={slug}
               href={`/trending/${slug}`}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
                 "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
                 isActive

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -519,7 +519,9 @@ export interface TrendingTopic {
   description: string;
   episodeCount: number;
   episodeIds: number[];
-  slug: string;
+  // Pre-#279 snapshot rows lack a slug key at runtime; consumers should call
+  // `getTopicSlug()` from @/lib/trending rather than accessing this field directly.
+  slug?: string;
 }
 
 export type TrendingTopicsRow = typeof trendingTopics.$inferSelect;

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -1,0 +1,16 @@
+import type { TrendingTopic } from "@/db/schema";
+import { slugify } from "@/lib/utils";
+
+// Trending snapshots regenerate daily; allow one missed cycle before flagging.
+export const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+export function isTrendingSnapshotStale(generatedAt: Date | null | undefined): boolean {
+  if (!generatedAt) return false;
+  return Date.now() - generatedAt.getTime() > STALE_THRESHOLD_MS;
+}
+
+// Pre-#279 JSON rows lack a slug key at runtime even though the TS type claims
+// it is required; derive it from the name for backward compatibility.
+export function getTopicSlug(topic: TrendingTopic): string {
+  return topic.slug ?? slugify(topic.name);
+}


### PR DESCRIPTION
## Summary

- New server-component route `/trending/[slug]` renders all episodes belonging to one trending topic with a horizontal `TopicSwitcher` that lets users jump between topics in the latest snapshot.
- New `getTrendingTopicBySlug` server action in `src/app/actions/dashboard.ts` joins `episodes` + `podcasts` filtered by `inArray(episodes.id, topic.episodeIds)`, sorted by `sql\`${episodes.worthItScore} DESC NULLS LAST\`` then `desc(publishDate)`. Legacy rows without a `slug` resolve via `slugify(name)` fallback in both the action match and the switcher href.
- Unknown slug, empty snapshot, and stale snapshot (>48h) all render the page with a friendly fallback card — no `notFound()`.

## Plan

Plan at `.dev/cdt/plans/plan-20260417-1319.md`. 6 tasks in 4 waves, Developer Model sonnet, Council Review false, no new ADRs. PM caught one correctness bug during planning (pg's `DESC` defaults to `NULLS FIRST`, not `NULLS LAST`) — fix incorporated; the `rank-episode-topics.ts:109` precedent was applied.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 1662/1662 tests pass, zero regressions (7 new cases for `getTrendingTopicBySlug`, 8 new RTL cases for `TopicSwitcher`)
- [x] `bun run build` — `/trending/[slug]` route present in manifest
- [x] QA smoke inspection against all 17 ACs from issue #280 (one bug found mid-QA — h1 was showing slug-derived text, fixed in 054bd8e)
- [x] Code review approved (plan adherence, NULLS LAST, legacy slug fallback in all three sites, no `notFound()`, stale notice, distinct fallback headings, auth guard, `RecommendedEpisodeDTO` shape preserved, no stray `page.tsx` exports, `@/` alias throughout, CHANGELOG entry)

## Known limitations

- Pre-existing Storybook issue: `next/link`-using stories fail at browser runtime with `process is not defined`. Affects every story using `<Link>`, not just the new `TopicSwitcher` stories. Needs separate fix in `.storybook/main.ts`. Not introduced by this PR.

Closes #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trending topic detail page at /trending/<slug> with horizontal topic switcher, ranked episode grid sorted by worth‑it score, loading skeletons, and stale-data notice
  * Slug fallback for legacy topics so links resolve when slugs are missing
  * Unauthenticated requests to topic detail redirect to sign‑in with return URL
  * Storybook stories for the topic switcher

* **Bug Fixes**
  * API now returns RSS episode identifiers aligned with save/library lookup

* **Tests**
  * Expanded coverage for trending actions, topic switcher, and detail content (error, empty, stale, success)

* **Chores**
  * Shared utilities for snapshot staleness checks and topic slug normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->