### PR TITLE
docs: tell agents to verify UI with agent-browser skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ bun run trigger:deploy # Deploy tasks to Trigger.dev Cloud
 - The pre-commit hook (Husky) automatically runs lint and tests on commit.
 - ADRs live in `docs/adr/` — read the relevant ADR before modifying areas it covers.
 - **UI verification (agents):** Vitest/RTL runs in jsdom and can't catch real rendering, layout, or interaction bugs. For any UI work, **invoke the `agent-browser` skill** to test the web app in a real browser:
-  - **App flows / pages:** start `bun run dev` (port 3000), then use `agent-browser` to navigate, click through the flow, fill forms, and take screenshots.
-  - **Isolated components:** start `bun run storybook` (port 6006), then use `agent-browser` to open the relevant story and screenshot it.
+  - **App flows / pages:** start `bun run dev` (port 3000), then use `agent-browser` to navigate to `http://localhost:3000`, click through the flow, fill forms, and take screenshots.
+  - **Isolated components:** start `bun run storybook` (port 6006), then use `agent-browser` to open `http://localhost:6006`, navigate to the relevant story, and screenshot it.
   - Exercise the golden path **and** edge cases; attach screenshots when reporting status. If you can't run a browser check, say so explicitly — don't claim UI success from type-checks alone.
 
 ## PR and commit instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ bun run trigger:deploy # Deploy tasks to Trigger.dev Cloud
 - Unit tests live in `__tests__/` directories co-located with source. Stories live alongside components as `*.stories.tsx` files.
 - The pre-commit hook (Husky) automatically runs lint and tests on commit.
 - ADRs live in `docs/adr/` — read the relevant ADR before modifying areas it covers.
+- **UI verification (agents):** Vitest/RTL runs in jsdom and can't catch real rendering, layout, or interaction bugs. For any UI work, **invoke the `agent-browser` skill** to test the web app in a real browser:
+  - **App flows / pages:** start `bun run dev` (port 3000), then use `agent-browser` to navigate, click through the flow, fill forms, and take screenshots.
+  - **Isolated components:** start `bun run storybook` (port 6006), then use `agent-browser` to open the relevant story and screenshot it.
+  - Exercise the golden path **and** edge cases; attach screenshots when reporting status. If you can't run a browser check, say so explicitly — don't claim UI success from type-checks alone.
 
 ## PR and commit instructions
 


### PR DESCRIPTION
## Summary
- Add a Testing-instructions bullet in `AGENTS.md` directing agents to invoke the `agent-browser` skill for any UI work.
- Dev server (port 3000) for app flows; Storybook (port 6006) for isolated components.
- Require screenshots + golden-path/edge-case checks, and honest reporting when a browser check isn't possible.

## Test plan
- [x] `AGENTS.md` renders correctly (markdown check).
- [ ] Follow-up: confirm agents actually trigger the skill on a real UI task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI testing guidelines to clarify that browser-based testing is required for validating real rendering, layout, and interactions across features. Introduced specific testing workflows for both application flows and component stories in dedicated environments, with explicit requirements for comprehensive coverage of standard paths and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->