### PR TITLE
feat: Redesign dashboard Trending Topics card as vertical list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Dashboard Trending Topics card redesigned as a vertical list with topic name, AI description (2-line clamp), episode count, and per-row link to `/trending/<slug>` (#281)
+
 ### Added
 - Trending topic detail page at /trending/<slug> with horizontal topic switcher and ranked episode list sorted by worth-it score (#280)
 - Personal topic overlap indicators — shows contextual labels (e.g. "You've heard 3 similar episodes", "New topic for you") based on listen history and saved episodes. Recommendations deprioritize heavily-consumed topics (#262)

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -123,10 +123,19 @@ describe("TrendingTopics", () => {
   })
 
   it("defensive fallback: empty slug falls back to slugify(name) for href", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
     const topics = [makeTopic({ name: "No Slug Topic", slug: "" })]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
     const link = screen.getByRole("link", { name: /No Slug Topic/ })
     expect(link).toHaveAttribute("href", "/trending/no-slug-topic")
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it("renders nothing when topics array is empty", () => {
+    const { container } = render(<TrendingTopics topics={[]} generatedAt={fixedDate} />)
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText("Trending Topics")).not.toBeInTheDocument()
   })
 })
 

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -11,8 +11,6 @@ import type { TrendingTopic } from "@/db/schema"
 const MOCK_NOW = new Date("2026-03-15T12:00:00.000Z")
 const fixedDate = new Date(MOCK_NOW.getTime() - 10 * 60 * 1000) // 10 minutes before MOCK_NOW
 
-// Slug defaults to slugify(name) so tests with distinct names get distinct
-// slugs (dedupe-by-slug would otherwise collapse them).
 function makeTopic(overrides: Partial<TrendingTopic> = {}): TrendingTopic {
   const name = overrides.name ?? "Test Topic"
   return {
@@ -39,56 +37,96 @@ describe("TrendingTopics", () => {
     vi.useRealTimers()
   })
 
-  it("renders correct number of pills for N topics", () => {
+  it("renders each topic as a link to /trending/<slug>", () => {
     const topics = [
       makeTopic({ name: "AI" }),
       makeTopic({ name: "Climate" }),
       makeTopic({ name: "Tech" }),
     ]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    const links = screen.getAllByRole("link")
+    expect(links.length).toBeGreaterThanOrEqual(3)
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", expect.stringMatching(/^\/trending\//))
+    }
     expect(screen.getByText("AI")).toBeInTheDocument()
     expect(screen.getByText("Climate")).toBeInTheDocument()
     expect(screen.getByText("Tech")).toBeInTheDocument()
   })
 
-  it("each pill shows 'Name (episodeCount)' format", () => {
-    const topics = [
-      makeTopic({ name: "Robotics", episodeCount: 12 }),
-      makeTopic({ name: "Space", episodeCount: 7 }),
-    ]
+  it("renders topic description with line-clamp-2 class", () => {
+    const topics = [makeTopic({ name: "AI", description: "AI is changing everything." })]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
-    expect(screen.getByText("Robotics")).toBeInTheDocument()
-    expect(screen.getByText("(12)")).toBeInTheDocument()
-    expect(screen.getByText("Space")).toBeInTheDocument()
-    expect(screen.getByText("(7)")).toBeInTheDocument()
+    const desc = screen.getByText("AI is changing everything.")
+    expect(desc).toBeInTheDocument()
+    expect(desc.className).toContain("line-clamp-2")
+  })
+
+  it("omits description paragraph when description is empty string", () => {
+    const topics = [makeTopic({ name: "AI", description: "" })]
+    const { container } = render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    expect(screen.getByText("AI")).toBeInTheDocument()
+    // No muted description paragraph should be present
+    const descParagraphs = container.querySelectorAll("p.line-clamp-2")
+    expect(descParagraphs).toHaveLength(0)
+  })
+
+  it("renders plural episode count: 'N episodes'", () => {
+    const topics = [makeTopic({ name: "Robotics", episodeCount: 12 })]
+    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    expect(screen.getByText("12 episodes")).toBeInTheDocument()
+  })
+
+  it("renders singular episode count: '1 episode'", () => {
+    const topics = [makeTopic({ name: "Solo Topic", episodeCount: 1 })]
+    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    expect(screen.getByText("1 episode")).toBeInTheDocument()
+  })
+
+  it("renders '0 episodes' for episodeCount of 0", () => {
+    const topics = [makeTopic({ name: "Empty Topic", episodeCount: 0 })]
+    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    expect(screen.getByText("0 episodes")).toBeInTheDocument()
+  })
+
+  it("topic name element has no truncate class", () => {
+    const longName = "This Is A Very Long Topic Name That Would Overflow In A Pill"
+    const topics = [makeTopic({ name: longName, episodeCount: 3 })]
+    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    const nameEl = screen.getByText(longName)
+    expect(nameEl.className).not.toContain("truncate")
+    expect(nameEl.className).not.toContain("line-clamp-1")
+  })
+
+  it("displays card title 'Trending Topics' and subline 'Past 7 days · Updated 10m ago'", () => {
+    const topics = [makeTopic({ name: "AI" })]
+    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
+    expect(screen.getByText("Trending Topics")).toBeInTheDocument()
+    expect(screen.getByText(/Past 7 days · Updated 10m ago/)).toBeInTheDocument()
   })
 
   it("renders a single topic correctly", () => {
     const topics = [makeTopic({ name: "Solo Topic", episodeCount: 1 })]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
     expect(screen.getByText("Solo Topic")).toBeInTheDocument()
-    expect(screen.getByText("(1)")).toBeInTheDocument()
+    expect(screen.getByText("1 episode")).toBeInTheDocument()
   })
 
-  it("renders episodeCount of 0 without crashing", () => {
-    const topics = [makeTopic({ name: "Empty Topic", episodeCount: 0 })]
+  it("deduplicates topics with the same slug", () => {
+    const topics = [
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "Tech", slug: "tech" }),
+    ]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
-    expect(screen.getByText("Empty Topic")).toBeInTheDocument()
-    expect(screen.getByText("(0)")).toBeInTheDocument()
+    expect(screen.getAllByText("AI")).toHaveLength(1)
   })
 
-  it("long topic name pill has title attribute for accessibility", () => {
-    const longName = "This Is A Very Long Topic Name That Would Overflow"
-    const topics = [makeTopic({ name: longName, episodeCount: 3 })]
+  it("defensive fallback: empty slug falls back to slugify(name) for href", () => {
+    const topics = [makeTopic({ name: "No Slug Topic", slug: "" })]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
-    const nameSpan = screen.getByTitle(longName)
-    expect(nameSpan).toBeInTheDocument()
-  })
-
-  it("displays deterministic subtitle with relative time", () => {
-    const topics = [makeTopic({ name: "AI" })]
-    render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
-    expect(screen.getByText(/Trending · 10m ago/)).toBeInTheDocument()
+    const link = screen.getByRole("link", { name: /No Slug Topic/ })
+    expect(link).toHaveAttribute("href", "/trending/no-slug-topic")
   })
 })
 
@@ -97,10 +135,14 @@ describe("TrendingTopics", () => {
 // ---------------------------------------------------------------------------
 
 describe("TrendingTopicsLoading", () => {
-  it("renders 6 pill-shaped skeleton placeholders", () => {
+  it("renders inside a Card with row-shaped skeleton placeholders (no rounded-full pills)", () => {
     const { container } = render(<TrendingTopicsLoading />)
     expect(container.firstChild).toBeInTheDocument()
-    const skeletons = container.querySelectorAll("[class*='rounded-full']")
-    expect(skeletons).toHaveLength(6)
+    // Must NOT have any rounded-full pill skeletons
+    const pillSkeletons = container.querySelectorAll("[class*='rounded-full']")
+    expect(pillSkeletons).toHaveLength(0)
+    // Must have at least one row-shaped placeholder group
+    const rowGroups = container.querySelectorAll("div.flex.items-start")
+    expect(rowGroups.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/src/components/dashboard/__tests__/trending-topics.test.tsx
+++ b/src/components/dashboard/__tests__/trending-topics.test.tsx
@@ -45,10 +45,10 @@ describe("TrendingTopics", () => {
     ]
     render(<TrendingTopics topics={topics} generatedAt={fixedDate} />)
     const links = screen.getAllByRole("link")
-    expect(links.length).toBeGreaterThanOrEqual(3)
-    for (const link of links) {
-      expect(link).toHaveAttribute("href", expect.stringMatching(/^\/trending\//))
-    }
+    expect(links).toHaveLength(3)
+    expect(links[0]).toHaveAttribute("href", "/trending/ai")
+    expect(links[1]).toHaveAttribute("href", "/trending/climate")
+    expect(links[2]).toHaveAttribute("href", "/trending/tech")
     expect(screen.getByText("AI")).toBeInTheDocument()
     expect(screen.getByText("Climate")).toBeInTheDocument()
     expect(screen.getByText("Tech")).toBeInTheDocument()
@@ -144,14 +144,8 @@ describe("TrendingTopics", () => {
 // ---------------------------------------------------------------------------
 
 describe("TrendingTopicsLoading", () => {
-  it("renders inside a Card with row-shaped skeleton placeholders (no rounded-full pills)", () => {
-    const { container } = render(<TrendingTopicsLoading />)
-    expect(container.firstChild).toBeInTheDocument()
-    // Must NOT have any rounded-full pill skeletons
-    const pillSkeletons = container.querySelectorAll("[class*='rounded-full']")
-    expect(pillSkeletons).toHaveLength(0)
-    // Must have at least one row-shaped placeholder group
-    const rowGroups = container.querySelectorAll("div.flex.items-start")
-    expect(rowGroups.length).toBeGreaterThanOrEqual(1)
+  it("renders exactly 5 row-shaped skeleton placeholders", () => {
+    render(<TrendingTopicsLoading />)
+    expect(screen.getAllByTestId("trending-loading-row")).toHaveLength(5)
   })
 })

--- a/src/components/dashboard/trending-topics.stories.tsx
+++ b/src/components/dashboard/trending-topics.stories.tsx
@@ -8,33 +8,26 @@ import { STORY_TWO_HOURS_AGO, STORY_THIRTY_MIN_AGO } from "@/test/story-fixtures
 // ---------------------------------------------------------------------------
 
 const baseTopics: TrendingTopic[] = [
-  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
-  { name: "Climate Policy", description: "", episodeCount: 8, episodeIds: [], slug: "climate-policy" },
-  { name: "Startup Funding", description: "", episodeCount: 5, episodeIds: [], slug: "startup-funding" },
-  { name: "Remote Work", description: "", episodeCount: 9, episodeIds: [], slug: "remote-work" },
-  { name: "Mental Health", description: "", episodeCount: 7, episodeIds: [], slug: "mental-health" },
-  { name: "Cryptocurrency", description: "", episodeCount: 3, episodeIds: [], slug: "cryptocurrency" },
-]
-
-const singleTopic: TrendingTopic[] = [
-  { name: "Artificial Intelligence", description: "", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
-]
-
-const maxTopics: TrendingTopic[] = [
-  ...baseTopics,
-  { name: "Supply Chain", description: "", episodeCount: 4, episodeIds: [], slug: "supply-chain" },
-  { name: "Space Exploration", description: "", episodeCount: 6, episodeIds: [], slug: "space-exploration" },
+  { name: "Artificial Intelligence", description: "How large language models are reshaping software engineering and knowledge work.", episodeCount: 12, episodeIds: [], slug: "artificial-intelligence" },
+  { name: "Climate Policy", description: "International carbon agreements and the gap between pledges and implementation.", episodeCount: 8, episodeIds: [], slug: "climate-policy" },
+  { name: "Startup Funding", description: "Venture capital trends in a higher-for-longer rate environment and what founders should expect.", episodeCount: 5, episodeIds: [], slug: "startup-funding" },
+  { name: "Remote Work", description: "Return-to-office mandates, hybrid models, and how distributed teams maintain culture.", episodeCount: 9, episodeIds: [], slug: "remote-work" },
+  { name: "Mental Health", description: "Workplace burnout, therapy access gaps, and digital mental health tools under scrutiny.", episodeCount: 7, episodeIds: [], slug: "mental-health" },
+  { name: "Cryptocurrency", description: "Regulatory developments, institutional adoption, and the aftermath of high-profile collapses.", episodeCount: 3, episodeIds: [], slug: "cryptocurrency" },
 ]
 
 const longNameTopics: TrendingTopic[] = [
-  { name: "The Impact of Large Language Models on Enterprise Software Development", description: "", episodeCount: 11, episodeIds: [], slug: "the-impact-of-large-language-models-on-enterprise-software-development" },
-  { name: "Decentralized Finance", description: "", episodeCount: 7, episodeIds: [], slug: "decentralized-finance" },
-  { name: "Quantum Computing Breakthroughs and Near-Term Commercial Applications", description: "", episodeCount: 4, episodeIds: [], slug: "quantum-computing-breakthroughs-and-near-term-commercial-applications" },
-  { name: "Climate Tech", description: "", episodeCount: 9, episodeIds: [], slug: "climate-tech" },
+  { name: "The Impact of Large Language Models on Enterprise Software Development Workflows", description: "From code review to architecture decisions, how LLMs are changing the day-to-day of professional software engineers.", episodeCount: 11, episodeIds: [], slug: "the-impact-of-large-language-models-on-enterprise-software-development" },
+  { name: "Decentralized Finance and the Future of Banking Infrastructure", description: "DeFi protocols, stablecoins, and what traditional banks are doing to compete.", episodeCount: 7, episodeIds: [], slug: "decentralized-finance" },
+  { name: "Quantum Computing Breakthroughs and Near-Term Commercial Applications", description: "Where quantum advantage is real today versus where it remains a research problem.", episodeCount: 4, episodeIds: [], slug: "quantum-computing-breakthroughs-and-near-term-commercial-applications" },
+  { name: "Climate Technology Investment and Green Infrastructure Deployment at Scale", description: "Grid modernization, battery storage, and the policy levers driving clean energy adoption.", episodeCount: 9, episodeIds: [], slug: "climate-tech" },
 ]
 
-const twoHoursAgo = STORY_TWO_HOURS_AGO
-const thirtyMinutesAgo = STORY_THIRTY_MIN_AGO
+const longDescriptionTopics: TrendingTopic[] = [
+  { name: "AI Regulation", description: "Governments worldwide are racing to pass AI governance frameworks. The EU AI Act introduced tiered risk categories that critics argue stifle innovation while proponents say protect fundamental rights. Meanwhile US federal efforts remain fragmented and state-level rules vary widely — creating compliance headaches for multinational companies.", episodeCount: 14, episodeIds: [], slug: "ai-regulation" },
+  { name: "Supply Chain Resilience", description: "After pandemic-era disruptions exposed critical single-supplier dependencies, global manufacturers are diversifying across geographies and building larger safety-stock buffers. The tradeoffs between just-in-time efficiency and resilience are reshaping procurement strategy and where factories get built.", episodeCount: 6, episodeIds: [], slug: "supply-chain-resilience" },
+  { name: "Space Commercialization", description: "Launch costs have fallen dramatically with reusable rockets, opening low Earth orbit to a new class of commercial operators. Satellite internet mega-constellations, in-orbit servicing, and the early-stage lunar economy are all competing for capital and spectrum allocations from regulators still using 1960s-era frameworks.", episodeCount: 9, episodeIds: [], slug: "space-commercialization" },
+]
 
 // ---------------------------------------------------------------------------
 // Meta
@@ -65,28 +58,28 @@ type Story = StoryObj<typeof TrendingTopics>
 export const Default: Story = {
   args: {
     topics: baseTopics,
-    generatedAt: twoHoursAgo,
-  },
-}
-
-export const SingleTopic: Story = {
-  args: {
-    topics: singleTopic,
-    generatedAt: twoHoursAgo,
-  },
-}
-
-export const MaxTopics: Story = {
-  args: {
-    topics: maxTopics,
-    generatedAt: thirtyMinutesAgo,
+    generatedAt: STORY_TWO_HOURS_AGO,
   },
 }
 
 export const LongNames: Story = {
   args: {
     topics: longNameTopics,
-    generatedAt: twoHoursAgo,
+    generatedAt: STORY_TWO_HOURS_AGO,
+  },
+}
+
+export const LongDescriptions: Story = {
+  args: {
+    topics: longDescriptionTopics,
+    generatedAt: STORY_THIRTY_MIN_AGO,
+  },
+}
+
+export const SingleTopic: Story = {
+  args: {
+    topics: [baseTopics[0]],
+    generatedAt: STORY_TWO_HOURS_AGO,
   },
 }
 

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -1,9 +1,15 @@
 import Link from "next/link";
 import { TrendingUp, ChevronRight } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
-import { getTopicSlug } from "@/lib/trending";
+import { dedupeTopics } from "@/lib/trending";
 import type { TrendingTopic } from "@/db/schema";
 
 interface TrendingTopicsProps {
@@ -13,7 +19,7 @@ interface TrendingTopicsProps {
 
 export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
   const updatedAgo = formatRelativeTime(generatedAt);
-  const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
+  const deduped = dedupeTopics(topics);
 
   if (deduped.length === 0) return null;
 
@@ -24,19 +30,19 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
           <TrendingUp className="h-4 w-4" />
           Trending Topics
         </CardTitle>
-        <p className="text-sm text-muted-foreground">Past 7 days · Updated {updatedAgo}</p>
+        <CardDescription>Past 7 days · Updated {updatedAgo}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-1">
-        {deduped.map((topic) => {
+        {deduped.map(({ topic, slug }) => {
           const count = topic.episodeCount;
           return (
             <Link
-              key={getTopicSlug(topic)}
-              href={`/trending/${getTopicSlug(topic)}`}
+              key={slug}
+              href={`/trending/${slug}`}
               className="flex items-start gap-3 rounded-md p-3 transition-colors hover:bg-accent"
             >
               <div className="min-w-0 flex-1">
-                <h3 className="font-semibold">{topic.name}</h3>
+                <p className="font-semibold">{topic.name}</p>
                 {topic.description && (
                   <p className="line-clamp-2 text-sm text-muted-foreground">{topic.description}</p>
                 )}
@@ -62,13 +68,17 @@ export function TrendingTopicsLoading() {
       </CardHeader>
       <CardContent className="space-y-1">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex items-start gap-3 p-3">
-            <div className="min-w-0 flex-1 space-y-2">
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-3 w-full" />
-              <Skeleton className="h-3 w-5/6" />
+          <div
+            key={i}
+            data-testid="trending-loading-row"
+            className="flex items-start gap-3 p-3"
+          >
+            <div className="min-w-0 flex-1">
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="mt-1.5 h-4 w-full" />
+              <Skeleton className="mt-1 h-4 w-5/6" />
             </div>
-            <Skeleton className="h-4 w-16 shrink-0" />
+            <Skeleton className="h-5 w-20 shrink-0" />
           </div>
         ))}
       </CardContent>

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -42,9 +42,11 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
               className="flex items-start gap-3 rounded-md p-3 transition-colors hover:bg-accent"
             >
               <div className="min-w-0 flex-1">
-                <p className="font-semibold">{topic.name}</p>
+                <p className="break-words font-semibold">{topic.name}</p>
                 {topic.description && (
-                  <p className="line-clamp-2 text-sm text-muted-foreground">{topic.description}</p>
+                  <p className="line-clamp-2 break-words text-sm text-muted-foreground">
+                    {topic.description}
+                  </p>
                 )}
               </div>
               <div className="flex shrink-0 items-center gap-1 text-sm text-muted-foreground">

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -15,6 +15,8 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
   const updatedAgo = formatRelativeTime(generatedAt);
   const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
 
+  if (deduped.length === 0) return null;
+
   return (
     <Card>
       <CardHeader>

--- a/src/components/dashboard/trending-topics.tsx
+++ b/src/components/dashboard/trending-topics.tsx
@@ -1,21 +1,10 @@
 import Link from "next/link";
-import { TrendingUp } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { TrendingUp, ChevronRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
 import { getTopicSlug } from "@/lib/trending";
 import type { TrendingTopic } from "@/db/schema";
-
-function TopicPill({ topic }: { topic: TrendingTopic }) {
-  return (
-    <Link href={`/trending/${getTopicSlug(topic)}`}>
-      <Badge variant="secondary" className="px-3 py-1 max-w-[200px] hover:bg-secondary/80 transition-colors">
-        <span className="min-w-0 flex-1 truncate text-sm" title={topic.name}>{topic.name}</span>
-        <span className="ml-1.5 text-muted-foreground font-normal shrink-0">({topic.episodeCount})</span>
-      </Badge>
-    </Link>
-  );
-}
 
 interface TrendingTopicsProps {
   topics: TrendingTopic[];
@@ -27,31 +16,60 @@ export function TrendingTopics({ topics, generatedAt }: TrendingTopicsProps) {
   const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
 
   return (
-    <div>
-      <div className="mb-3 flex items-center gap-2">
-        <TrendingUp className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium text-muted-foreground">
-          Trending · {updatedAgo}
-        </span>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {deduped.map((topic) => (
-          <TopicPill key={getTopicSlug(topic)} topic={topic} />
-        ))}
-      </div>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <TrendingUp className="h-4 w-4" />
+          Trending Topics
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">Past 7 days · Updated {updatedAgo}</p>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {deduped.map((topic) => {
+          const count = topic.episodeCount;
+          return (
+            <Link
+              key={getTopicSlug(topic)}
+              href={`/trending/${getTopicSlug(topic)}`}
+              className="flex items-start gap-3 rounded-md p-3 transition-colors hover:bg-accent"
+            >
+              <div className="min-w-0 flex-1">
+                <h3 className="font-semibold">{topic.name}</h3>
+                {topic.description && (
+                  <p className="line-clamp-2 text-sm text-muted-foreground">{topic.description}</p>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-1 text-sm text-muted-foreground">
+                <span>{count} {count === 1 ? "episode" : "episodes"}</span>
+                <ChevronRight className="h-4 w-4" />
+              </div>
+            </Link>
+          );
+        })}
+      </CardContent>
+    </Card>
   );
 }
 
 export function TrendingTopicsLoading() {
   return (
-    <div>
-      <Skeleton className="mb-3 h-4 w-32" />
-      <div className="flex flex-wrap gap-2">
-        {[1, 2, 3, 4, 5, 6].map((i) => (
-          <Skeleton key={i} className="h-7 w-24 rounded-full" />
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-56" />
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-3 p-3">
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+            </div>
+            <Skeleton className="h-4 w-16 shrink-0" />
+          </div>
         ))}
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/trending/topic-switcher.tsx
+++ b/src/components/trending/topic-switcher.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { getTopicSlug } from "@/lib/trending";
+import { dedupeTopics } from "@/lib/trending";
 import type { TrendingTopic } from "@/db/schema";
 
 interface TopicSwitcherProps {
@@ -9,17 +9,14 @@ interface TopicSwitcherProps {
 }
 
 export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
-  // Dedupe by resolved slug so two topics sharing a display name but distinct
-  // slugs both remain reachable from the switcher.
-  const deduped = Array.from(new Map(topics.map((t) => [getTopicSlug(t), t])).values());
+  const deduped = dedupeTopics(topics);
 
   if (deduped.length === 0) return null;
 
   return (
     <nav aria-label="Trending topics" className="overflow-x-auto">
       <div className="flex gap-2 whitespace-nowrap pb-2">
-        {deduped.map((t) => {
-          const slug = getTopicSlug(t);
+        {deduped.map(({ topic, slug }) => {
           const isActive = slug === activeSlug;
           return (
             <Link
@@ -33,7 +30,7 @@ export function TopicSwitcher({ topics, activeSlug }: TopicSwitcherProps) {
                   : "bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground"
               )}
             >
-              {t.name}
+              {topic.name}
             </Link>
           );
         })}

--- a/src/lib/__tests__/trending.test.ts
+++ b/src/lib/__tests__/trending.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  STALE_THRESHOLD_MS,
+  dedupeTopics,
+  getTopicSlug,
+  isTrendingSnapshotStale,
+} from "@/lib/trending";
+import type { TrendingTopic } from "@/db/schema";
+
+const MOCK_NOW = new Date("2026-03-15T12:00:00.000Z");
+
+function makeTopic(overrides: Partial<TrendingTopic> = {}): TrendingTopic {
+  const name = overrides.name ?? "Test Topic";
+  return {
+    name,
+    description: "",
+    episodeCount: 0,
+    episodeIds: [],
+    slug: name.toLowerCase(),
+    ...overrides,
+  };
+}
+
+describe("isTrendingSnapshotStale", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(MOCK_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false for null or undefined generatedAt", () => {
+    expect(isTrendingSnapshotStale(null)).toBe(false);
+    expect(isTrendingSnapshotStale(undefined)).toBe(false);
+  });
+
+  it("returns false just inside the 48h threshold", () => {
+    const oneSecondInside = new Date(MOCK_NOW.getTime() - STALE_THRESHOLD_MS + 1_000);
+    expect(isTrendingSnapshotStale(oneSecondInside)).toBe(false);
+  });
+
+  it("returns false exactly at the threshold boundary", () => {
+    const exactlyAtThreshold = new Date(MOCK_NOW.getTime() - STALE_THRESHOLD_MS);
+    expect(isTrendingSnapshotStale(exactlyAtThreshold)).toBe(false);
+  });
+
+  it("returns true just past the 48h threshold", () => {
+    const oneSecondPast = new Date(MOCK_NOW.getTime() - STALE_THRESHOLD_MS - 1_000);
+    expect(isTrendingSnapshotStale(oneSecondPast)).toBe(true);
+  });
+
+  it("returns false for a snapshot from the future (defensive)", () => {
+    const future = new Date(MOCK_NOW.getTime() + 60 * 1000);
+    expect(isTrendingSnapshotStale(future)).toBe(false);
+  });
+});
+
+describe("getTopicSlug", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns the populated slug as-is", () => {
+    const topic = makeTopic({ name: "Climate Tech", slug: "climate-tech" });
+    expect(getTopicSlug(topic)).toBe("climate-tech");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to slugify(name) for an empty-string slug and warns", () => {
+    const topic = makeTopic({ name: "Climate Tech", slug: "" });
+    expect(getTopicSlug(topic)).toBe("climate-tech");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to slugify(name) for a missing slug (pre-#279 rows) without warning", () => {
+    // Pre-#279 JSON rows lack a slug key at runtime even though TS claims it is required.
+    const topic = { name: "Climate Tech" } as unknown as TrendingTopic;
+    expect(getTopicSlug(topic)).toBe("climate-tech");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedupeTopics", () => {
+  it("returns { topic, slug } pairs for each unique slug", () => {
+    const topics = [
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "Climate", slug: "climate" }),
+    ];
+    const result = dedupeTopics(topics);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ topic: topics[0], slug: "ai" });
+    expect(result[1]).toEqual({ topic: topics[1], slug: "climate" });
+  });
+
+  it("collapses duplicate slugs to one entry", () => {
+    const topics = [
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "Tech", slug: "tech" }),
+    ];
+    const result = dedupeTopics(topics);
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.slug)).toEqual(["ai", "tech"]);
+  });
+
+  it("preserves two topics with the same display name but distinct slugs", () => {
+    const topics = [
+      makeTopic({ name: "AI", slug: "ai" }),
+      makeTopic({ name: "AI", slug: "ai-research" }),
+    ];
+    const result = dedupeTopics(topics);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(dedupeTopics([])).toEqual([]);
+  });
+
+  it("computes each topic's slug exactly once (no duplicate warn for empty-slug topics)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const topics = [makeTopic({ name: "Empty Slug Topic", slug: "" })];
+    dedupeTopics(topics);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/src/lib/__tests__/trending.test.ts
+++ b/src/lib/__tests__/trending.test.ts
@@ -124,11 +124,20 @@ describe("dedupeTopics", () => {
     expect(dedupeTopics([])).toEqual([]);
   });
 
-  it("computes each topic's slug exactly once (no duplicate warn for empty-slug topics)", () => {
+  it("warns exactly once per empty-slug topic across duplicate entries (no extra call from dedup map)", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const topics = [makeTopic({ name: "Empty Slug Topic", slug: "" })];
-    dedupeTopics(topics);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
+    try {
+      const topics = [
+        makeTopic({ name: "Empty Slug Topic", slug: "" }),
+        makeTopic({ name: "Empty Slug Topic", slug: "" }),
+      ];
+      const result = dedupeTopics(topics);
+      // Two entries, same computed slug → collapse to one, and each topic's
+      // slug was computed exactly once (2 calls, not 4).
+      expect(result).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -12,5 +12,5 @@ export function isTrendingSnapshotStale(generatedAt: Date | null | undefined): b
 // Pre-#279 JSON rows lack a slug key at runtime even though the TS type claims
 // it is required; derive it from the name for backward compatibility.
 export function getTopicSlug(topic: TrendingTopic): string {
-  return topic.slug ?? slugify(topic.name);
+  return topic.slug || slugify(topic.name);
 }

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -24,3 +24,15 @@ export function getTopicSlug(topic: TrendingTopic): string {
   }
   return topic.slug || slugify(topic.name);
 }
+
+// Dedupe topics by their resolved slug so two topics with a shared display name
+// but distinct slugs both survive, and two topics with the same slug collapse
+// to one. Returns `{ topic, slug }` pairs so callers can reuse the computed
+// slug without calling `getTopicSlug` again (which would duplicate the
+// empty-slug console.warn per topic per render).
+export function dedupeTopics(
+  topics: TrendingTopic[],
+): Array<{ topic: TrendingTopic; slug: string }> {
+  const withSlugs = topics.map((topic) => ({ topic, slug: getTopicSlug(topic) }));
+  return Array.from(new Map(withSlugs.map((e) => [e.slug, e])).values());
+}

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -10,7 +10,17 @@ export function isTrendingSnapshotStale(generatedAt: Date | null | undefined): b
 }
 
 // Pre-#279 JSON rows lack a slug key at runtime even though the TS type claims
-// it is required; derive it from the name for backward compatibility.
+// it is required; derive it from the name for backward compatibility. Uses `||`
+// (not `??`) so empty-string slugs from stale snapshots also fall back — an
+// empty slug would otherwise render as "/trending/".
 export function getTopicSlug(topic: TrendingTopic): string {
+  // Empty-string slugs are distinct from legacy missing slugs (pre-#279); log
+  // them so a real upstream data regression doesn't look identical to expected
+  // legacy rows once pre-#279 snapshots age out.
+  if (topic.slug === "") {
+    console.warn("Trending topic has empty-string slug; falling back to slugify(name):", {
+      name: topic.name,
+    });
+  }
   return topic.slug || slugify(topic.name);
 }


### PR DESCRIPTION
## Summary

- Replace truncated Badge pill grid in `src/components/dashboard/trending-topics.tsx` with a vertical list.
- Each row shows topic name (semibold, no truncation), LLM description (muted, 2-line clamp), episode count, and a `ChevronRight`, with the whole row wrapped in `<Link href="/trending/<slug>">` plus hover styling.
- `TrendingTopicsLoading` skeleton, Storybook stories, and unit tests are updated to mirror the new layout.
- Sub-change in `src/lib/trending.ts`: `getTopicSlug` switched from `??` to `||` so empty-string `slug` values from pre-#279 stale snapshots fall back to `slugify(name)` (locks in the defensive fallback required by #281).

## Test plan

- [x] `bun run lint`
- [x] `bun run test` (135 files, 1675 tests — all pass)
- [x] `bun run build`
- [x] `bun run build-storybook`
- [x] Unit tests cover: link `href` pattern `/trending/<slug>`, singular/plural episode count, no `truncate`/`line-clamp-1` on name, description `line-clamp-2`, header subline "Past 7 days · Updated ...", skeleton without `rounded-full`, defensive fallback with `slug: ""` → `href="/trending/no-slug-topic"`.
- [x] Storybook stories: `Default`, `LongNames`, `LongDescriptions`, `SingleTopic`, `Loading`.
- [ ] Manual check in Storybook viewport addon at 360 / 768 / 1280 px — verify no topic name truncates.

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Trending Topics redesigned as a card with a vertical, clickable list showing name, optional 2-line AI description, and episode counts; loading shows row-style placeholders.
  * Improved long-name handling and updated card subtitle to include "Trending Topics" plus recency info.

* **Bug Fixes**
  * Deduplicates topics by identifier and hides the card when no topics; missing/empty identifiers now auto-generate fallbacks (with a logged warning).

* **Tests / Stories**
  * Updated tests and sample stories to cover new layout, dedupe, empty-description, pluralization, and loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->