### PR TITLE
feat: sync listening queue and player session across devices

### DIFF
--- a/.storybook/mocks/db-schema.ts
+++ b/.storybook/mocks/db-schema.ts
@@ -13,3 +13,5 @@ export const pushSubscriptions = {};
 export const trendingTopics = {};
 export const episodeTopics = {};
 export const listenHistory = {};
+export const userQueueItems = {};
+export const userPlayerSession = {};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Podcast discovery, AI-powered summarization, and library management for busy pro
 - Before planning any work, always sync with `main` (`git fetch origin main && git rebase origin/main`). This works in worktrees and on feature branches with in-progress work.
 - Before editing any code, always create a new branch from an up-to-date `main`.
 - Push feature branches to `origin` and open PRs against `main`.
+- **Effort estimation.** Weigh refactors by risk, scope clarity, and safety net (TypeScript, tests) — not by file count or imagined human-coordination cost. Cross-file cleanups that touch 10–50 files are routine one-session work; "project-wide churn" is not a valid reason to defer a clean refactor. Use review bandwidth, not labor, as the legitimate ceiling.
 
 ## Dev environment tips
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dashboard Trending Topics card redesigned as a vertical list with topic name, AI description (2-line clamp), episode count, and per-row link to `/trending/<slug>` (#281)
 
 ### Added
+- Cross-device sync for the listening queue and currently-playing episode. Queue and resume-position now round-trip through the server and reconcile on app mount or window focus. Concurrent mutations use last-commit-wins; active playback is never rewound by a server refetch. (#282)
 - Trending topic detail page at /trending/<slug> with horizontal topic switcher and ranked episode list sorted by worth-it score (#280)
 - Personal topic overlap indicators — shows contextual labels (e.g. "You've heard 3 similar episodes", "New topic for you") based on listen history and saved episodes. Recommendations deprioritize heavily-consumed topics (#262)
 - `rank-episode-topics` daily Trigger.dev scheduled task (7 AM UTC) that ranks episodes within each topic via exhaustive pairwise LLM comparison; win-count aggregation with worthItScore tiebreaker; adaptive episode cap (10/topic for ≤20 topics, 5/topic for >20); up to 50 topics per run (#261)

--- a/docs/adr/014-episode-queue-client-side.md
+++ b/docs/adr/014-episode-queue-client-side.md
@@ -1,6 +1,9 @@
 # ADR-014: Client-Side Episode Queue with localStorage Persistence
 
-**Status:** Proposed
+**Status:** Superseded by [ADR-036](036-cross-device-queue-session-sync.md)
+
+> Superseded by ADR-036 on 2026-04-18 — the client-side-only approach was replaced by server-backed cross-device sync. See ADR-036 for the current design.
+
 **Date:** 2026-03-03
 **Issue:** [#94](https://github.com/Chalet-Labs/contentgenie/issues/94)
 

--- a/docs/adr/036-cross-device-queue-session-sync.md
+++ b/docs/adr/036-cross-device-queue-session-sync.md
@@ -1,0 +1,185 @@
+# ADR-036: Cross-Device Queue & Player Session Sync
+
+**Status:** Proposed
+**Date:** 2026-04-18
+**Issue:** [#282](https://github.com/Chalet-Labs/contentgenie/issues/282)
+**Supersedes:** [ADR-014](014-episode-queue-client-side.md) (client-side queue with localStorage)
+
+## Context
+
+ADR-014 made the queue device-local, stored in `localStorage` only. Twelve
+months later, user feedback says the opposite is expected: people use
+ContentGenie on a mobile PWA **and** a desktop browser, and the queue and
+resume-position must follow them across devices (Spotify / Apple Podcasts
+norm). The same is true for the currently-playing episode — pausing on phone
+and opening laptop should resume at approximately the same timestamp.
+
+Today:
+
+- `src/lib/queue-persistence.ts` persists the queue to `localStorage` under
+  `contentgenie-player-queue`.
+- `src/lib/player-session.ts` persists `{ episode, currentTime, savedAt }` to
+  `localStorage` under `contentgenie-player-session` with a 24h TTL.
+- `src/contexts/audio-player-context.tsx` hydrates and writes to both on
+  mutations. No server round-trip exists.
+
+`localStorage` is per-origin-per-browser; an installed PWA and desktop browser
+are completely isolated buckets. Nothing to reconcile — there is simply no
+wire.
+
+Competing constraints for a server-backed replacement:
+
+- Queue mutations are frequent during drag-and-drop reorder — must not hammer
+  Neon or make the UI wait on the network.
+- Users rarely mutate the queue on two devices simultaneously, so the system
+  should optimize for the common case (one active device) and accept a
+  reasonable behaviour in the rare concurrent case.
+- The audio player works for episodes the user has never saved (search
+  results), so the server-side store cannot assume the episode exists in
+  `episodes` / `userLibrary`.
+- No new dependencies; reuse existing Drizzle + server-action patterns.
+
+## Options Considered
+
+### Option A: `setQueue` replace-all + last-commit-wins + denormalized fields (chosen)
+
+Add `user_queue_items` and `user_player_session` tables with **denormalized**
+episode fields (title, audioUrl, artwork, duration, chaptersUrl).
+
+One mutation endpoint for the queue:
+
+```ts
+setQueue(episodes: AudioEpisode[]): Promise<{ success: true } | { success: false; error: string }>
+```
+
+The server transaction deletes all rows for the user and inserts the supplied
+array; `position = array_index`. No per-operation `add` / `remove` / `reorder`
+actions. Client optimistic reducer dispatches remain instant; a trailing-edge
+1500ms debounce collapses rapid reorders into a single write whose payload is
+the latest committed state. Conflict resolution is commit-order: the last
+`setQueue` wins; no version token, no merge.
+
+Session uses a single-row upsert per user; same last-write-wins semantics with
+the existing 5s client-side throttle.
+
+- **Pros:**
+  - Ordering races are impossible to express — there is only one
+    mutation path, and its input is a full snapshot.
+  - Last-commit-wins needs no version/etag handshake; the action code is
+    trivially correct.
+  - Denormalized episode fields mean the queue works for non-library
+    episodes (search results) without coupling to the episode-ingest
+    pipeline.
+  - Debounce turns a 50-event drag into one ~8 KB write.
+  - Client reducer stays optimistic — user-perceived latency is zero.
+- **Cons:**
+  - Wire payload scales with queue length (acceptable: 50 items ≈ 8 KB; 200
+    items ≈ 30 KB).
+  - Concurrent mutations on two devices: one device's write disappears on the
+    other's next focus refetch. Documented and acceptable per product scope.
+  - Denormalization means renames/artwork changes aren't reflected in queue
+    items after they were enqueued. Acceptable: an episode's immutable
+    identity is its `podcastindex` id; metadata drift is cosmetic.
+  - Two unique indexes (`(userId, episodeId)` and `(userId, position)`)
+    impose correctness obligations on the action — every write must produce
+    dense, zero-based positions.
+
+### Option B: Per-operation actions (`addToQueue`, `removeFromQueue`, `reorderQueue`)
+
+Four actions, each mutates one row. Reorder sends the new full order or uses
+relative swaps.
+
+- **Pros:** Smaller wire payloads per op. More granular telemetry.
+- **Cons:** Ordering races are structural — a sequence of `reorder` and
+  `remove` calls from the client can arrive at the server out of order, and
+  the server cannot detect this without version tokens. Either we add
+  `updatedAt`-based optimistic concurrency (more code, more client round-trip
+  handling) or we ignore the problem and ship subtle bugs. The debounce
+  strategy doesn't apply cleanly — you either debounce each op type
+  separately (races persist across types) or you serialize everything into a
+  queue, at which point you've reinvented `setQueue` with extra steps.
+
+### Option C: Normalized FK to `episodes.id` + upsert on enqueue
+
+`user_queue_items.episodeId` references `episodes.id`. Every queue mutation
+ensures the episode exists by calling `upsertPodcast` + episode upsert.
+
+- **Pros:** Integrity. Metadata stays fresh via the ingest pipeline.
+- **Cons:** Couples queue mutations to the full podcast/episode ingest path
+  for no user-visible benefit. Search-result episodes with incomplete
+  metadata get partial rows written to `episodes`. Blast radius of any
+  ingest-pipeline bug now includes queue mutations. Slower cold enqueue.
+
+### Option D: Realtime push (websocket / SSE / Supabase-style)
+
+Server pushes queue changes to all devices in real time.
+
+- **Pros:** Two simultaneously-open tabs stay in sync without focus events.
+- **Cons:** Realtime infrastructure, connection management, reconnect logic,
+  auth over a long-lived transport. Product scope explicitly excludes this
+  ("Same-tab realtime sync is explicitly not required"). Overkill.
+
+## Decision
+
+**Option A.** `setQueue` replace-all, last-commit-wins, denormalized episode
+fields on both tables, debounced by final state (1500ms trailing edge).
+
+## Rationale
+
+- **Correctness by construction.** A single mutation path that takes a full
+  snapshot removes an entire class of bugs (reorder-vs-remove races,
+  out-of-order arrivals, position renumbering drift). Tests only need to
+  verify that `setQueue([a, b, c])` leaves the DB with exactly those rows.
+- **Matches the read path.** Focus-driven refetch is the sync model. The
+  server always hands the client a full, ordered snapshot; the client always
+  hands the server a full, ordered snapshot. Both directions use the same
+  shape.
+- **Decouples from episode ingest.** Denormalized fields make the queue
+  independent of whether an episode has been saved or summarized. Enqueueing
+  from a search result is a 2-query transaction instead of a 4-query chain
+  through `upsertPodcast`.
+- **Debounce is honest about UX.** Drag-and-drop dispatches 10–30 reorder
+  events within a second. A per-op action strategy sprays writes during the
+  drag; our strategy sends exactly one write 1.5s after settle. The user sees
+  zero latency regardless.
+- **Concurrent-device conflict is rare and survivable.** Empirically, a user
+  mutating the queue on two devices within the same 30s window is a corner
+  case. Documented behaviour ("the most recent commit wins") is simpler to
+  explain than "your queue was merged, here's why it looks different."
+
+## Consequences
+
+- Two new tables in `src/db/schema.ts`:
+  `user_queue_items` (one row per queue entry, with `(userId, position)` and
+  `(userId, episodeId)` unique indexes) and `user_player_session` (one row
+  per user, `userId` primary key).
+- Two new server-action modules: `src/app/actions/listening-queue.ts` and
+  `src/app/actions/player-session.ts`. Both follow the existing return-shape
+  contract `{ success: true; data?: T } | { success: false; error: string }`,
+  call `auth()` then `ensureUserExists(userId)`, and use Zod validation on
+  the `AudioEpisode` payload (mirroring `src/lib/schemas/library.ts`).
+- **Name explicitly:** the new modules are `listening-queue` / `player-session`.
+  They are **not** the pre-existing `src/contexts/sync-queue-context.tsx` /
+  `src/lib/sync-queue.ts` (IndexedDB-backed offline action replay for save /
+  subscribe — unrelated). See ADR-012 and ADR-019 for that system.
+- `src/contexts/audio-player-context.tsx` is refactored: instant hydrate
+  from localStorage cache on mount, then parallel `getQueue()` +
+  `getPlayerSession()`, then reconcile per the rules in the issue (pending-
+  write guard for queue; never-rewind-active-playback for session).
+- `src/lib/queue-persistence.ts` and `src/lib/player-session.ts` are
+  downgraded to cache-only helpers. The 24h TTL in `player-session.ts` is
+  removed — server is now the source of truth and has no TTL.
+- One-time migration on first mount after deploy: if server state is empty
+  and local state is non-empty, the client uploads the local snapshot. Safe
+  under `setQueue` replace-all semantics; concurrent first-mount on two
+  devices is the only racey case and resolves the same way as any concurrent
+  mutation (commit-order wins).
+- **Supersedes ADR-014.** That ADR explicitly called out "If cross-device
+  sync is desired in the future, the queue state shape is already an array
+  of AudioEpisode objects that could be persisted server-side without
+  restructuring the client code." This ADR cashes that cheque.
+- Explicitly **out of scope** for this ADR: realtime push, offline-write
+  replay integration with `sync-queue-context`, syncing
+  volume/playback-speed (kept device-local per `player-preferences.ts`), and
+  a cross-device "Now playing" indicator UI. Each may be revisited
+  individually in future issues.

--- a/docs/adr/036-cross-device-queue-session-sync.md
+++ b/docs/adr/036-cross-device-queue-session-sync.md
@@ -177,6 +177,19 @@ fields on both tables, debounced by final state (1500ms trailing edge).
   under `setQueue` replace-all semantics; concurrent first-mount on two
   devices is the only racey case and resolves the same way as any concurrent
   mutation (commit-order wins).
+- **Per-user migration markers.** Migration is gated by localStorage keys
+  `contentgenie-queue-migrated-<userId>` / `contentgenie-session-migrated-<userId>`
+  (see `src/lib/migration-marker.ts`). Once set, "server empty" is treated
+  as authoritative — a queue cleared on Device A is no longer resurrected
+  by Device B's stale cache. The original ADR-036 draft accepted this
+  trade-off; the markers close it without changing the last-write-wins
+  write semantics.
+- **Cross-user browser guard.** localStorage key
+  `contentgenie-last-user-id` tracks the last signed-in user. On mount, if
+  it differs from the current `userId`, the entire local cache + all
+  per-user markers are wiped before the first server fetch. Prevents
+  User A's cached queue from leaking into User B's account when both use
+  the same browser.
 - **Supersedes ADR-014.** That ADR explicitly called out "If cross-device
   sync is desired in the future, the queue state shape is already an array
   of AudioEpisode objects that could be persisted server-side without

--- a/docs/adr/036-cross-device-queue-session-sync.md
+++ b/docs/adr/036-cross-device-queue-session-sync.md
@@ -1,6 +1,6 @@
 # ADR-036: Cross-Device Queue & Player Session Sync
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-18
 **Issue:** [#282](https://github.com/Chalet-Labs/contentgenie/issues/282)
 **Supersedes:** [ADR-014](014-episode-queue-client-side.md) (client-side queue with localStorage)

--- a/docs/adr/036-cross-device-queue-session-sync.md
+++ b/docs/adr/036-cross-device-queue-session-sync.md
@@ -155,9 +155,12 @@ fields on both tables, debounced by final state (1500ms trailing edge).
   per user, `userId` primary key).
 - Two new server-action modules: `src/app/actions/listening-queue.ts` and
   `src/app/actions/player-session.ts`. Both follow the existing return-shape
-  contract `{ success: true; data?: T } | { success: false; error: string }`,
-  call `auth()` then `ensureUserExists(userId)`, and use Zod validation on
-  the `AudioEpisode` payload (mirroring `src/lib/schemas/library.ts`).
+  contract `{ success: true; data?: T } | { success: false; error: string }`
+  and authenticate with `auth()`. The write actions (`setQueue`,
+  `savePlayerSession`) additionally call `ensureUserExists(userId)` before
+  persistence and run the `AudioEpisode` payload through Zod (mirroring
+  `src/lib/schemas/library.ts`); the read and clear actions skip
+  `ensureUserExists` because they never need to create a user row.
 - **Name explicitly:** the new modules are `listening-queue` / `player-session`.
   They are **not** the pre-existing `src/contexts/sync-queue-context.tsx` /
   `src/lib/sync-queue.ts` (IndexedDB-backed offline action replay for save /

--- a/drizzle/0020_wooden_darkstar.sql
+++ b/drizzle/0020_wooden_darkstar.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "user_player_session" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"episode_id" text NOT NULL,
+	"title" text NOT NULL,
+	"podcast_title" text NOT NULL,
+	"audio_url" text NOT NULL,
+	"artwork" text,
+	"duration" integer,
+	"chapters_url" text,
+	"current_time" numeric(12, 3) NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_queue_items" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"episode_id" text NOT NULL,
+	"title" text NOT NULL,
+	"podcast_title" text NOT NULL,
+	"audio_url" text NOT NULL,
+	"artwork" text,
+	"duration" integer,
+	"chapters_url" text,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_player_session" ADD CONSTRAINT "user_player_session_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_queue_items" ADD CONSTRAINT "user_queue_items_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_queue_items_user_episode_idx" ON "user_queue_items" USING btree ("user_id","episode_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "user_queue_items_user_position_idx" ON "user_queue_items" USING btree ("user_id","position");

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1838 @@
+{
+  "id": "9fc00c93-c992-4240-a770-8293f35ffb72",
+  "prevId": "c0803d80-b2e0-4915-ae9d-1ec38048aaf4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summarization_prompt": {
+          "name": "summarization_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_config_updated_by_users_id_fk": {
+          "name": "ai_config_updated_by_users_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_enum": {
+          "name": "provider_enum",
+          "value": "\"ai_config\".\"provider\" IN ('openrouter', 'zai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_library_id": {
+          "name": "user_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_library_id_idx": {
+          "name": "bookmarks_user_library_id_idx",
+          "columns": [
+            {
+              "expression": "user_library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_library_id_user_library_id_fk": {
+          "name": "bookmarks_user_library_id_user_library_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user_library",
+          "columnsFrom": [
+            "user_library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episode_topics": {
+      "name": "episode_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_rank": {
+          "name": "topic_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranked_at": {
+          "name": "ranked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episode_topics_episode_topic_idx": {
+          "name": "episode_topics_episode_topic_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_idx": {
+          "name": "episode_topics_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_rank_idx": {
+          "name": "episode_topics_topic_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episode_topics_episode_id_episodes_id_fk": {
+          "name": "episode_topics_episode_id_episodes_id_fk",
+          "tableFrom": "episode_topics",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relevance_range": {
+          "name": "relevance_range",
+          "value": "\"episode_topics\".\"relevance\" >= 0 AND \"episode_topics\".\"relevance\" <= 1"
+        },
+        "topic_not_blank": {
+          "name": "topic_not_blank",
+          "value": "length(btrim(\"episode_topics\".\"topic\")) > 0"
+        },
+        "topic_rank_positive": {
+          "name": "topic_rank_positive",
+          "value": "\"episode_topics\".\"topic_rank\" IS NULL OR \"episode_topics\".\"topic_rank\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_score": {
+          "name": "worth_it_score",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_reason": {
+          "name": "worth_it_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_dimensions": {
+          "name": "worth_it_dimensions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_run_id": {
+          "name": "summary_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_run_id": {
+          "name": "transcript_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_status": {
+          "name": "summary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_source": {
+          "name": "transcript_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_status": {
+          "name": "transcript_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_fetched_at": {
+          "name": "transcript_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_error": {
+          "name": "transcript_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_guid": {
+          "name": "rss_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episodes_podcast_index_id_idx": {
+          "name": "episodes_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_podcast_id_idx": {
+          "name": "episodes_podcast_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_rss_guid_idx": {
+          "name": "episodes_rss_guid_idx",
+          "columns": [
+            {
+              "expression": "rss_guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_podcast_id_podcasts_id_fk": {
+          "name": "episodes_podcast_id_podcasts_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "episodes_podcast_index_id_unique": {
+          "name": "episodes_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "worth_it_score_range": {
+          "name": "worth_it_score_range",
+          "value": "\"episodes\".\"worth_it_score\" >= 0 AND \"episodes\".\"worth_it_score\" <= 10"
+        },
+        "summary_status_enum": {
+          "name": "summary_status_enum",
+          "value": "\"episodes\".\"summary_status\" IN ('queued', 'running', 'summarizing', 'completed', 'failed')"
+        },
+        "transcript_source_enum": {
+          "name": "transcript_source_enum",
+          "value": "\"episodes\".\"transcript_source\" IN ('podcastindex', 'assemblyai', 'description-url')"
+        },
+        "transcript_status_enum": {
+          "name": "transcript_status_enum",
+          "value": "\"episodes\".\"transcript_status\" IN ('missing', 'fetching', 'available', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listen_history": {
+      "name": "listen_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_episode_id": {
+          "name": "podcast_index_episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listen_duration_seconds": {
+          "name": "listen_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listen_history_user_episode_idx": {
+          "name": "listen_history_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_user_id_idx": {
+          "name": "listen_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_podcast_index_episode_id_idx": {
+          "name": "listen_history_podcast_index_episode_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listen_history_user_id_users_id_fk": {
+          "name": "listen_history_user_id_users_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listen_history_episode_id_episodes_id_fk": {
+          "name": "listen_history_episode_id_episodes_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_episode_unique_idx": {
+          "name": "notifications_user_episode_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "episode_id IS NOT NULL AND type = 'new_episode'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_episode_id_episodes_id_fk": {
+          "name": "notifications_episode_id_episodes_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_enum": {
+          "name": "notification_type_enum",
+          "value": "\"notifications\".\"type\" IN ('new_episode', 'summary_completed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.podcasts": {
+      "name": "podcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_feed_url": {
+          "name": "rss_feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_episode_date": {
+          "name": "latest_episode_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'podcastindex'"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "podcasts_podcast_index_id_idx": {
+          "name": "podcasts_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "podcasts_podcast_index_id_unique": {
+          "name": "podcasts_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "source_enum": {
+          "name": "source_enum",
+          "value": "\"podcasts\".\"source\" IN ('podcastindex', 'rss')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending_topics": {
+      "name": "trending_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trending_topics_generated_at_idx": {
+          "name": "trending_topics_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library": {
+      "name": "user_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_library_user_episode_idx": {
+          "name": "user_library_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_user_id_idx": {
+          "name": "user_library_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_episode_id_idx": {
+          "name": "user_library_episode_id_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_collection_id_idx": {
+          "name": "user_library_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_user_id_users_id_fk": {
+          "name": "user_library_user_id_users_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_episode_id_episodes_id_fk": {
+          "name": "user_library_episode_id_episodes_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_collection_id_collections_id_fk": {
+          "name": "user_library_collection_id_collections_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_player_session": {
+      "name": "user_player_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_title": {
+          "name": "podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters_url": {
+          "name": "chapters_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_time": {
+          "name": "current_time",
+          "type": "numeric(12, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_player_session_user_id_users_id_fk": {
+          "name": "user_player_session_user_id_users_id_fk",
+          "tableFrom": "user_player_session",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_queue_items": {
+      "name": "user_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_title": {
+          "name": "podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters_url": {
+          "name": "chapters_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_queue_items_user_episode_idx": {
+          "name": "user_queue_items_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_queue_items_user_position_idx": {
+          "name": "user_queue_items_user_position_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_queue_items_user_id_users_id_fk": {
+          "name": "user_queue_items_user_id_users_id_fk",
+          "tableFrom": "user_queue_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_podcast_idx": {
+          "name": "user_subscriptions_user_podcast_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_id_idx": {
+          "name": "user_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_podcast_id_podcasts_id_fk": {
+          "name": "user_subscriptions_podcast_id_podcasts_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776458963778,
       "tag": "0019_lumpy_overlord",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1776549145897,
+      "tag": "0020_wooden_darkstar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/__tests__/__fixtures.ts
+++ b/src/app/actions/__tests__/__fixtures.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared fixtures + pure mock factories for server-action tests.
+ * File starts with `__` to signal non-test intent and sort before siblings.
+ * Kept intentionally small: Vitest hoists `vi.mock(...)` calls to the top of
+ * each test module, so mock registration itself must live in each test file.
+ * What IS portable: fixture data, and mock-return factories that don't close
+ * over file-local variables.
+ */
+import { vi } from "vitest"
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+export const validEpisode: AudioEpisode = {
+  id: "ep-1",
+  title: "Test Episode",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 600,
+}
+
+export const validEpisode2: AudioEpisode = {
+  id: "ep-2",
+  title: "Test Episode 2",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio2.mp3",
+}
+
+/**
+ * Factory for the `drizzle-orm` mock. Pure (no closure over file-local vars),
+ * so it's safe to call from inside a `vi.mock("drizzle-orm", () => …)` factory.
+ */
+export function createDrizzleOrmMock() {
+  return {
+    eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+    asc: vi.fn((col: unknown) => ({ col, direction: "asc" })),
+  }
+}

--- a/src/app/actions/__tests__/__fixtures.ts
+++ b/src/app/actions/__tests__/__fixtures.ts
@@ -3,8 +3,10 @@
  * File starts with `__` to signal non-test intent and sort before siblings.
  * Kept intentionally small: Vitest hoists `vi.mock(...)` calls to the top of
  * each test module, so mock registration itself must live in each test file.
- * What IS portable: mock-return factories that don't close over file-local
- * variables. Episode fixtures live in `@/test/fixtures/audio-episode`.
+ * Helper factories here are safe to reference from inside a `vi.mock(..., () => …)`
+ * factory because that factory runs lazily (at first `import(...)` of the
+ * mocked module), by which time ESM imports have resolved.
+ * Episode fixtures live in `@/test/fixtures/audio-episode`.
  */
 import { vi } from "vitest"
 
@@ -18,5 +20,57 @@ export function createDrizzleOrmMock() {
   return {
     eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
     asc: vi.fn((col: unknown) => ({ col, direction: "asc" })),
+  }
+}
+
+/**
+ * Build a 2-level chain: `db.insert(table).values(rows)`.
+ * `values()` returns whatever `valuesSpy` returns (usually a resolved Promise).
+ */
+export function makeInsertChain(
+  insertSpy: (...args: unknown[]) => void,
+  valuesSpy: (...args: unknown[]) => unknown,
+) {
+  return (...args: unknown[]) => {
+    insertSpy(...args)
+    return {
+      values: (...vArgs: unknown[]) => valuesSpy(...vArgs),
+    }
+  }
+}
+
+/**
+ * Build a 3-level chain: `db.insert(table).values(rows).onConflictDoUpdate(opts)`.
+ * `valuesSpy` is called for argument tracking; its return value is discarded
+ * in favor of the next-level wrapper. `onConflictSpy`'s return is returned.
+ */
+export function makeInsertConflictChain(
+  insertSpy: (...args: unknown[]) => void,
+  valuesSpy: (...args: unknown[]) => void,
+  onConflictSpy: (opts: unknown) => unknown,
+) {
+  return (...args: unknown[]) => {
+    insertSpy(...args)
+    return {
+      values: (...vArgs: unknown[]) => {
+        valuesSpy(...vArgs)
+        return {
+          onConflictDoUpdate: (opts: unknown) => onConflictSpy(opts),
+        }
+      },
+    }
+  }
+}
+
+/** Build a 2-level chain: `db.delete(table).where(predicate)`. */
+export function makeDeleteChain(
+  deleteSpy: (...args: unknown[]) => void,
+  whereSpy: (...args: unknown[]) => unknown,
+) {
+  return (...args: unknown[]) => {
+    deleteSpy(...args)
+    return {
+      where: (...wArgs: unknown[]) => whereSpy(...wArgs),
+    }
   }
 }

--- a/src/app/actions/__tests__/__fixtures.ts
+++ b/src/app/actions/__tests__/__fixtures.ts
@@ -8,7 +8,9 @@
  * mocked module), by which time ESM imports have resolved.
  * Episode fixtures live in `@/test/fixtures/audio-episode`.
  */
-import { vi } from "vitest"
+import { expect, vi } from "vitest"
+
+type MockFn = ReturnType<typeof vi.fn>
 
 export { validEpisode, validEpisode2 } from "@/test/fixtures/audio-episode"
 
@@ -72,5 +74,85 @@ export function makeDeleteChain(
     return {
       where: (...wArgs: unknown[]) => whereSpy(...wArgs),
     }
+  }
+}
+
+/**
+ * Module shape for `@clerk/nextjs/server`. Intended for use inside
+ * `vi.mock("@clerk/nextjs/server", () => makeClerkAuthMock(() => mockAuth()))`.
+ * The global test setup already installs a happy-path Clerk mock; action tests
+ * override it so they can drive `userId` per test (e.g. null for the
+ * unauthenticated case).
+ */
+export function makeClerkAuthMock(authSpy: () => unknown) {
+  return { auth: authSpy }
+}
+
+/**
+ * Module shape for `@/db/helpers`. Intended for use inside
+ * `vi.mock("@/db/helpers", () => makeUserHelpersMock(mockEnsureUserExists))`.
+ */
+export function makeUserHelpersMock(
+  ensureUserExistsSpy: (...args: unknown[]) => unknown,
+) {
+  return { ensureUserExists: ensureUserExistsSpy }
+}
+
+/**
+ * Default "happy path" `beforeEach` body for server-action tests.
+ * Clears all mocks, signs in as `user_123`, makes `ensureUserExists` a no-op.
+ * Usage: `beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))`
+ * Call a second `beforeEach(...)` for describe-specific mock resets.
+ */
+export function happyPathSetup(authSpy: MockFn, ensureUserExistsSpy: MockFn) {
+  return () => {
+    vi.clearAllMocks()
+    authSpy.mockResolvedValue({ userId: "user_123" })
+    ensureUserExistsSpy.mockResolvedValue(undefined)
+  }
+}
+
+/**
+ * Test body for the canonical "returns { success: false } when
+ * unauthenticated" case. Sets the auth spy to return `{ userId: null }`,
+ * runs the action, and asserts the action failed AND that `blockedSpy`
+ * (the next-in-chain operation that should have been gated) was never
+ * called. Usage:
+ *
+ *   it("... when unauthenticated", testUnauthenticated(
+ *     mockAuth,
+ *     async () => (await import("...")).action(),
+ *     mockFindFirst,
+ *   ))
+ */
+export function testUnauthenticated(
+  authSpy: MockFn,
+  runAction: () => Promise<{ success: boolean }>,
+  blockedSpy: MockFn,
+) {
+  return async () => {
+    authSpy.mockResolvedValue({ userId: null })
+    const result = await runAction()
+    expect(result.success).toBe(false)
+    expect(blockedSpy).not.toHaveBeenCalled()
+  }
+}
+
+/**
+ * Test body for the canonical "returns { success: false } on DB error" case.
+ * Makes `failingSpy` reject with `new Error("DB failure")`, silences
+ * `console.error`, runs the action, and asserts failure + that
+ * `console.error` was invoked.
+ */
+export function testDbError(
+  failingSpy: MockFn,
+  runAction: () => Promise<{ success: boolean }>,
+) {
+  return async () => {
+    failingSpy.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const result = await runAction()
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
   }
 }

--- a/src/app/actions/__tests__/__fixtures.ts
+++ b/src/app/actions/__tests__/__fixtures.ts
@@ -1,29 +1,14 @@
 /**
- * Shared fixtures + pure mock factories for server-action tests.
+ * Shared mock factories for server-action tests.
  * File starts with `__` to signal non-test intent and sort before siblings.
  * Kept intentionally small: Vitest hoists `vi.mock(...)` calls to the top of
  * each test module, so mock registration itself must live in each test file.
- * What IS portable: fixture data, and mock-return factories that don't close
- * over file-local variables.
+ * What IS portable: mock-return factories that don't close over file-local
+ * variables. Episode fixtures live in `@/test/fixtures/audio-episode`.
  */
 import { vi } from "vitest"
-import type { AudioEpisode } from "@/contexts/audio-player-context"
 
-export const validEpisode: AudioEpisode = {
-  id: "ep-1",
-  title: "Test Episode",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio.mp3",
-  artwork: "https://example.com/art.jpg",
-  duration: 600,
-}
-
-export const validEpisode2: AudioEpisode = {
-  id: "ep-2",
-  title: "Test Episode 2",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio2.mp3",
-}
+export { validEpisode, validEpisode2 } from "@/test/fixtures/audio-episode"
 
 /**
  * Factory for the `drizzle-orm` mock. Pure (no closure over file-local vars),

--- a/src/app/actions/__tests__/listening-queue.test.ts
+++ b/src/app/actions/__tests__/listening-queue.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
+import {
+  createDrizzleOrmMock,
+  validEpisode,
+  validEpisode2,
+} from "@/app/actions/__tests__/__fixtures"
 
 // Mock Clerk auth
 const mockAuth = vi.fn()
@@ -82,27 +87,8 @@ vi.mock("@/db/schema", () => ({
   },
 }))
 
-// Mock drizzle-orm
-vi.mock("drizzle-orm", () => ({
-  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
-  asc: vi.fn((col: unknown) => ({ col, direction: "asc" })),
-}))
-
-const validEpisode: AudioEpisode = {
-  id: "ep-1",
-  title: "Test Episode",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio.mp3",
-  artwork: "https://example.com/art.jpg",
-  duration: 600,
-}
-
-const validEpisode2: AudioEpisode = {
-  id: "ep-2",
-  title: "Test Episode 2",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio2.mp3",
-}
+// Mock drizzle-orm (shared factory lives in __fixtures.ts)
+vi.mock("drizzle-orm", () => createDrizzleOrmMock())
 
 describe("getQueue", () => {
   beforeEach(() => {

--- a/src/app/actions/__tests__/listening-queue.test.ts
+++ b/src/app/actions/__tests__/listening-queue.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
   createDrizzleOrmMock,
+  makeDeleteChain,
+  makeInsertChain,
   validEpisode,
   validEpisode2,
 } from "@/app/actions/__tests__/__fixtures"
@@ -19,44 +21,16 @@ const mockDelete = vi.fn()
 const mockDeleteWhere = vi.fn()
 const mockFindMany = vi.fn()
 const mockTx = {
-  insert: (...args: unknown[]) => {
-    mockInsert(...args)
-    return {
-      values: (...vArgs: unknown[]) => {
-        return mockInsertValues(...vArgs)
-      },
-    }
-  },
-  delete: (...args: unknown[]) => {
-    mockDelete(...args)
-    return {
-      where: (...wArgs: unknown[]) => {
-        return mockDeleteWhere(...wArgs)
-      },
-    }
-  },
+  insert: makeInsertChain(mockInsert, mockInsertValues),
+  delete: makeDeleteChain(mockDelete, mockDeleteWhere),
 }
 const mockTransaction = vi.fn()
 
 vi.mock("@/db", () => ({
   db: {
     transaction: (...args: unknown[]) => mockTransaction(...args),
-    insert: (...args: unknown[]) => {
-      mockInsert(...args)
-      return {
-        values: (...vArgs: unknown[]) => {
-          return mockInsertValues(...vArgs)
-        },
-      }
-    },
-    delete: (...args: unknown[]) => {
-      mockDelete(...args)
-      return {
-        where: (...wArgs: unknown[]) => {
-          return mockDeleteWhere(...wArgs)
-        },
-      }
-    },
+    insert: makeInsertChain(mockInsert, mockInsertValues),
+    delete: makeDeleteChain(mockDelete, mockDeleteWhere),
     query: {
       userQueueItems: {
         findMany: (...args: unknown[]) => mockFindMany(...args),

--- a/src/app/actions/__tests__/listening-queue.test.ts
+++ b/src/app/actions/__tests__/listening-queue.test.ts
@@ -2,17 +2,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
   createDrizzleOrmMock,
+  happyPathSetup,
+  makeClerkAuthMock,
   makeDeleteChain,
   makeInsertChain,
+  makeUserHelpersMock,
+  testDbError,
+  testUnauthenticated,
   validEpisode,
   validEpisode2,
 } from "@/app/actions/__tests__/__fixtures"
 
 // Mock Clerk auth
 const mockAuth = vi.fn()
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: () => mockAuth(),
-}))
+vi.mock("@clerk/nextjs/server", () =>
+  makeClerkAuthMock(() => mockAuth()),
+)
 
 // Mock database
 const mockInsert = vi.fn()
@@ -41,9 +46,9 @@ vi.mock("@/db", () => ({
 
 // Mock helpers
 const mockEnsureUserExists = vi.fn()
-vi.mock("@/db/helpers", () => ({
-  ensureUserExists: (...args: unknown[]) => mockEnsureUserExists(...args),
-}))
+vi.mock("@/db/helpers", () =>
+  makeUserHelpersMock((...args: unknown[]) => mockEnsureUserExists(...args)),
+)
 
 // Mock schema
 vi.mock("@/db/schema", () => ({
@@ -64,37 +69,35 @@ vi.mock("@/db/schema", () => ({
 // Mock drizzle-orm (shared factory lives in __fixtures.ts)
 vi.mock("drizzle-orm", () => createDrizzleOrmMock())
 
+const importAction = async () => import("@/app/actions/listening-queue")
+
 describe("getQueue", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
     mockFindMany.mockResolvedValue([])
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockInsertValues.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { getQueue } = await import("@/app/actions/listening-queue")
-    const result = await getQueue()
-    expect(result.success).toBe(false)
-    expect(mockFindMany).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).getQueue(),
+      mockFindMany,
+    ),
+  )
 
   it("returns { success: true, data: [] } when user has no rows", async () => {
     mockFindMany.mockResolvedValue([])
-    const { getQueue } = await import("@/app/actions/listening-queue")
+    const { getQueue } = await importAction()
     const result = await getQueue()
     expect(result).toEqual({ success: true, data: [] })
   })
 
   it("does not call ensureUserExists (read-only path)", async () => {
-    const { getQueue } = await import("@/app/actions/listening-queue")
+    const { getQueue } = await importAction()
     await getQueue()
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
@@ -129,7 +132,7 @@ describe("getQueue", () => {
       },
     ]
     mockFindMany.mockResolvedValue(dbRows)
-    const { getQueue } = await import("@/app/actions/listening-queue")
+    const { getQueue } = await importAction()
     const result = await getQueue()
     expect(result.success).toBe(true)
     if (!result.success) throw new Error("should be success")
@@ -156,42 +159,37 @@ describe("getQueue", () => {
     ])
   })
 
-  it("returns { success: false, error } on DB error", async () => {
-    mockFindMany.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { getQueue } = await import("@/app/actions/listening-queue")
-    const result = await getQueue()
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error",
+    testDbError(
+      mockFindMany,
+      async () => (await importAction()).getQueue(),
+    ),
+  )
 })
 
 describe("setQueue", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockInsertValues.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
     mockTransaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<void>) => {
       await fn(mockTx)
     })
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { setQueue } = await import("@/app/actions/listening-queue")
-    const result = await setQueue([validEpisode])
-    expect(result.success).toBe(false)
-    expect(mockTransaction).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).setQueue([validEpisode]),
+      mockTransaction,
+    ),
+  )
 
   it("Zod-rejects an invalid payload without touching the DB", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     // audioUrl is not a valid URL
     const badEpisode = { id: "ep-1", title: "T", podcastTitle: "P", audioUrl: "not-a-url" }
     const result = await setQueue([badEpisode as AudioEpisode])
@@ -201,7 +199,7 @@ describe("setQueue", () => {
   })
 
   it("rejects a queue containing duplicate episode IDs before touching the DB", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     const result = await setQueue([validEpisode, { ...validEpisode }])
     expect(result.success).toBe(false)
     expect(mockTransaction).not.toHaveBeenCalled()
@@ -209,7 +207,7 @@ describe("setQueue", () => {
   })
 
   it("rejects a queue with a non-https audioUrl before touching the DB", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     const jsUrl = {
       ...validEpisode,
       audioUrl: "javascript:alert(1)",
@@ -221,7 +219,7 @@ describe("setQueue", () => {
   })
 
   it("calls db.transaction, with DELETE before INSERT scoped to the signed-in user", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     await setQueue([validEpisode, validEpisode2])
     expect(mockTransaction).toHaveBeenCalledTimes(1)
     const deleteOrder = mockDelete.mock.invocationCallOrder[0]
@@ -234,7 +232,7 @@ describe("setQueue", () => {
   })
 
   it("inserts rows with position = 0, 1, 2 and explicit updatedAt Date", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     await setQueue([validEpisode, validEpisode2])
     expect(mockInsertValues).toHaveBeenCalledTimes(1)
     const rows = mockInsertValues.mock.calls[0][0]
@@ -246,7 +244,7 @@ describe("setQueue", () => {
   })
 
   it("with empty array produces only DELETE (no INSERT)", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     await setQueue([])
     expect(mockTransaction).toHaveBeenCalledTimes(1)
     expect(mockDelete).toHaveBeenCalledTimes(1)
@@ -258,7 +256,7 @@ describe("setQueue", () => {
   })
 
   it("calls ensureUserExists before the transaction", async () => {
-    const { setQueue } = await import("@/app/actions/listening-queue")
+    const { setQueue } = await importAction()
     await setQueue([validEpisode])
     expect(mockEnsureUserExists).toHaveBeenCalledWith("user_123")
     const ensureOrder = mockEnsureUserExists.mock.invocationCallOrder[0]
@@ -266,38 +264,33 @@ describe("setQueue", () => {
     expect(ensureOrder).toBeLessThan(txOrder)
   })
 
-  it("returns { success: false, error } on DB error and calls console.error", async () => {
-    mockTransaction.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { setQueue } = await import("@/app/actions/listening-queue")
-    const result = await setQueue([validEpisode])
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error and calls console.error",
+    testDbError(
+      mockTransaction,
+      async () => (await importAction()).setQueue([validEpisode]),
+    ),
+  )
 })
 
 describe("clearQueue", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { clearQueue } = await import("@/app/actions/listening-queue")
-    const result = await clearQueue()
-    expect(result.success).toBe(false)
-    expect(mockDelete).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).clearQueue(),
+      mockDelete,
+    ),
+  )
 
   it("issues DELETE WHERE userId = $user on success", async () => {
-    const { clearQueue } = await import("@/app/actions/listening-queue")
+    const { clearQueue } = await importAction()
     const result = await clearQueue()
     expect(result).toEqual({ success: true })
     expect(mockDelete).toHaveBeenCalledTimes(1)
@@ -309,17 +302,16 @@ describe("clearQueue", () => {
   })
 
   it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {
-    const { clearQueue } = await import("@/app/actions/listening-queue")
+    const { clearQueue } = await importAction()
     await clearQueue()
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
 
-  it("returns { success: false, error } on DB error", async () => {
-    mockDeleteWhere.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { clearQueue } = await import("@/app/actions/listening-queue")
-    const result = await clearQueue()
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error",
+    testDbError(
+      mockDeleteWhere,
+      async () => (await importAction()).clearQueue(),
+    ),
+  )
 })

--- a/src/app/actions/__tests__/listening-queue.test.ts
+++ b/src/app/actions/__tests__/listening-queue.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+// Mock Clerk auth
+const mockAuth = vi.fn()
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+}))
+
+// Mock database
+const mockInsert = vi.fn()
+const mockInsertValues = vi.fn()
+const mockDelete = vi.fn()
+const mockDeleteWhere = vi.fn()
+const mockFindMany = vi.fn()
+const mockTx = {
+  insert: (...args: unknown[]) => {
+    mockInsert(...args)
+    return {
+      values: (...vArgs: unknown[]) => {
+        return mockInsertValues(...vArgs)
+      },
+    }
+  },
+  delete: (...args: unknown[]) => {
+    mockDelete(...args)
+    return {
+      where: (...wArgs: unknown[]) => {
+        return mockDeleteWhere(...wArgs)
+      },
+    }
+  },
+}
+const mockTransaction = vi.fn()
+
+vi.mock("@/db", () => ({
+  db: {
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+    insert: (...args: unknown[]) => {
+      mockInsert(...args)
+      return {
+        values: (...vArgs: unknown[]) => {
+          return mockInsertValues(...vArgs)
+        },
+      }
+    },
+    delete: (...args: unknown[]) => {
+      mockDelete(...args)
+      return {
+        where: (...wArgs: unknown[]) => {
+          return mockDeleteWhere(...wArgs)
+        },
+      }
+    },
+    query: {
+      userQueueItems: {
+        findMany: (...args: unknown[]) => mockFindMany(...args),
+      },
+    },
+  },
+}))
+
+// Mock helpers
+const mockEnsureUserExists = vi.fn()
+vi.mock("@/db/helpers", () => ({
+  ensureUserExists: (...args: unknown[]) => mockEnsureUserExists(...args),
+}))
+
+// Mock schema
+vi.mock("@/db/schema", () => ({
+  userQueueItems: {
+    userId: "userId",
+    episodeId: "episodeId",
+    position: "position",
+    title: "title",
+    podcastTitle: "podcastTitle",
+    audioUrl: "audioUrl",
+    artwork: "artwork",
+    duration: "duration",
+    chaptersUrl: "chaptersUrl",
+    updatedAt: "updatedAt",
+  },
+}))
+
+// Mock drizzle-orm
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  asc: vi.fn((col: unknown) => ({ col, direction: "asc" })),
+}))
+
+const validEpisode: AudioEpisode = {
+  id: "ep-1",
+  title: "Test Episode",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 600,
+}
+
+const validEpisode2: AudioEpisode = {
+  id: "ep-2",
+  title: "Test Episode 2",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio2.mp3",
+}
+
+describe("getQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockFindMany.mockResolvedValue([])
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockInsertValues.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { getQueue } = await import("@/app/actions/listening-queue")
+    const result = await getQueue()
+    expect(result.success).toBe(false)
+    expect(mockFindMany).not.toHaveBeenCalled()
+  })
+
+  it("returns { success: true, data: [] } when user has no rows", async () => {
+    mockFindMany.mockResolvedValue([])
+    const { getQueue } = await import("@/app/actions/listening-queue")
+    const result = await getQueue()
+    expect(result).toEqual({ success: true, data: [] })
+  })
+
+  it("does not call ensureUserExists (read-only path)", async () => {
+    const { getQueue } = await import("@/app/actions/listening-queue")
+    await getQueue()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("maps DB rows back to AudioEpisode[] ordered by position ASC", async () => {
+    const dbRows = [
+      {
+        id: 1,
+        userId: "user_123",
+        position: 0,
+        episodeId: "ep-1",
+        title: "Test Episode",
+        podcastTitle: "Test Podcast",
+        audioUrl: "https://example.com/audio.mp3",
+        artwork: "https://example.com/art.jpg",
+        duration: 600,
+        chaptersUrl: null,
+        updatedAt: new Date(),
+      },
+      {
+        id: 2,
+        userId: "user_123",
+        position: 1,
+        episodeId: "ep-2",
+        title: "Test Episode 2",
+        podcastTitle: "Test Podcast",
+        audioUrl: "https://example.com/audio2.mp3",
+        artwork: null,
+        duration: null,
+        chaptersUrl: null,
+        updatedAt: new Date(),
+      },
+    ]
+    mockFindMany.mockResolvedValue(dbRows)
+    const { getQueue } = await import("@/app/actions/listening-queue")
+    const result = await getQueue()
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error("should be success")
+    expect(result.data).toHaveLength(2)
+    expect(result.data[0]).toEqual({
+      id: "ep-1",
+      title: "Test Episode",
+      podcastTitle: "Test Podcast",
+      audioUrl: "https://example.com/audio.mp3",
+      artwork: "https://example.com/art.jpg",
+      duration: 600,
+    })
+    expect(result.data[1]).toEqual({
+      id: "ep-2",
+      title: "Test Episode 2",
+      podcastTitle: "Test Podcast",
+      audioUrl: "https://example.com/audio2.mp3",
+    })
+    // Verify orderBy was passed with asc
+    const findManyCall = mockFindMany.mock.calls[0][0]
+    expect(findManyCall).toHaveProperty("orderBy")
+  })
+
+  it("returns { success: false, error } on DB error", async () => {
+    mockFindMany.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { getQueue } = await import("@/app/actions/listening-queue")
+    const result = await getQueue()
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe("setQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockInsertValues.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+    mockTransaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<void>) => {
+      await fn(mockTx)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    const result = await setQueue([validEpisode])
+    expect(result.success).toBe(false)
+    expect(mockTransaction).not.toHaveBeenCalled()
+  })
+
+  it("Zod-rejects an invalid payload without touching the DB", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    // audioUrl is not a valid URL
+    const badEpisode = { id: "ep-1", title: "T", podcastTitle: "P", audioUrl: "not-a-url" }
+    const result = await setQueue([badEpisode as AudioEpisode])
+    expect(result.success).toBe(false)
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("calls db.transaction, with DELETE before INSERT", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    await setQueue([validEpisode, validEpisode2])
+    expect(mockTransaction).toHaveBeenCalledTimes(1)
+    const deleteOrder = mockDelete.mock.invocationCallOrder[0]
+    const insertOrder = mockInsert.mock.invocationCallOrder[0]
+    expect(deleteOrder).toBeLessThan(insertOrder)
+  })
+
+  it("inserts rows with position = 0, 1, 2 and explicit updatedAt Date", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    await setQueue([validEpisode, validEpisode2])
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const rows = mockInsertValues.mock.calls[0][0]
+    expect(rows).toHaveLength(2)
+    expect(rows[0].position).toBe(0)
+    expect(rows[1].position).toBe(1)
+    expect(rows[0].updatedAt).toBeInstanceOf(Date)
+    expect(rows[1].updatedAt).toBeInstanceOf(Date)
+  })
+
+  it("with empty array produces only DELETE (no INSERT)", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    await setQueue([])
+    expect(mockTransaction).toHaveBeenCalledTimes(1)
+    expect(mockDelete).toHaveBeenCalledTimes(1)
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it("calls ensureUserExists before the transaction", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    await setQueue([validEpisode])
+    expect(mockEnsureUserExists).toHaveBeenCalledWith("user_123")
+    const ensureOrder = mockEnsureUserExists.mock.invocationCallOrder[0]
+    const txOrder = mockTransaction.mock.invocationCallOrder[0]
+    expect(ensureOrder).toBeLessThan(txOrder)
+  })
+
+  it("returns { success: false, error } on DB error and calls console.error", async () => {
+    mockTransaction.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    const result = await setQueue([validEpisode])
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe("clearQueue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { clearQueue } = await import("@/app/actions/listening-queue")
+    const result = await clearQueue()
+    expect(result.success).toBe(false)
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it("issues DELETE WHERE userId = $user on success", async () => {
+    const { clearQueue } = await import("@/app/actions/listening-queue")
+    const result = await clearQueue()
+    expect(result).toEqual({ success: true })
+    expect(mockDelete).toHaveBeenCalledTimes(1)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {
+    const { clearQueue } = await import("@/app/actions/listening-queue")
+    await clearQueue()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("returns { success: false, error } on DB error", async () => {
+    mockDeleteWhere.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { clearQueue } = await import("@/app/actions/listening-queue")
+    const result = await clearQueue()
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/__tests__/listening-queue.test.ts
+++ b/src/app/actions/__tests__/listening-queue.test.ts
@@ -188,9 +188,12 @@ describe("getQueue", () => {
       podcastTitle: "Test Podcast",
       audioUrl: "https://example.com/audio2.mp3",
     })
-    // Verify orderBy was passed with asc
+    // Verify rows are scoped to the signed-in user and ordered by position ASC
     const findManyCall = mockFindMany.mock.calls[0][0]
-    expect(findManyCall).toHaveProperty("orderBy")
+    expect(findManyCall.where).toEqual({ col: "userId", val: "user_123" })
+    expect(findManyCall.orderBy).toEqual([
+      { col: "position", direction: "asc" },
+    ])
   })
 
   it("returns { success: false, error } on DB error", async () => {
@@ -237,13 +240,37 @@ describe("setQueue", () => {
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
 
-  it("calls db.transaction, with DELETE before INSERT", async () => {
+  it("rejects a queue containing duplicate episode IDs before touching the DB", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    const result = await setQueue([validEpisode, { ...validEpisode }])
+    expect(result.success).toBe(false)
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("rejects a queue with a non-https audioUrl before touching the DB", async () => {
+    const { setQueue } = await import("@/app/actions/listening-queue")
+    const jsUrl = {
+      ...validEpisode,
+      audioUrl: "javascript:alert(1)",
+    } as AudioEpisode
+    const result = await setQueue([jsUrl])
+    expect(result.success).toBe(false)
+    expect(mockTransaction).not.toHaveBeenCalled()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("calls db.transaction, with DELETE before INSERT scoped to the signed-in user", async () => {
     const { setQueue } = await import("@/app/actions/listening-queue")
     await setQueue([validEpisode, validEpisode2])
     expect(mockTransaction).toHaveBeenCalledTimes(1)
     const deleteOrder = mockDelete.mock.invocationCallOrder[0]
     const insertOrder = mockInsert.mock.invocationCallOrder[0]
     expect(deleteOrder).toBeLessThan(insertOrder)
+    expect(mockDeleteWhere).toHaveBeenCalledWith({
+      col: "userId",
+      val: "user_123",
+    })
   })
 
   it("inserts rows with position = 0, 1, 2 and explicit updatedAt Date", async () => {
@@ -263,6 +290,10 @@ describe("setQueue", () => {
     await setQueue([])
     expect(mockTransaction).toHaveBeenCalledTimes(1)
     expect(mockDelete).toHaveBeenCalledTimes(1)
+    expect(mockDeleteWhere).toHaveBeenCalledWith({
+      col: "userId",
+      val: "user_123",
+    })
     expect(mockInsert).not.toHaveBeenCalled()
   })
 
@@ -311,6 +342,10 @@ describe("clearQueue", () => {
     expect(result).toEqual({ success: true })
     expect(mockDelete).toHaveBeenCalledTimes(1)
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+    expect(mockDeleteWhere).toHaveBeenCalledWith({
+      col: "userId",
+      val: "user_123",
+    })
   })
 
   it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
+import {
+  createDrizzleOrmMock,
+  validEpisode,
+} from "@/app/actions/__tests__/__fixtures"
 
 // Mock Clerk auth
 const mockAuth = vi.fn()
@@ -68,19 +72,8 @@ vi.mock("@/db/schema", () => ({
   },
 }))
 
-// Mock drizzle-orm
-vi.mock("drizzle-orm", () => ({
-  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
-}))
-
-const validEpisode: AudioEpisode = {
-  id: "ep-1",
-  title: "Test Episode",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio.mp3",
-  artwork: "https://example.com/art.jpg",
-  duration: 600,
-}
+// Mock drizzle-orm (shared factory lives in __fixtures.ts)
+vi.mock("drizzle-orm", () => createDrizzleOrmMock())
 
 describe("getPlayerSession", () => {
   beforeEach(() => {

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -209,9 +209,12 @@ describe("savePlayerSession", () => {
     await savePlayerSession(validEpisode, 120)
     expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1)
     const opts = mockOnConflictDoUpdate.mock.calls[0][0]
-    expect(opts).toHaveProperty("target")
+    expect(opts.target).toBe("userId")
     expect(opts).toHaveProperty("set")
     expect(opts.set.updatedAt).toBeInstanceOf(Date)
+    // The conflict update set must NOT include the userId key — that's the
+    // conflict target and re-setting it is a semantic no-op that muddies intent.
+    expect(opts.set).not.toHaveProperty("userId")
   })
 
   it("persists currentTime as a decimal string", async () => {

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
   createDrizzleOrmMock,
+  makeDeleteChain,
+  makeInsertConflictChain,
   validEpisode,
 } from "@/app/actions/__tests__/__fixtures"
 
@@ -21,27 +23,12 @@ const mockFindFirst = vi.fn()
 
 vi.mock("@/db", () => ({
   db: {
-    insert: (...args: unknown[]) => {
-      mockInsert(...args)
-      return {
-        values: (...vArgs: unknown[]) => {
-          mockInsertValues(...vArgs)
-          return {
-            onConflictDoUpdate: (opts: unknown) => {
-              return mockOnConflictDoUpdate(opts)
-            },
-          }
-        },
-      }
-    },
-    delete: (...args: unknown[]) => {
-      mockDelete(...args)
-      return {
-        where: (...wArgs: unknown[]) => {
-          return mockDeleteWhere(...wArgs)
-        },
-      }
-    },
+    insert: makeInsertConflictChain(
+      mockInsert,
+      mockInsertValues,
+      mockOnConflictDoUpdate,
+    ),
+    delete: makeDeleteChain(mockDelete, mockDeleteWhere),
     query: {
       userPlayerSession: {
         findFirst: (...args: unknown[]) => mockFindFirst(...args),

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -2,16 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
   createDrizzleOrmMock,
+  happyPathSetup,
+  makeClerkAuthMock,
   makeDeleteChain,
   makeInsertConflictChain,
+  makeUserHelpersMock,
+  testDbError,
+  testUnauthenticated,
   validEpisode,
 } from "@/app/actions/__tests__/__fixtures"
 
 // Mock Clerk auth
 const mockAuth = vi.fn()
-vi.mock("@clerk/nextjs/server", () => ({
-  auth: () => mockAuth(),
-}))
+vi.mock("@clerk/nextjs/server", () =>
+  makeClerkAuthMock(() => mockAuth()),
+)
 
 // Mock database
 const mockInsert = vi.fn()
@@ -39,9 +44,9 @@ vi.mock("@/db", () => ({
 
 // Mock helpers
 const mockEnsureUserExists = vi.fn()
-vi.mock("@/db/helpers", () => ({
-  ensureUserExists: (...args: unknown[]) => mockEnsureUserExists(...args),
-}))
+vi.mock("@/db/helpers", () =>
+  makeUserHelpersMock((...args: unknown[]) => mockEnsureUserExists(...args)),
+)
 
 // Mock schema
 vi.mock("@/db/schema", () => ({
@@ -62,37 +67,35 @@ vi.mock("@/db/schema", () => ({
 // Mock drizzle-orm (shared factory lives in __fixtures.ts)
 vi.mock("drizzle-orm", () => createDrizzleOrmMock())
 
+const importAction = async () => import("@/app/actions/player-session")
+
 describe("getPlayerSession", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
     mockFindFirst.mockResolvedValue(null)
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockOnConflictDoUpdate.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { getPlayerSession } = await import("@/app/actions/player-session")
-    const result = await getPlayerSession()
-    expect(result.success).toBe(false)
-    expect(mockFindFirst).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).getPlayerSession(),
+      mockFindFirst,
+    ),
+  )
 
   it("returns { success: true, data: null } when no row exists", async () => {
     mockFindFirst.mockResolvedValue(null)
-    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const { getPlayerSession } = await importAction()
     const result = await getPlayerSession()
     expect(result).toEqual({ success: true, data: null })
   })
 
   it("does not call ensureUserExists (read-only path)", async () => {
-    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const { getPlayerSession } = await importAction()
     await getPlayerSession()
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
@@ -111,7 +114,7 @@ describe("getPlayerSession", () => {
       updatedAt: new Date(),
     }
     mockFindFirst.mockResolvedValue(dbRow)
-    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const { getPlayerSession } = await importAction()
     const result = await getPlayerSession()
     expect(result.success).toBe(true)
     if (!result.success) throw new Error("should be success")
@@ -127,39 +130,34 @@ describe("getPlayerSession", () => {
     })
   })
 
-  it("returns { success: false, error } on DB error", async () => {
-    mockFindFirst.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { getPlayerSession } = await import("@/app/actions/player-session")
-    const result = await getPlayerSession()
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error",
+    testDbError(
+      mockFindFirst,
+      async () => (await importAction()).getPlayerSession(),
+    ),
+  )
 })
 
 describe("savePlayerSession", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockOnConflictDoUpdate.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { savePlayerSession } = await import("@/app/actions/player-session")
-    const result = await savePlayerSession(validEpisode, 120)
-    expect(result.success).toBe(false)
-    expect(mockInsert).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).savePlayerSession(validEpisode, 120),
+      mockInsert,
+    ),
+  )
 
   it("Zod-rejects an invalid payload without touching the DB", async () => {
-    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const { savePlayerSession } = await importAction()
     const badEpisode = { id: "ep-1", title: "T", podcastTitle: "P", audioUrl: "not-a-url" }
     const result = await savePlayerSession(badEpisode as AudioEpisode, 120)
     expect(result.success).toBe(false)
@@ -168,7 +166,7 @@ describe("savePlayerSession", () => {
   })
 
   it("Zod-rejects currentTime above the upper bound without touching the DB", async () => {
-    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const { savePlayerSession } = await importAction()
     const result = await savePlayerSession(validEpisode, 1_000_001)
     expect(result.success).toBe(false)
     expect(mockInsert).not.toHaveBeenCalled()
@@ -176,7 +174,7 @@ describe("savePlayerSession", () => {
   })
 
   it("calls ensureUserExists before the insert", async () => {
-    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const { savePlayerSession } = await importAction()
     await savePlayerSession(validEpisode, 120)
     expect(mockEnsureUserExists).toHaveBeenCalledWith("user_123")
     const ensureOrder = mockEnsureUserExists.mock.invocationCallOrder[0]
@@ -185,7 +183,7 @@ describe("savePlayerSession", () => {
   })
 
   it("uses onConflictDoUpdate targeting userPlayerSession.userId with updatedAt Date in set", async () => {
-    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const { savePlayerSession } = await importAction()
     await savePlayerSession(validEpisode, 120)
     expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1)
     const opts = mockOnConflictDoUpdate.mock.calls[0][0]
@@ -198,7 +196,7 @@ describe("savePlayerSession", () => {
   })
 
   it("persists currentTime as a decimal string", async () => {
-    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const { savePlayerSession } = await importAction()
     await savePlayerSession(validEpisode, 123.456)
     expect(mockInsertValues).toHaveBeenCalledTimes(1)
     const insertedValues = mockInsertValues.mock.calls[0][0]
@@ -206,38 +204,33 @@ describe("savePlayerSession", () => {
     expect(insertedValues.currentTime).toMatch(/^\d+(\.\d+)?$/)
   })
 
-  it("returns { success: false, error } on DB error", async () => {
-    mockOnConflictDoUpdate.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { savePlayerSession } = await import("@/app/actions/player-session")
-    const result = await savePlayerSession(validEpisode, 120)
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error",
+    testDbError(
+      mockOnConflictDoUpdate,
+      async () => (await importAction()).savePlayerSession(validEpisode, 120),
+    ),
+  )
 })
 
 describe("clearPlayerSession", () => {
+  beforeEach(happyPathSetup(mockAuth, mockEnsureUserExists))
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockAuth.mockResolvedValue({ userId: "user_123" })
-    mockEnsureUserExists.mockResolvedValue(undefined)
     mockDeleteWhere.mockResolvedValue(undefined)
   })
+  afterEach(() => vi.restoreAllMocks())
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it("returns { success: false, error } when unauthenticated", async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-    const { clearPlayerSession } = await import("@/app/actions/player-session")
-    const result = await clearPlayerSession()
-    expect(result.success).toBe(false)
-    expect(mockDelete).not.toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } when unauthenticated",
+    testUnauthenticated(
+      mockAuth,
+      async () => (await importAction()).clearPlayerSession(),
+      mockDelete,
+    ),
+  )
 
   it("issues DELETE WHERE userId = $user on success", async () => {
-    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    const { clearPlayerSession } = await importAction()
     const result = await clearPlayerSession()
     expect(result).toEqual({ success: true })
     expect(mockDelete).toHaveBeenCalledTimes(1)
@@ -245,17 +238,16 @@ describe("clearPlayerSession", () => {
   })
 
   it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {
-    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    const { clearPlayerSession } = await importAction()
     await clearPlayerSession()
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
 
-  it("returns { success: false, error } on DB error", async () => {
-    mockDeleteWhere.mockRejectedValue(new Error("DB failure"))
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    const { clearPlayerSession } = await import("@/app/actions/player-session")
-    const result = await clearPlayerSession()
-    expect(result.success).toBe(false)
-    expect(consoleSpy).toHaveBeenCalled()
-  })
+  it(
+    "returns { success: false, error } on DB error",
+    testDbError(
+      mockDeleteWhere,
+      async () => (await importAction()).clearPlayerSession(),
+    ),
+  )
 })

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -187,6 +187,14 @@ describe("savePlayerSession", () => {
     expect(mockEnsureUserExists).not.toHaveBeenCalled()
   })
 
+  it("Zod-rejects currentTime above the upper bound without touching the DB", async () => {
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const result = await savePlayerSession(validEpisode, 1_000_001)
+    expect(result.success).toBe(false)
+    expect(mockInsert).not.toHaveBeenCalled()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
   it("calls ensureUserExists before the insert", async () => {
     const { savePlayerSession } = await import("@/app/actions/player-session")
     await savePlayerSession(validEpisode, 120)

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+// Mock Clerk auth
+const mockAuth = vi.fn()
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+}))
+
+// Mock database
+const mockInsert = vi.fn()
+const mockInsertValues = vi.fn()
+const mockOnConflictDoUpdate = vi.fn()
+const mockDelete = vi.fn()
+const mockDeleteWhere = vi.fn()
+const mockFindFirst = vi.fn()
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: (...args: unknown[]) => {
+      mockInsert(...args)
+      return {
+        values: (...vArgs: unknown[]) => {
+          mockInsertValues(...vArgs)
+          return {
+            onConflictDoUpdate: (opts: unknown) => {
+              return mockOnConflictDoUpdate(opts)
+            },
+          }
+        },
+      }
+    },
+    delete: (...args: unknown[]) => {
+      mockDelete(...args)
+      return {
+        where: (...wArgs: unknown[]) => {
+          return mockDeleteWhere(...wArgs)
+        },
+      }
+    },
+    query: {
+      userPlayerSession: {
+        findFirst: (...args: unknown[]) => mockFindFirst(...args),
+      },
+    },
+  },
+}))
+
+// Mock helpers
+const mockEnsureUserExists = vi.fn()
+vi.mock("@/db/helpers", () => ({
+  ensureUserExists: (...args: unknown[]) => mockEnsureUserExists(...args),
+}))
+
+// Mock schema
+vi.mock("@/db/schema", () => ({
+  userPlayerSession: {
+    userId: "userId",
+    episodeId: "episodeId",
+    title: "title",
+    podcastTitle: "podcastTitle",
+    audioUrl: "audioUrl",
+    artwork: "artwork",
+    duration: "duration",
+    chaptersUrl: "chaptersUrl",
+    currentTime: "currentTime",
+    updatedAt: "updatedAt",
+  },
+}))
+
+// Mock drizzle-orm
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+}))
+
+const validEpisode: AudioEpisode = {
+  id: "ep-1",
+  title: "Test Episode",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 600,
+}
+
+describe("getPlayerSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockFindFirst.mockResolvedValue(null)
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockOnConflictDoUpdate.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const result = await getPlayerSession()
+    expect(result.success).toBe(false)
+    expect(mockFindFirst).not.toHaveBeenCalled()
+  })
+
+  it("returns { success: true, data: null } when no row exists", async () => {
+    mockFindFirst.mockResolvedValue(null)
+    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const result = await getPlayerSession()
+    expect(result).toEqual({ success: true, data: null })
+  })
+
+  it("does not call ensureUserExists (read-only path)", async () => {
+    const { getPlayerSession } = await import("@/app/actions/player-session")
+    await getPlayerSession()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("returns episode reassembled from denormalized columns with currentTime as number", async () => {
+    const dbRow = {
+      userId: "user_123",
+      episodeId: "ep-1",
+      title: "Test Episode",
+      podcastTitle: "Test Podcast",
+      audioUrl: "https://example.com/audio.mp3",
+      artwork: "https://example.com/art.jpg",
+      duration: 600,
+      chaptersUrl: null,
+      currentTime: "123.456",
+      updatedAt: new Date(),
+    }
+    mockFindFirst.mockResolvedValue(dbRow)
+    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const result = await getPlayerSession()
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error("should be success")
+    expect(result.data).not.toBeNull()
+    expect(result.data!.currentTime).toBe(123.456)
+    expect(result.data!.episode).toEqual({
+      id: "ep-1",
+      title: "Test Episode",
+      podcastTitle: "Test Podcast",
+      audioUrl: "https://example.com/audio.mp3",
+      artwork: "https://example.com/art.jpg",
+      duration: 600,
+    })
+  })
+
+  it("returns { success: false, error } on DB error", async () => {
+    mockFindFirst.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { getPlayerSession } = await import("@/app/actions/player-session")
+    const result = await getPlayerSession()
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe("savePlayerSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockOnConflictDoUpdate.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const result = await savePlayerSession(validEpisode, 120)
+    expect(result.success).toBe(false)
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it("Zod-rejects an invalid payload without touching the DB", async () => {
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const badEpisode = { id: "ep-1", title: "T", podcastTitle: "P", audioUrl: "not-a-url" }
+    const result = await savePlayerSession(badEpisode as AudioEpisode, 120)
+    expect(result.success).toBe(false)
+    expect(mockInsert).not.toHaveBeenCalled()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("calls ensureUserExists before the insert", async () => {
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    await savePlayerSession(validEpisode, 120)
+    expect(mockEnsureUserExists).toHaveBeenCalledWith("user_123")
+    const ensureOrder = mockEnsureUserExists.mock.invocationCallOrder[0]
+    const insertOrder = mockInsert.mock.invocationCallOrder[0]
+    expect(ensureOrder).toBeLessThan(insertOrder)
+  })
+
+  it("uses onConflictDoUpdate targeting userPlayerSession.userId with updatedAt Date in set", async () => {
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    await savePlayerSession(validEpisode, 120)
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1)
+    const opts = mockOnConflictDoUpdate.mock.calls[0][0]
+    expect(opts).toHaveProperty("target")
+    expect(opts).toHaveProperty("set")
+    expect(opts.set.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it("persists currentTime as a decimal string", async () => {
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    await savePlayerSession(validEpisode, 123.456)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertedValues = mockInsertValues.mock.calls[0][0]
+    expect(typeof insertedValues.currentTime).toBe("string")
+    expect(insertedValues.currentTime).toMatch(/^\d+(\.\d+)?$/)
+  })
+
+  it("returns { success: false, error } on DB error", async () => {
+    mockOnConflictDoUpdate.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { savePlayerSession } = await import("@/app/actions/player-session")
+    const result = await savePlayerSession(validEpisode, 120)
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe("clearPlayerSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue({ userId: "user_123" })
+    mockEnsureUserExists.mockResolvedValue(undefined)
+    mockDeleteWhere.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns { success: false, error } when unauthenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    const result = await clearPlayerSession()
+    expect(result.success).toBe(false)
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it("issues DELETE WHERE userId = $user on success", async () => {
+    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    const result = await clearPlayerSession()
+    expect(result).toEqual({ success: true })
+    expect(mockDelete).toHaveBeenCalledTimes(1)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {
+    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    await clearPlayerSession()
+    expect(mockEnsureUserExists).not.toHaveBeenCalled()
+  })
+
+  it("returns { success: false, error } on DB error", async () => {
+    mockDeleteWhere.mockRejectedValue(new Error("DB failure"))
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { clearPlayerSession } = await import("@/app/actions/player-session")
+    const result = await clearPlayerSession()
+    expect(result.success).toBe(false)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/__tests__/player-session.test.ts
+++ b/src/app/actions/__tests__/player-session.test.ts
@@ -92,6 +92,11 @@ describe("getPlayerSession", () => {
     const { getPlayerSession } = await importAction()
     const result = await getPlayerSession()
     expect(result).toEqual({ success: true, data: null })
+    // Scope regression guard: findFirst must filter by the signed-in userId.
+    // `eq` is mocked to return `{ col, val }` so we can assert the predicate.
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { col: "userId", val: "user_123" },
+    })
   })
 
   it("does not call ensureUserExists (read-only path)", async () => {
@@ -235,6 +240,11 @@ describe("clearPlayerSession", () => {
     expect(result).toEqual({ success: true })
     expect(mockDelete).toHaveBeenCalledTimes(1)
     expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+    // Scope regression guard: the DELETE must filter by the signed-in userId.
+    expect(mockDeleteWhere).toHaveBeenCalledWith({
+      col: "userId",
+      val: "user_123",
+    })
   })
 
   it("does not call ensureUserExists (DELETE is no-op on nonexistent user)", async () => {

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -5,8 +5,10 @@ import { eq, asc } from "drizzle-orm"
 import { db } from "@/db"
 import { ensureUserExists } from "@/db/helpers"
 import { userQueueItems } from "@/db/schema"
-import { queueSchema } from "@/lib/schemas/listening-queue"
-import type { AudioEpisode } from "@/contexts/audio-player-context"
+import {
+  queueSchema,
+  type AudioEpisode,
+} from "@/lib/schemas/listening-queue"
 
 export async function getQueue(): Promise<
   { success: true; data: AudioEpisode[] } | { success: false; error: string }
@@ -48,7 +50,8 @@ export async function setQueue(
 
   const parsed = queueSchema.safeParse(episodes)
   if (!parsed.success) {
-    return { success: false, error: parsed.error.message }
+    console.warn("[setQueue] validation failed", parsed.error.issues)
+    return { success: false, error: "Invalid queue data" }
   }
 
   try {

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -8,6 +8,7 @@ import { userQueueItems } from "@/db/schema"
 import {
   queueSchema,
   toAudioEpisode,
+  toEpisodeDenormRow,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -65,13 +66,7 @@ export async function setQueue(
         const rows = parsed.data.map((ep, index) => ({
           userId,
           position: index,
-          episodeId: ep.id,
-          title: ep.title,
-          podcastTitle: ep.podcastTitle,
-          audioUrl: ep.audioUrl,
-          artwork: ep.artwork ?? null,
-          duration: ep.duration ?? null,
-          chaptersUrl: ep.chaptersUrl ?? null,
+          ...toEpisodeDenormRow(ep),
           updatedAt: new Date(),
         }))
         await tx.insert(userQueueItems).values(rows)

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -7,6 +7,7 @@ import { ensureUserExists } from "@/db/helpers"
 import { userQueueItems } from "@/db/schema"
 import {
   queueSchema,
+  toAudioEpisode,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -22,18 +23,7 @@ export async function getQueue(): Promise<
       orderBy: [asc(userQueueItems.position)],
     })
 
-    const data: AudioEpisode[] = rows.map((row) => {
-      const episode: AudioEpisode = {
-        id: row.episodeId,
-        title: row.title,
-        podcastTitle: row.podcastTitle,
-        audioUrl: row.audioUrl,
-      }
-      if (row.artwork != null) episode.artwork = row.artwork
-      if (row.duration != null) episode.duration = row.duration
-      if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl
-      return episode
-    })
+    const data: AudioEpisode[] = rows.map(toAudioEpisode)
 
     return { success: true, data }
   } catch (e) {

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -1,10 +1,10 @@
 "use server"
 
-import { auth } from "@clerk/nextjs/server"
 import { eq, asc } from "drizzle-orm"
 import { db } from "@/db"
 import { ensureUserExists } from "@/db/helpers"
 import { userQueueItems } from "@/db/schema"
+import { withAuthAction } from "@/lib/auth-wrapper"
 import {
   queueSchema,
   toAudioEpisode,
@@ -15,22 +15,19 @@ import {
 export async function getQueue(): Promise<
   { success: true; data: AudioEpisode[] } | { success: false; error: string }
 > {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
-
-  try {
-    const rows = await db.query.userQueueItems.findMany({
-      where: eq(userQueueItems.userId, userId),
-      orderBy: [asc(userQueueItems.position)],
-    })
-
-    const data: AudioEpisode[] = rows.map(toAudioEpisode)
-
-    return { success: true, data }
-  } catch (e) {
-    console.error("Failed to get queue:", e)
-    return { success: false, error: "Failed to get queue" }
-  }
+  return withAuthAction(async (userId) => {
+    try {
+      const rows = await db.query.userQueueItems.findMany({
+        where: eq(userQueueItems.userId, userId),
+        orderBy: [asc(userQueueItems.position)],
+      })
+      const data: AudioEpisode[] = rows.map(toAudioEpisode)
+      return { success: true as const, data }
+    } catch (e) {
+      console.error("Failed to get queue:", e)
+      return { success: false as const, error: "Failed to get queue" }
+    }
+  })
 }
 
 /**
@@ -47,50 +44,48 @@ export async function getQueue(): Promise<
 export async function setQueue(
   episodes: AudioEpisode[]
 ): Promise<{ success: true } | { success: false; error: string }> {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
+  return withAuthAction(async (userId) => {
+    const parsed = queueSchema.safeParse(episodes)
+    if (!parsed.success) {
+      console.warn("[setQueue] validation failed", parsed.error.issues)
+      return { success: false as const, error: "Invalid queue data" }
+    }
 
-  const parsed = queueSchema.safeParse(episodes)
-  if (!parsed.success) {
-    console.warn("[setQueue] validation failed", parsed.error.issues)
-    return { success: false, error: "Invalid queue data" }
-  }
+    try {
+      await ensureUserExists(userId)
 
-  try {
-    await ensureUserExists(userId)
+      await db.transaction(async (tx) => {
+        await tx.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
 
-    await db.transaction(async (tx) => {
-      await tx.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
+        if (parsed.data.length > 0) {
+          const rows = parsed.data.map((ep, index) => ({
+            userId,
+            position: index,
+            ...toEpisodeDenormRow(ep),
+            updatedAt: new Date(),
+          }))
+          await tx.insert(userQueueItems).values(rows)
+        }
+      })
 
-      if (parsed.data.length > 0) {
-        const rows = parsed.data.map((ep, index) => ({
-          userId,
-          position: index,
-          ...toEpisodeDenormRow(ep),
-          updatedAt: new Date(),
-        }))
-        await tx.insert(userQueueItems).values(rows)
-      }
-    })
-
-    return { success: true }
-  } catch (e) {
-    console.error("Failed to set queue:", e)
-    return { success: false, error: "Failed to set queue" }
-  }
+      return { success: true as const }
+    } catch (e) {
+      console.error("Failed to set queue:", e)
+      return { success: false as const, error: "Failed to set queue" }
+    }
+  })
 }
 
 export async function clearQueue(): Promise<
   { success: true } | { success: false; error: string }
 > {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
-
-  try {
-    await db.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
-    return { success: true }
-  } catch (e) {
-    console.error("Failed to clear queue:", e)
-    return { success: false, error: "Failed to clear queue" }
-  }
+  return withAuthAction(async (userId) => {
+    try {
+      await db.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
+      return { success: true as const }
+    } catch (e) {
+      console.error("Failed to clear queue:", e)
+      return { success: false as const, error: "Failed to clear queue" }
+    }
+  })
 }

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -42,6 +42,17 @@ export async function getQueue(): Promise<
   }
 }
 
+/**
+ * Replaces the entire queue for the authenticated user with the provided
+ * array. There is no `addToQueue` / `removeFromQueue` partial-update action
+ * by design: atomic replace-all eliminates ordering races between concurrent
+ * optimistic mutations. Positions are derived from array index. Passing an
+ * empty array is equivalent to `clearQueue`.
+ *
+ * Conflict strategy is last-commit-wins. No version token, no merge — per
+ * ADR-036. Two devices mutating concurrently will resolve to whichever
+ * commit arrives last on the database.
+ */
 export async function setQueue(
   episodes: AudioEpisode[]
 ): Promise<{ success: true } | { success: false; error: string }> {

--- a/src/app/actions/listening-queue.ts
+++ b/src/app/actions/listening-queue.ts
@@ -1,0 +1,97 @@
+"use server"
+
+import { auth } from "@clerk/nextjs/server"
+import { eq, asc } from "drizzle-orm"
+import { db } from "@/db"
+import { ensureUserExists } from "@/db/helpers"
+import { userQueueItems } from "@/db/schema"
+import { queueSchema } from "@/lib/schemas/listening-queue"
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+export async function getQueue(): Promise<
+  { success: true; data: AudioEpisode[] } | { success: false; error: string }
+> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  try {
+    const rows = await db.query.userQueueItems.findMany({
+      where: eq(userQueueItems.userId, userId),
+      orderBy: [asc(userQueueItems.position)],
+    })
+
+    const data: AudioEpisode[] = rows.map((row) => {
+      const episode: AudioEpisode = {
+        id: row.episodeId,
+        title: row.title,
+        podcastTitle: row.podcastTitle,
+        audioUrl: row.audioUrl,
+      }
+      if (row.artwork != null) episode.artwork = row.artwork
+      if (row.duration != null) episode.duration = row.duration
+      if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl
+      return episode
+    })
+
+    return { success: true, data }
+  } catch (e) {
+    console.error("Failed to get queue:", e)
+    return { success: false, error: "Failed to get queue" }
+  }
+}
+
+export async function setQueue(
+  episodes: AudioEpisode[]
+): Promise<{ success: true } | { success: false; error: string }> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  const parsed = queueSchema.safeParse(episodes)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.message }
+  }
+
+  try {
+    await ensureUserExists(userId)
+
+    await db.transaction(async (tx) => {
+      await tx.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
+
+      if (parsed.data.length > 0) {
+        const rows = parsed.data.map((ep, index) => ({
+          userId,
+          position: index,
+          episodeId: ep.id,
+          title: ep.title,
+          podcastTitle: ep.podcastTitle,
+          audioUrl: ep.audioUrl,
+          artwork: ep.artwork ?? null,
+          duration: ep.duration ?? null,
+          chaptersUrl: ep.chaptersUrl ?? null,
+          updatedAt: new Date(),
+        }))
+        await tx.insert(userQueueItems).values(rows)
+      }
+    })
+
+    return { success: true }
+  } catch (e) {
+    console.error("Failed to set queue:", e)
+    return { success: false, error: "Failed to set queue" }
+  }
+}
+
+export async function clearQueue(): Promise<
+  { success: true } | { success: false; error: string }
+> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  try {
+    await db.delete(userQueueItems).where(eq(userQueueItems.userId, userId))
+    return { success: true }
+  } catch (e) {
+    console.error("Failed to clear queue:", e)
+    return { success: false, error: "Failed to clear queue" }
+  }
+}

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -66,8 +66,7 @@ export async function savePlayerSession(
   try {
     await ensureUserExists(userId)
 
-    const sessionValues = {
-      userId,
+    const updateValues = {
       episodeId: validEpisode.id,
       title: validEpisode.title,
       podcastTitle: validEpisode.podcastTitle,
@@ -81,10 +80,10 @@ export async function savePlayerSession(
 
     await db
       .insert(userPlayerSession)
-      .values(sessionValues)
+      .values({ userId, ...updateValues })
       .onConflictDoUpdate({
         target: userPlayerSession.userId,
-        set: sessionValues,
+        set: updateValues,
       })
 
     return { success: true }

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -44,6 +44,16 @@ export async function getPlayerSession(): Promise<
   }
 }
 
+/**
+ * Upserts the per-user resume-position row. Client is expected to throttle
+ * calls (~5s) so we are not hammering Neon on every `timeupdate` tick.
+ *
+ * Conflict strategy is last-write-wins on the row — per ADR-036. Two devices
+ * writing concurrently resolve to whichever `savePlayerSession` commits last.
+ * The context's `never-rewind-active-playback` guard prevents the losing
+ * write's stale `currentTime` from ever being applied on the still-playing
+ * device.
+ */
 export async function savePlayerSession(
   episode: AudioEpisode,
   currentTime: number

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -1,0 +1,113 @@
+"use server"
+
+import { auth } from "@clerk/nextjs/server"
+import { eq } from "drizzle-orm"
+import { db } from "@/db"
+import { ensureUserExists } from "@/db/helpers"
+import { userPlayerSession } from "@/db/schema"
+import { savePlayerSessionSchema } from "@/lib/schemas/listening-queue"
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+export async function getPlayerSession(): Promise<
+  | { success: true; data: { episode: AudioEpisode; currentTime: number } | null }
+  | { success: false; error: string }
+> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  try {
+    const row = await db.query.userPlayerSession.findFirst({
+      where: eq(userPlayerSession.userId, userId),
+    })
+
+    if (!row) return { success: true, data: null }
+
+    const episode: AudioEpisode = {
+      id: row.episodeId,
+      title: row.title,
+      podcastTitle: row.podcastTitle,
+      audioUrl: row.audioUrl,
+    }
+    if (row.artwork != null) episode.artwork = row.artwork
+    if (row.duration != null) episode.duration = row.duration
+    if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl
+
+    return {
+      success: true,
+      data: { episode, currentTime: Number(row.currentTime) },
+    }
+  } catch (e) {
+    console.error("Failed to get player session:", e)
+    return { success: false, error: "Failed to get player session" }
+  }
+}
+
+export async function savePlayerSession(
+  episode: AudioEpisode,
+  currentTime: number
+): Promise<{ success: true } | { success: false; error: string }> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  const parsed = savePlayerSessionSchema.safeParse({ episode, currentTime })
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.message }
+  }
+
+  const { episode: validEpisode, currentTime: validCurrentTime } = parsed.data
+
+  try {
+    await ensureUserExists(userId)
+
+    await db
+      .insert(userPlayerSession)
+      .values({
+        userId,
+        episodeId: validEpisode.id,
+        title: validEpisode.title,
+        podcastTitle: validEpisode.podcastTitle,
+        audioUrl: validEpisode.audioUrl,
+        artwork: validEpisode.artwork ?? null,
+        duration: validEpisode.duration ?? null,
+        chaptersUrl: validEpisode.chaptersUrl ?? null,
+        currentTime: String(validCurrentTime),
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: userPlayerSession.userId,
+        set: {
+          episodeId: validEpisode.id,
+          title: validEpisode.title,
+          podcastTitle: validEpisode.podcastTitle,
+          audioUrl: validEpisode.audioUrl,
+          artwork: validEpisode.artwork ?? null,
+          duration: validEpisode.duration ?? null,
+          chaptersUrl: validEpisode.chaptersUrl ?? null,
+          currentTime: String(validCurrentTime),
+          updatedAt: new Date(),
+        },
+      })
+
+    return { success: true }
+  } catch (e) {
+    console.error("Failed to save player session:", e)
+    return { success: false, error: "Failed to save player session" }
+  }
+}
+
+export async function clearPlayerSession(): Promise<
+  { success: true } | { success: false; error: string }
+> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+
+  try {
+    await db
+      .delete(userPlayerSession)
+      .where(eq(userPlayerSession.userId, userId))
+    return { success: true }
+  } catch (e) {
+    console.error("Failed to clear player session:", e)
+    return { success: false, error: "Failed to clear player session" }
+  }
+}

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -8,6 +8,7 @@ import { userPlayerSession } from "@/db/schema"
 import {
   savePlayerSessionSchema,
   toAudioEpisode,
+  toEpisodeDenormRow,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -67,13 +68,7 @@ export async function savePlayerSession(
     await ensureUserExists(userId)
 
     const updateValues = {
-      episodeId: validEpisode.id,
-      title: validEpisode.title,
-      podcastTitle: validEpisode.podcastTitle,
-      audioUrl: validEpisode.audioUrl,
-      artwork: validEpisode.artwork ?? null,
-      duration: validEpisode.duration ?? null,
-      chaptersUrl: validEpisode.chaptersUrl ?? null,
+      ...toEpisodeDenormRow(validEpisode),
       currentTime: String(validCurrentTime),
       updatedAt: new Date(),
     }

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -1,10 +1,10 @@
 "use server"
 
-import { auth } from "@clerk/nextjs/server"
 import { eq } from "drizzle-orm"
 import { db } from "@/db"
 import { ensureUserExists } from "@/db/helpers"
 import { userPlayerSession } from "@/db/schema"
+import { withAuthAction } from "@/lib/auth-wrapper"
 import {
   savePlayerSessionSchema,
   toAudioEpisode,
@@ -16,27 +16,26 @@ export async function getPlayerSession(): Promise<
   | { success: true; data: { episode: AudioEpisode; currentTime: number } | null }
   | { success: false; error: string }
 > {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
+  return withAuthAction(async (userId) => {
+    try {
+      const row = await db.query.userPlayerSession.findFirst({
+        where: eq(userPlayerSession.userId, userId),
+      })
 
-  try {
-    const row = await db.query.userPlayerSession.findFirst({
-      where: eq(userPlayerSession.userId, userId),
-    })
+      if (!row) return { success: true as const, data: null }
 
-    if (!row) return { success: true, data: null }
-
-    return {
-      success: true,
-      data: {
-        episode: toAudioEpisode(row),
-        currentTime: Number(row.currentTime),
-      },
+      return {
+        success: true as const,
+        data: {
+          episode: toAudioEpisode(row),
+          currentTime: Number(row.currentTime),
+        },
+      }
+    } catch (e) {
+      console.error("Failed to get player session:", e)
+      return { success: false as const, error: "Failed to get player session" }
     }
-  } catch (e) {
-    console.error("Failed to get player session:", e)
-    return { success: false, error: "Failed to get player session" }
-  }
+  })
 }
 
 /**
@@ -53,54 +52,52 @@ export async function savePlayerSession(
   episode: AudioEpisode,
   currentTime: number
 ): Promise<{ success: true } | { success: false; error: string }> {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
-
-  const parsed = savePlayerSessionSchema.safeParse({ episode, currentTime })
-  if (!parsed.success) {
-    console.warn("[savePlayerSession] validation failed", parsed.error.issues)
-    return { success: false, error: "Invalid session data" }
-  }
-
-  const { episode: validEpisode, currentTime: validCurrentTime } = parsed.data
-
-  try {
-    await ensureUserExists(userId)
-
-    const updateValues = {
-      ...toEpisodeDenormRow(validEpisode),
-      currentTime: String(validCurrentTime),
-      updatedAt: new Date(),
+  return withAuthAction(async (userId) => {
+    const parsed = savePlayerSessionSchema.safeParse({ episode, currentTime })
+    if (!parsed.success) {
+      console.warn("[savePlayerSession] validation failed", parsed.error.issues)
+      return { success: false as const, error: "Invalid session data" }
     }
 
-    await db
-      .insert(userPlayerSession)
-      .values({ userId, ...updateValues })
-      .onConflictDoUpdate({
-        target: userPlayerSession.userId,
-        set: updateValues,
-      })
+    const { episode: validEpisode, currentTime: validCurrentTime } = parsed.data
 
-    return { success: true }
-  } catch (e) {
-    console.error("Failed to save player session:", e)
-    return { success: false, error: "Failed to save player session" }
-  }
+    try {
+      await ensureUserExists(userId)
+
+      const updateValues = {
+        ...toEpisodeDenormRow(validEpisode),
+        currentTime: String(validCurrentTime),
+        updatedAt: new Date(),
+      }
+
+      await db
+        .insert(userPlayerSession)
+        .values({ userId, ...updateValues })
+        .onConflictDoUpdate({
+          target: userPlayerSession.userId,
+          set: updateValues,
+        })
+
+      return { success: true as const }
+    } catch (e) {
+      console.error("Failed to save player session:", e)
+      return { success: false as const, error: "Failed to save player session" }
+    }
+  })
 }
 
 export async function clearPlayerSession(): Promise<
   { success: true } | { success: false; error: string }
 > {
-  const { userId } = await auth()
-  if (!userId) return { success: false, error: "Unauthorized" }
-
-  try {
-    await db
-      .delete(userPlayerSession)
-      .where(eq(userPlayerSession.userId, userId))
-    return { success: true }
-  } catch (e) {
-    console.error("Failed to clear player session:", e)
-    return { success: false, error: "Failed to clear player session" }
-  }
+  return withAuthAction(async (userId) => {
+    try {
+      await db
+        .delete(userPlayerSession)
+        .where(eq(userPlayerSession.userId, userId))
+      return { success: true as const }
+    } catch (e) {
+      console.error("Failed to clear player session:", e)
+      return { success: false as const, error: "Failed to clear player session" }
+    }
+  })
 }

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -7,6 +7,7 @@ import { ensureUserExists } from "@/db/helpers"
 import { userPlayerSession } from "@/db/schema"
 import {
   savePlayerSessionSchema,
+  toAudioEpisode,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -24,19 +25,12 @@ export async function getPlayerSession(): Promise<
 
     if (!row) return { success: true, data: null }
 
-    const episode: AudioEpisode = {
-      id: row.episodeId,
-      title: row.title,
-      podcastTitle: row.podcastTitle,
-      audioUrl: row.audioUrl,
-    }
-    if (row.artwork != null) episode.artwork = row.artwork
-    if (row.duration != null) episode.duration = row.duration
-    if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl
-
     return {
       success: true,
-      data: { episode, currentTime: Number(row.currentTime) },
+      data: {
+        episode: toAudioEpisode(row),
+        currentTime: Number(row.currentTime),
+      },
     }
   } catch (e) {
     console.error("Failed to get player session:", e)
@@ -72,33 +66,25 @@ export async function savePlayerSession(
   try {
     await ensureUserExists(userId)
 
+    const sessionValues = {
+      userId,
+      episodeId: validEpisode.id,
+      title: validEpisode.title,
+      podcastTitle: validEpisode.podcastTitle,
+      audioUrl: validEpisode.audioUrl,
+      artwork: validEpisode.artwork ?? null,
+      duration: validEpisode.duration ?? null,
+      chaptersUrl: validEpisode.chaptersUrl ?? null,
+      currentTime: String(validCurrentTime),
+      updatedAt: new Date(),
+    }
+
     await db
       .insert(userPlayerSession)
-      .values({
-        userId,
-        episodeId: validEpisode.id,
-        title: validEpisode.title,
-        podcastTitle: validEpisode.podcastTitle,
-        audioUrl: validEpisode.audioUrl,
-        artwork: validEpisode.artwork ?? null,
-        duration: validEpisode.duration ?? null,
-        chaptersUrl: validEpisode.chaptersUrl ?? null,
-        currentTime: String(validCurrentTime),
-        updatedAt: new Date(),
-      })
+      .values(sessionValues)
       .onConflictDoUpdate({
         target: userPlayerSession.userId,
-        set: {
-          episodeId: validEpisode.id,
-          title: validEpisode.title,
-          podcastTitle: validEpisode.podcastTitle,
-          audioUrl: validEpisode.audioUrl,
-          artwork: validEpisode.artwork ?? null,
-          duration: validEpisode.duration ?? null,
-          chaptersUrl: validEpisode.chaptersUrl ?? null,
-          currentTime: String(validCurrentTime),
-          updatedAt: new Date(),
-        },
+        set: sessionValues,
       })
 
     return { success: true }

--- a/src/app/actions/player-session.ts
+++ b/src/app/actions/player-session.ts
@@ -5,8 +5,10 @@ import { eq } from "drizzle-orm"
 import { db } from "@/db"
 import { ensureUserExists } from "@/db/helpers"
 import { userPlayerSession } from "@/db/schema"
-import { savePlayerSessionSchema } from "@/lib/schemas/listening-queue"
-import type { AudioEpisode } from "@/contexts/audio-player-context"
+import {
+  savePlayerSessionSchema,
+  type AudioEpisode,
+} from "@/lib/schemas/listening-queue"
 
 export async function getPlayerSession(): Promise<
   | { success: true; data: { episode: AudioEpisode; currentTime: number } | null }
@@ -51,7 +53,8 @@ export async function savePlayerSession(
 
   const parsed = savePlayerSessionSchema.safeParse({ episode, currentTime })
   if (!parsed.success) {
-    return { success: false, error: parsed.error.message }
+    console.warn("[savePlayerSession] validation failed", parsed.error.issues)
+    return { success: false, error: "Invalid session data" }
   }
 
   const { episode: validEpisode, currentTime: validCurrentTime } = parsed.data

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -1349,6 +1349,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, act } from "@testing-library/react"
+import { render, screen, act, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import {
   AudioPlayerProvider,
@@ -1161,6 +1161,28 @@ describe("Chapter state management", () => {
 })
 
 // ---------------------------------------------------------------------------
+// Cross-device sync: server action mocks (T8)
+// ---------------------------------------------------------------------------
+
+const mockGetQueue = vi.fn().mockResolvedValue({ success: true, data: [] })
+const mockSetQueueAction = vi.fn().mockResolvedValue({ success: true })
+const mockClearQueueAction = vi.fn().mockResolvedValue({ success: true })
+vi.mock("@/app/actions/listening-queue", () => ({
+  getQueue: (...args: unknown[]) => mockGetQueue(...args),
+  setQueue: (...args: unknown[]) => mockSetQueueAction(...args),
+  clearQueue: (...args: unknown[]) => mockClearQueueAction(...args),
+}))
+
+const mockGetPlayerSession = vi.fn().mockResolvedValue({ success: true, data: null })
+const mockSavePlayerSessionAction = vi.fn().mockResolvedValue({ success: true })
+const mockClearPlayerSessionAction = vi.fn().mockResolvedValue({ success: true })
+vi.mock("@/app/actions/player-session", () => ({
+  getPlayerSession: (...args: unknown[]) => mockGetPlayerSession(...args),
+  savePlayerSession: (...args: unknown[]) => mockSavePlayerSessionAction(...args),
+  clearPlayerSession: (...args: unknown[]) => mockClearPlayerSessionAction(...args),
+}))
+
+// ---------------------------------------------------------------------------
 // Listen history recording (T3.1)
 // ---------------------------------------------------------------------------
 
@@ -1310,5 +1332,280 @@ describe("Listen history recording", () => {
     )
     const callArgs = mockRecordListenEvent.mock.calls[0][0]
     expect(callArgs.durationSeconds).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-device sync: hydration, reconcile, migration (T8)
+// ---------------------------------------------------------------------------
+
+describe("Cross-device sync: hydration and reconcile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    playMock.mockResolvedValue(undefined)
+    mockLoadPrefs.mockReturnValue({ volume: 0.8, playbackSpeed: 1.5 })
+    mockLoadQueue.mockReturnValue([])
+    mockLoadSession.mockReturnValue(null)
+    mockGetQueue.mockResolvedValue({ success: true, data: [] })
+    mockGetPlayerSession.mockResolvedValue({ success: true, data: null })
+    mockSetQueueAction.mockResolvedValue({ success: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("calls getQueue and getPlayerSession on mount (after loadQueue/loadPlayerSession)", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockGetQueue).toHaveBeenCalled()
+    expect(mockGetPlayerSession).toHaveBeenCalled()
+    // Server calls must happen after (or concurrent with) local cache reads
+    const loadQueueOrder = mockLoadQueue.mock.invocationCallOrder[0]
+    const getQueueOrder = mockGetQueue.mock.invocationCallOrder[0]
+    expect(loadQueueOrder).toBeLessThanOrEqual(getQueueOrder)
+  })
+
+  it("replaces queue with server state when server returns a non-empty queue different from local", async () => {
+    const serverQueue: AudioEpisode[] = [
+      { id: "server-1", title: "Server Ep 1", podcastTitle: "Podcast", audioUrl: "https://example.com/s1.mp3" },
+    ]
+    mockGetQueue.mockResolvedValue({ success: true, data: serverQueue })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("queueIds")).toHaveTextContent("server-1")
+    }, { timeout: 5000 })
+  })
+
+  it("calls setQueue(localQueue) exactly once when server is empty and local cache is non-empty (migration)", async () => {
+    const localQueue: AudioEpisode[] = [
+      { id: "local-1", title: "Local Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/l1.mp3" },
+    ]
+    mockLoadQueue.mockReturnValue(localQueue)
+    mockGetQueue.mockResolvedValue({ success: true, data: [] })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockSetQueueAction).toHaveBeenCalledTimes(1)
+    expect(mockSetQueueAction).toHaveBeenCalledWith(localQueue)
+  })
+
+  it("does not overwrite currentTime on focus when active episode matches server session", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const serverSession = {
+      episode: { ...mockEpisode },
+      currentTime: 999, // stale server time
+    }
+    mockGetPlayerSession.mockResolvedValue({ success: true, data: serverSession })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Play the episode
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    audio.currentTime = 300 // actively playing at 300s
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Simulate focus event to trigger reconcile
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"))
+      await vi.runAllTimersAsync()
+    })
+
+    vi.useRealTimers()
+    // Audio currentTime should NOT have been reset to 999 (server stale time)
+    expect(audio.currentTime).toBe(300)
+  })
+
+  it("does not dispatch INIT_QUEUE with server state when a local queue mutation is pending (debounce timer active)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const serverQueue: AudioEpisode[] = [
+      { id: "server-1", title: "Server Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/s1.mp3" },
+    ]
+    mockGetQueue.mockResolvedValue({ success: true, data: serverQueue })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Play episode first so queue state is active
+    await user.click(screen.getByText("Play Episode"))
+
+    // Add to queue to trigger local mutation (debounce timer starts)
+    await user.click(screen.getByText("Add Q1"))
+    // Queue now has q-1 pending write; don't advance timers so debounce is still active
+
+    // Fire focus event which should trigger getQueue
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"))
+      // Advance only the focus debounce (200ms), NOT the queue debounce (1500ms)
+      vi.advanceTimersByTime(200)
+      await Promise.resolve()
+    })
+
+    vi.useRealTimers()
+    // Queue should still be q-1 (local mutation), NOT replaced by server-1
+    expect(screen.getByTestId("queueIds")).toHaveTextContent("q-1")
+  })
+
+  it("migration race: in-flight setQueue suppresses concurrent focus INIT_QUEUE dispatch", async () => {
+    const localQueue: AudioEpisode[] = [
+      { id: "local-1", title: "Local Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/l1.mp3" },
+    ]
+    mockLoadQueue.mockReturnValue(localQueue)
+
+    // Server starts empty (triggers migration)
+    let resolveMigration!: (value: { success: true }) => void
+    const migrationPromise = new Promise<{ success: true }>((resolve) => {
+      resolveMigration = resolve
+    })
+    mockGetQueue
+      .mockResolvedValueOnce({ success: true, data: [] }) // mount: empty → triggers migration
+      .mockResolvedValueOnce({ success: true, data: [] }) // focus: still empty (migration not done)
+    mockSetQueueAction.mockReturnValueOnce(migrationPromise)
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Wait for mount fetch to resolve (triggers migration, but migration upload is pending)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Simulate focus event while migration upload is still in-flight
+    // The focus debounce is 200ms — wait for it to fire
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"))
+      await new Promise((r) => setTimeout(r, 300))
+    })
+
+    // Queue must still be the local snapshot (not wiped by server empty state)
+    expect(screen.getByTestId("queueIds")).toHaveTextContent("local-1")
+
+    // Resolve migration upload
+    await act(async () => {
+      resolveMigration({ success: true })
+      await new Promise((r) => setTimeout(r, 50))
+    })
+  })
+
+  it("dispatches INIT_QUEUE with lastAckedQueue and fires toast on setQueue server failure", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // Start with server returning an initial queue (lastAcked = this)
+    const initialServerQueue: AudioEpisode[] = [
+      { id: "acked-1", title: "Acked Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/a1.mp3" },
+    ]
+    mockGetQueue.mockResolvedValue({ success: true, data: initialServerQueue })
+    // Subsequent setQueue calls fail
+    mockSetQueueAction.mockResolvedValue({ success: false, error: "DB error" })
+
+    const { toast } = await import("sonner")
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Wait for mount reconcile (lastAckedQueue = initialServerQueue)
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Play episode first so we can add to queue
+    await user.click(screen.getByText("Play Episode"))
+
+    // Add an episode to trigger debounced setQueue
+    await user.click(screen.getByText("Add Q1"))
+
+    // Advance debounce timer to fire setQueue (which fails)
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await vi.runAllTimersAsync()
+    })
+
+    vi.useRealTimers()
+
+    // After failure, queue should be rolled back to lastAckedQueue
+    await waitFor(() => {
+      expect(screen.getByTestId("queueIds")).toHaveTextContent("acked-1")
+    }, { timeout: 2000 })
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it("savePlayerSession server action is called on the 5s throttle tick", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await user.click(screen.getByText("Play Episode"))
+
+    // Need to set isSessionRestored first by advancing timers for the session restore
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    const audio = getAudioElement()!
+    audio.currentTime = 60
+
+    // Fire timeupdate events to trigger the 5s throttle
+    act(() => fireAudioEvent("timeupdate"))
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+    act(() => fireAudioEvent("timeupdate"))
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    vi.useRealTimers()
+    expect(mockSavePlayerSessionAction).toHaveBeenCalled()
   })
 })

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -1672,4 +1672,163 @@ describe("Cross-device sync: hydration and reconcile", () => {
     vi.useRealTimers()
     expect(mockSavePlayerSessionAction).toHaveBeenCalled()
   })
+
+  it("does not write local queue back to server on cold boot when server has a different queue (local-wins regression)", async () => {
+    const localQueue: AudioEpisode[] = [
+      { id: "local-1", title: "Local Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/l1.mp3" },
+    ]
+    const serverQueue: AudioEpisode[] = [
+      { id: "server-1", title: "Server Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/s1.mp3" },
+    ]
+    mockLoadQueue.mockReturnValue(localQueue)
+    mockGetQueue.mockResolvedValue({ success: true, data: serverQueue })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Wait long enough for the debounce window (1500ms) to elapse — if the bug
+    // were present, setQueueAction would have fired with localQueue by now.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1700))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("queueIds")).toHaveTextContent("server-1")
+    }, { timeout: 5000 })
+
+    // setQueueAction must NOT have been called — no user mutation happened;
+    // the server provided an authoritative state and no write should go back.
+    expect(mockSetQueueAction).not.toHaveBeenCalled()
+  })
+
+  it("refetches on visibilitychange when document becomes visible", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+    mockGetQueue.mockClear()
+    mockGetPlayerSession.mockClear()
+
+    // Simulate a visibility change to "visible"
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+      await new Promise((r) => setTimeout(r, 300))
+    })
+
+    expect(mockGetQueue).toHaveBeenCalled()
+    expect(mockGetPlayerSession).toHaveBeenCalled()
+  })
+
+  it("calls clearPlayerSession server action when the user closes the player", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText("Play Episode"))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+    mockClearPlayerSessionAction.mockClear()
+
+    await user.click(screen.getByText("Close"))
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockClearPlayerSessionAction).toHaveBeenCalled()
+  })
+
+  it("calls savePlayerSession server action on beforeunload", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText("Play Episode"))
+
+    // Let session restoration flip isSessionRestored
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+      fireAudioEvent("durationchange")
+    })
+
+    const audio = getAudioElement()!
+    audio.currentTime = 42
+    mockSavePlayerSessionAction.mockClear()
+
+    await act(async () => {
+      window.dispatchEvent(new Event("beforeunload"))
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockSavePlayerSessionAction).toHaveBeenCalled()
+  })
+
+  it("calls savePlayerSession server action on pause (alongside the localStorage cache)", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText("Play Episode"))
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+      fireAudioEvent("durationchange")
+    })
+
+    const audio = getAudioElement()!
+    audio.currentTime = 77
+    mockSavePlayerSessionAction.mockClear()
+
+    await act(async () => {
+      fireAudioEvent("pause")
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockSavePlayerSessionAction).toHaveBeenCalled()
+  })
+
+  it("fires a toast when the migration upload fails", async () => {
+    const localQueue: AudioEpisode[] = [
+      { id: "local-1", title: "Local Ep", podcastTitle: "Podcast", audioUrl: "https://example.com/l1.mp3" },
+    ]
+    mockLoadQueue.mockReturnValue(localQueue)
+    mockGetQueue.mockResolvedValue({ success: true, data: [] })
+    mockSetQueueAction.mockResolvedValueOnce({ success: false, error: "DB error" })
+
+    const { toast } = await import("sonner")
+    ;(toast.error as ReturnType<typeof vi.fn>).mockClear?.()
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100))
+    })
+
+    expect(toast.error).toHaveBeenCalled()
+  })
 })

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -55,9 +55,6 @@ const playMock = vi.fn().mockResolvedValue(undefined)
 const pauseMock = vi.fn()
 const loadMock = vi.fn()
 
-// Track event listeners on audio elements
-const audioListeners: Record<string, EventListener[]> = {}
-
 function getAudioElement(): HTMLAudioElement | null {
   return document.querySelector("audio")
 }

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -1448,6 +1448,73 @@ describe("Cross-device sync: hydration and reconcile", () => {
     expect(audio.currentTime).toBe(300)
   })
 
+  it("applies server currentTime when same episode is paused (not active playback)", async () => {
+    const user = userEvent.setup()
+    const serverSession = {
+      episode: { ...mockEpisode },
+      currentTime: 250,
+    }
+    // Session is null on first call (no local cache) so mount sync won't load anything;
+    // on focus refetch, return the server session for the same episode
+    mockGetPlayerSession
+      .mockResolvedValueOnce({ success: true, data: null }) // mount: no session
+      .mockResolvedValue({ success: true, data: serverSession }) // focus: has session
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Wait for mount sync to complete
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Play the episode, leave it paused (jsdom never truly plays)
+    await user.click(screen.getByText("Play Episode"))
+    const audio = getAudioElement()!
+    Object.defineProperty(audio, "duration", { value: 600, configurable: true })
+    audio.currentTime = 100
+
+    // Simulate focus event; wait for 200ms debounce + async fetch to complete
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"))
+      await new Promise((r) => setTimeout(r, 300))
+    })
+
+    // currentTime should have been updated to server value since episode is paused
+    expect(audio.currentTime).toBe(250)
+  })
+
+  it("loads server session episode when a different episode is on device (cross-device sync)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const serverEpisode: AudioEpisode = {
+      id: "server-ep-x",
+      title: "Server Episode",
+      podcastTitle: "Podcast",
+      audioUrl: "https://example.com/server.mp3",
+    }
+    const serverSession = { episode: serverEpisode, currentTime: 120 }
+    mockGetPlayerSession.mockResolvedValue({ success: true, data: serverSession })
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>
+    )
+
+    // Wait for mount sync — server session has different episode from local (none)
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    vi.useRealTimers()
+    // Server episode should have been loaded (no auto-play)
+    expect(screen.getByTestId("episodeTitle")).toHaveTextContent("Server Episode")
+    expect(screen.getByTestId("isPlaying")).toHaveTextContent("false")
+  })
+
   it("does not dispatch INIT_QUEUE with server state when a local queue mutation is pending (debounce timer active)", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -300,7 +300,10 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
   const listenHistoryFiredRef = useRef<Map<string, number>>(new Map())
 
   // Cross-device sync refs
-  const pendingQueueWriteRef = useRef(false)
+  // Counter instead of boolean: stays > 0 while any debounce timer is scheduled OR
+  // any setQueueAction is in-flight, preventing a concurrent focus refetch from
+  // clobbering an unacked local mutation even across sequential writes.
+  const pendingQueueWriteRef = useRef(0)
   const lastAckedQueueRef = useRef<AudioEpisode[]>([])
   const queueDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const focusDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -370,12 +373,14 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
         const serverQueue = queueResult.data
         if (serverQueue.length === 0 && localQueue.length > 0) {
           // One-time migration: upload local queue to server
-          pendingQueueWriteRef.current = true
+          pendingQueueWriteRef.current++
           try {
-            await setQueueAction(localQueue)
-            lastAckedQueueRef.current = localQueue
+            const result = await setQueueAction(localQueue)
+            if (result.success) {
+              lastAckedQueueRef.current = localQueue
+            }
           } finally {
-            pendingQueueWriteRef.current = false
+            pendingQueueWriteRef.current--
           }
         } else if (serverQueue.length > 0) {
           // Server has data — reconcile only if no pending local write
@@ -391,14 +396,27 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
       if (cancelled) return
 
-      // Reconcile session (cold boot always applies server session if no local session)
+      // Reconcile session
       if (sessionResult.success && sessionResult.data) {
         const serverSession = sessionResult.data
         const currentEp = stateRef.current.currentEpisode
-        if (currentEp && currentEp.id === serverSession.episode.id) {
+        const audio = audioRef.current
+        const isActivelyPlaying = audio ? !audio.paused : stateRef.current.isPlaying
+        const sameEpisode = currentEp && currentEp.id === serverSession.episode.id
+
+        if (sameEpisode && isActivelyPlaying) {
           // Never rewind active playback
-        } else if (!currentEp) {
-          // Cold boot with no session playing — apply server session
+        } else if (sameEpisode && !isActivelyPlaying) {
+          // Same episode, paused — safe to seek to server currentTime
+          if (audio && Number.isFinite(serverSession.currentTime)) {
+            pendingSeekRef.current = serverSession.currentTime
+            if (audio.duration > 0 && !isNaN(audio.duration)) {
+              audio.currentTime = Math.min(serverSession.currentTime, audio.duration)
+              pendingSeekRef.current = null
+            }
+          }
+        } else {
+          // Different episode OR no episode — load server session (no auto-play)
           isRestoringSession.current = true
           loadEpisodeIntoPlayer(serverSession.episode, {
             andPlay: false,
@@ -433,13 +451,27 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           dispatch({ type: "INIT_QUEUE", queue: queueResult.data })
         }
 
-        // Session reconcile: never rewind active playback
+        // Session reconcile
         if (sessionResult.success && sessionResult.data) {
           const serverSession = sessionResult.data
           const currentEp = stateRef.current.currentEpisode
-          if (currentEp && currentEp.id === serverSession.episode.id) {
-            // Active episode matches — do not overwrite currentTime
-          } else if (!currentEp) {
+          const audio = audioRef.current
+          const isActivelyPlaying = audio ? !audio.paused : stateRef.current.isPlaying
+          const sameEpisode = currentEp && currentEp.id === serverSession.episode.id
+
+          if (sameEpisode && isActivelyPlaying) {
+            // Never rewind active playback
+          } else if (sameEpisode && !isActivelyPlaying) {
+            // Same episode, paused — safe to seek to server currentTime
+            if (audio && Number.isFinite(serverSession.currentTime)) {
+              pendingSeekRef.current = serverSession.currentTime
+              if (audio.duration > 0 && !isNaN(audio.duration)) {
+                audio.currentTime = Math.min(serverSession.currentTime, audio.duration)
+                pendingSeekRef.current = null
+              }
+            }
+          } else {
+            // Different episode OR no episode — load server session (no auto-play)
             isRestoringSession.current = true
             loadEpisodeIntoPlayer(serverSession.episode, {
               andPlay: false,
@@ -484,12 +516,15 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       return
     }
 
-    // Trailing-edge 1500ms debounce: collapses rapid reorders into a single setQueue call
+    // Trailing-edge 1500ms debounce: collapses rapid reorders into a single setQueue call.
+    // Increment the counter when scheduling so the flag stays > 0 while any timer or
+    // in-flight write is outstanding (prevents focus-refetch from clobbering).
     if (queueDebounceTimerRef.current) {
       clearTimeout(queueDebounceTimerRef.current)
+      pendingQueueWriteRef.current-- // cancel the previously scheduled increment
     }
     const snapshot = state.queue.slice()
-    pendingQueueWriteRef.current = true
+    pendingQueueWriteRef.current++
     queueDebounceTimerRef.current = setTimeout(async () => {
       queueDebounceTimerRef.current = null
       try {
@@ -510,7 +545,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
         suppressQueueWriteRef.current = true
         dispatch({ type: "INIT_QUEUE", queue: lastAckedQueueRef.current })
       } finally {
-        pendingQueueWriteRef.current = false
+        pendingQueueWriteRef.current--
       }
     }, 1500)
 
@@ -518,6 +553,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       if (queueDebounceTimerRef.current) {
         clearTimeout(queueDebounceTimerRef.current)
         queueDebounceTimerRef.current = null
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- pendingQueueWriteRef is a plain counter ref, not a DOM ref; stale-value warning does not apply
+        pendingQueueWriteRef.current--
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -31,6 +31,16 @@ import {
 import { fadeOutAudio } from "@/lib/audio-fade"
 import type { Chapter } from "@/lib/chapters"
 import { recordListenEvent } from "@/app/actions/listen-history"
+import {
+  getQueue,
+  setQueue as setQueueAction,
+  clearQueue as clearQueueAction,
+} from "@/app/actions/listening-queue"
+import {
+  getPlayerSession,
+  savePlayerSession as savePlayerSessionAction,
+  clearPlayerSession as clearPlayerSessionAction,
+} from "@/app/actions/player-session"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -290,6 +300,15 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
   // so re-firing after success would be a no-op server call.
   const listenHistoryFiredRef = useRef<Map<string, number>>(new Map())
 
+  // Cross-device sync refs
+  const pendingQueueWriteRef = useRef(false)
+  const lastAckedQueueRef = useRef<AudioEpisode[]>([])
+  const queueDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const focusDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Set to true when dispatching INIT_QUEUE from a server reconcile; prevents the
+  // queue-persist effect from scheduling a write back to the server for that change.
+  const suppressQueueWriteRef = useRef(false)
+
   const [state, dispatch] = useReducer(reducer, initialState)
 
   const progressRef = useRef<AudioPlayerProgress>({ currentTime: 0, buffered: 0 })
@@ -334,10 +353,175 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     isSessionRestored.current = true
   }, [])
 
-  // ---- Persist queue to localStorage on changes ----
+  // ---- Server-sync on mount: parallel getQueue + getPlayerSession, reconcile, migrate ----
+  useEffect(() => {
+    let cancelled = false
+
+    async function syncOnMount() {
+      const [queueResult, sessionResult] = await Promise.all([
+        getQueue(),
+        getPlayerSession(),
+      ])
+
+      if (cancelled) return
+
+      // Reconcile queue
+      const localQueue = loadQueue()
+      if (queueResult.success) {
+        const serverQueue = queueResult.data
+        if (serverQueue.length === 0 && localQueue.length > 0) {
+          // One-time migration: upload local queue to server
+          pendingQueueWriteRef.current = true
+          try {
+            await setQueueAction(localQueue)
+            lastAckedQueueRef.current = localQueue
+          } finally {
+            pendingQueueWriteRef.current = false
+          }
+        } else if (serverQueue.length > 0) {
+          // Server has data — reconcile only if no pending local write
+          if (!pendingQueueWriteRef.current) {
+            lastAckedQueueRef.current = serverQueue
+            dispatch({ type: "INIT_QUEUE", queue: serverQueue })
+          }
+        } else {
+          // Both empty — set lastAcked to empty
+          lastAckedQueueRef.current = []
+        }
+      }
+
+      if (cancelled) return
+
+      // Reconcile session (cold boot always applies server session if no local session)
+      if (sessionResult.success && sessionResult.data) {
+        const serverSession = sessionResult.data
+        const currentEp = stateRef.current.currentEpisode
+        if (currentEp && currentEp.id === serverSession.episode.id) {
+          // Never rewind active playback
+        } else if (!currentEp) {
+          // Cold boot with no session playing — apply server session
+          isRestoringSession.current = true
+          loadEpisodeIntoPlayer(serverSession.episode, {
+            andPlay: false,
+            startAt: serverSession.currentTime,
+          })
+        }
+      }
+    }
+
+    void syncOnMount()
+    return () => { cancelled = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ---- Focus/visibilitychange refetch: reconcile server state (200ms debounce) ----
+  useEffect(() => {
+    function scheduleRefetch() {
+      if (focusDebounceTimerRef.current) {
+        clearTimeout(focusDebounceTimerRef.current)
+      }
+      focusDebounceTimerRef.current = setTimeout(async () => {
+        focusDebounceTimerRef.current = null
+
+        const [queueResult, sessionResult] = await Promise.all([
+          getQueue(),
+          getPlayerSession(),
+        ])
+
+        // Queue reconcile: skip if a local write is pending
+        if (queueResult.success && !pendingQueueWriteRef.current) {
+          lastAckedQueueRef.current = queueResult.data
+          dispatch({ type: "INIT_QUEUE", queue: queueResult.data })
+        }
+
+        // Session reconcile: never rewind active playback
+        if (sessionResult.success && sessionResult.data) {
+          const serverSession = sessionResult.data
+          const currentEp = stateRef.current.currentEpisode
+          if (currentEp && currentEp.id === serverSession.episode.id) {
+            // Active episode matches — do not overwrite currentTime
+          } else if (!currentEp) {
+            isRestoringSession.current = true
+            loadEpisodeIntoPlayer(serverSession.episode, {
+              andPlay: false,
+              startAt: serverSession.currentTime,
+            })
+          }
+        }
+      }, 200)
+    }
+
+    const onVisibilityFocus = () => {
+      if (document.visibilityState === "visible") scheduleRefetch()
+    }
+
+    window.addEventListener("focus", scheduleRefetch)
+    document.addEventListener("visibilitychange", onVisibilityFocus)
+    return () => {
+      window.removeEventListener("focus", scheduleRefetch)
+      document.removeEventListener("visibilitychange", onVisibilityFocus)
+      if (focusDebounceTimerRef.current) {
+        clearTimeout(focusDebounceTimerRef.current)
+        focusDebounceTimerRef.current = null
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ---- Persist queue to localStorage + debounced server write ----
   useEffect(() => {
     if (!isQueueHydrated.current) return
+
     saveQueue(state.queue)
+
+    // Skip server write if the queue matches the last server-acked state (no user mutation)
+    const currentIds = state.queue.map((ep) => ep.id).join(",")
+    const ackedIds = lastAckedQueueRef.current.map((ep) => ep.id).join(",")
+    if (currentIds === ackedIds) return
+
+    // Skip server write if this queue change originated from a server reconcile
+    if (suppressQueueWriteRef.current) {
+      suppressQueueWriteRef.current = false
+      return
+    }
+
+    // Trailing-edge 1500ms debounce: collapses rapid reorders into a single setQueue call
+    if (queueDebounceTimerRef.current) {
+      clearTimeout(queueDebounceTimerRef.current)
+    }
+    const snapshot = state.queue.slice()
+    pendingQueueWriteRef.current = true
+    queueDebounceTimerRef.current = setTimeout(async () => {
+      queueDebounceTimerRef.current = null
+      try {
+        const result = await setQueueAction(snapshot)
+        if (result.success) {
+          lastAckedQueueRef.current = snapshot
+        } else {
+          toast.error("Couldn't sync queue", {
+            description: "Your queue change couldn't be saved. Rolling back.",
+          })
+          suppressQueueWriteRef.current = true
+          dispatch({ type: "INIT_QUEUE", queue: lastAckedQueueRef.current })
+        }
+      } catch {
+        toast.error("Couldn't sync queue", {
+          description: "Your queue change couldn't be saved. Rolling back.",
+        })
+        suppressQueueWriteRef.current = true
+        dispatch({ type: "INIT_QUEUE", queue: lastAckedQueueRef.current })
+      } finally {
+        pendingQueueWriteRef.current = false
+      }
+    }, 1500)
+
+    return () => {
+      if (queueDebounceTimerRef.current) {
+        clearTimeout(queueDebounceTimerRef.current)
+        queueDebounceTimerRef.current = null
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.queue])
 
   // ---- Sync volume & speed to audio element ----
@@ -559,7 +743,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       clearSleepTimerInterval()
       cancelFade()
       if (options?.clearSession) {
-        clearPlayerSession()
+        clearPlayerSession() // localStorage cache
+        void clearPlayerSessionAction() // server source of truth
       }
       if (sessionSaveTimerRef.current) {
         clearTimeout(sessionSaveTimerRef.current)
@@ -765,7 +950,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           sessionSaveTimerRef.current = null
           const ep = stateRef.current.currentEpisode
           if (ep) {
-            savePlayerSession(ep, audio.currentTime)
+            savePlayerSession(ep, audio.currentTime) // localStorage cache
+            void savePlayerSessionAction(ep, audio.currentTime) // server source of truth
           }
         }, 5000)
       }
@@ -972,7 +1158,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       const ep = stateRef.current.currentEpisode
       const audio = audioRef.current
       if (ep && audio && isSessionRestored.current) {
-        savePlayerSession(ep, audio.currentTime)
+        savePlayerSession(ep, audio.currentTime) // localStorage cache
+        void savePlayerSessionAction(ep, audio.currentTime) // fire-and-forget to server
       }
     }
     window.addEventListener("beforeunload", onBeforeUnload)

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -390,8 +390,17 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     isSessionRestored.current = true
   }, [])
 
-  // ---- Server-sync on mount: parallel getQueue + getPlayerSession, reconcile, migrate ----
+  // ---- Server-sync: parallel getQueue + getPlayerSession, reconcile, migrate ----
+  // Runs whenever Clerk finishes loading OR `userId` changes. Without the
+  // `isAuthLoaded && userId` gate on the deps, a first-render pre-hydration
+  // pass would call the server actions, get Unauthorized, and never retry
+  // (the effect had `[]` deps), leaving cross-device state unsynced and
+  // — worse — letting an empty server response wipe a non-empty local queue.
   useEffect(() => {
+    if (!isAuthLoaded || !userId) return
+    // Bind the narrowed userId for the nested async closure — TypeScript
+    // doesn't propagate the guard across the function boundary.
+    const activeUserId = userId
     let cancelled = false
 
     async function syncOnMount() {
@@ -399,19 +408,17 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       // browser, wipe the prior user's localStorage BEFORE reconciling against
       // the server — otherwise User A's cached queue/session would leak into
       // User B's account on the first write.
-      if (isAuthLoaded && userId) {
-        const lastUserId = getLastUserId()
-        if (lastUserId && lastUserId !== userId) {
-          clearAllUserLocalData()
-          suppressQueueWriteRef.current = true
-          dispatch({ type: "INIT_QUEUE", queue: [] })
-          lastAckedQueueRef.current = []
-          // Reset player state (no clearSession flag — the server session
-          // belongs to the new user, we don't want to delete it).
-          teardownPlayer()
-        }
-        setLastUserId(userId)
+      const lastUserId = getLastUserId()
+      if (lastUserId && lastUserId !== activeUserId) {
+        clearAllUserLocalData()
+        suppressQueueWriteRef.current = true
+        dispatch({ type: "INIT_QUEUE", queue: [] })
+        lastAckedQueueRef.current = []
+        // Reset player state (no clearSession flag — the server session
+        // belongs to the new user, we don't want to delete it).
+        teardownPlayer()
       }
+      setLastUserId(activeUserId)
 
       let queueResult: Awaited<ReturnType<typeof getQueue>>
       let sessionResult: Awaited<ReturnType<typeof getPlayerSession>>
@@ -430,9 +437,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       // Reconcile queue — gated by per-user migration marker so a queue
       // cleared on another device isn't resurrected by this browser's cache.
       const localQueue = loadQueue()
-      if (queueResult.success && userId) {
+      if (queueResult.success) {
         const serverQueue = queueResult.data
-        const hasMigrated = hasQueueMigrated(userId)
+        const hasMigrated = hasQueueMigrated(activeUserId)
         if (serverQueue.length === 0) {
           if (localQueue.length > 0 && !hasMigrated) {
             // One-time upload of pre-sync local queue
@@ -441,7 +448,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
               const result = await setQueueAction(localQueue)
               if (result.success) {
                 lastAckedQueueRef.current = localQueue
-                markQueueMigrated(userId)
+                markQueueMigrated(activeUserId)
               } else {
                 console.error("Queue migration failed:", result.error)
                 toast.error("Couldn't sync your queue", {
@@ -466,16 +473,16 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
             saveQueue([])
           } else {
             lastAckedQueueRef.current = []
-            if (!hasMigrated) markQueueMigrated(userId)
+            if (!hasMigrated) markQueueMigrated(activeUserId)
           }
         } else if (serverQueue.length > 0) {
           if (!pendingQueueWriteRef.current) {
             lastAckedQueueRef.current = serverQueue
             dispatch({ type: "INIT_QUEUE", queue: serverQueue })
-            if (!hasMigrated) markQueueMigrated(userId)
+            if (!hasMigrated) markQueueMigrated(activeUserId)
           }
         }
-      } else if (!queueResult.success) {
+      } else {
         console.warn("Mount getQueue failed:", queueResult.error)
       }
 
@@ -487,12 +494,12 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       if (sessionResult.success) {
         if (sessionResult.data) {
           reconcileServerSession(sessionResult.data)
-          if (userId && !hasSessionMigrated(userId)) markSessionMigrated(userId)
-        } else if (userId) {
+          if (!hasSessionMigrated(activeUserId)) markSessionMigrated(activeUserId)
+        } else {
           const localEp = stateRef.current.currentEpisode
           const audio = audioRef.current
           const hasLocal = localEp !== null
-          const migrated = hasSessionMigrated(userId)
+          const migrated = hasSessionMigrated(activeUserId)
           if (hasLocal && !migrated) {
             // One-time upload of pre-sync local session
             const t = audio?.currentTime ?? 0
@@ -504,12 +511,12 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
               .catch((err) =>
                 console.warn("[player] session migration threw", err)
               )
-            markSessionMigrated(userId)
+            markSessionMigrated(activeUserId)
           } else if (hasLocal && migrated) {
             // Server authoritative empty — close the locally restored player.
             teardownPlayer({ clearSession: true })
           } else if (!hasLocal && !migrated) {
-            markSessionMigrated(userId)
+            markSessionMigrated(activeUserId)
           }
         }
       } else {
@@ -519,11 +526,12 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
     void syncOnMount()
     return () => { cancelled = true }
-  // Runs once on mount. `reconcileServerSession`, `loadEpisodeIntoPlayer`, and
-  // the imported server actions are referenced via closure; re-running on
-  // their identity churn would re-trigger cross-device fetch every render.
+  // Only `isAuthLoaded`/`userId` gate the effect. `reconcileServerSession`,
+  // `loadEpisodeIntoPlayer`, and the provider-scope helpers are closed over
+  // and change identity every render; re-running on those would re-trigger
+  // the cross-device fetch continuously.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [isAuthLoaded, userId])
 
   // ---- Focus/visibilitychange refetch: reconcile server state (200ms debounce) ----
   useEffect(() => {

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -519,16 +519,20 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
     saveQueue(state.queue)
 
-    // Skip server write if the queue matches the last server-acked state (no user mutation)
-    const currentIds = state.queue.map((ep) => ep.id).join(",")
-    const ackedIds = lastAckedQueueRef.current.map((ep) => ep.id).join(",")
-    if (currentIds === ackedIds) return
-
     // Skip server write if this queue change originated from a server reconcile
+    // or a rollback-triggered INIT_QUEUE. Check this BEFORE the acked-IDs
+    // early return — otherwise a rollback (which restores the acked queue by
+    // definition) would bail on ID equality and leave the suppress flag set,
+    // silently dropping the next real user mutation.
     if (suppressQueueWriteRef.current) {
       suppressQueueWriteRef.current = false
       return
     }
+
+    // Skip server write if the queue matches the last server-acked state (no user mutation)
+    const currentIds = state.queue.map((ep) => ep.id).join(",")
+    const ackedIds = lastAckedQueueRef.current.map((ep) => ep.id).join(",")
+    if (currentIds === ackedIds) return
 
     // Trailing-edge 1500ms debounce: collapses rapid reorders into a single setQueue call.
     // Increment the counter when scheduling so the flag stays > 0 while any timer or

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/player-session"
 import { fadeOutAudio } from "@/lib/audio-fade"
 import type { Chapter } from "@/lib/chapters"
+import type { AudioEpisode } from "@/lib/schemas/listening-queue"
 import { recordListenEvent } from "@/app/actions/listen-history"
 import {
   getQueue,
@@ -53,15 +54,7 @@ export interface SleepTimerState {
   type: SleepTimerType
 }
 
-export interface AudioEpisode {
-  id: string
-  title: string
-  podcastTitle: string
-  audioUrl: string
-  artwork?: string
-  duration?: number
-  chaptersUrl?: string
-}
+export type { AudioEpisode }
 
 export interface AudioPlayerState {
   currentEpisode: AudioEpisode | null
@@ -303,6 +296,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
   // Counter instead of boolean: stays > 0 while any debounce timer is scheduled OR
   // any setQueueAction is in-flight, preventing a concurrent focus refetch from
   // clobbering an unacked local mutation even across sequential writes.
+  // See ADR-036.
   const pendingQueueWriteRef = useRef(0)
   const lastAckedQueueRef = useRef<AudioEpisode[]>([])
   const queueDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -335,6 +329,10 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
   // ---- Hydrate queue from localStorage on mount ----
   useEffect(() => {
     const persisted = loadQueue()
+    // Seed lastAckedQueueRef so the persist effect's first run sees currentIds ===
+    // ackedIds and skips scheduling a spurious setQueue write. Without this, the
+    // cached local queue would overwrite the server state on every cold boot.
+    lastAckedQueueRef.current = persisted
     dispatch({ type: "INIT_QUEUE", queue: persisted })
     isQueueHydrated.current = true
   }, [])
@@ -360,10 +358,17 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     let cancelled = false
 
     async function syncOnMount() {
-      const [queueResult, sessionResult] = await Promise.all([
-        getQueue(),
-        getPlayerSession(),
-      ])
+      let queueResult: Awaited<ReturnType<typeof getQueue>>
+      let sessionResult: Awaited<ReturnType<typeof getPlayerSession>>
+      try {
+        ;[queueResult, sessionResult] = await Promise.all([
+          getQueue(),
+          getPlayerSession(),
+        ])
+      } catch (err) {
+        console.error("Failed to fetch cross-device sync state on mount:", err)
+        return
+      }
 
       if (cancelled) return
 
@@ -378,12 +383,26 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
             const result = await setQueueAction(localQueue)
             if (result.success) {
               lastAckedQueueRef.current = localQueue
+            } else {
+              console.error("Queue migration failed:", result.error)
+              toast.error("Couldn't sync your queue", {
+                description:
+                  "Your local queue didn't upload. We'll try again on the next change.",
+              })
             }
+          } catch (err) {
+            console.error("Queue migration threw:", err)
+            toast.error("Couldn't sync your queue", {
+              description:
+                "Your local queue didn't upload. We'll try again on the next change.",
+            })
           } finally {
             pendingQueueWriteRef.current--
           }
         } else if (serverQueue.length > 0) {
-          // Server has data — reconcile only if no pending local write
+          // Server has data — reconcile only if no pending local write.
+          // `lastAckedQueueRef` is updated BEFORE dispatch so the persist
+          // effect's id comparison sees a match and skips the server write.
           if (!pendingQueueWriteRef.current) {
             lastAckedQueueRef.current = serverQueue
             dispatch({ type: "INIT_QUEUE", queue: serverQueue })
@@ -392,6 +411,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           // Both empty — set lastAcked to empty
           lastAckedQueueRef.current = []
         }
+      } else {
+        console.warn("Mount getQueue failed:", queueResult.error)
       }
 
       if (cancelled) return
@@ -423,6 +444,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
             startAt: serverSession.currentTime,
           })
         }
+      } else if (!sessionResult.success) {
+        console.warn("Mount getPlayerSession failed:", sessionResult.error)
       }
     }
 
@@ -440,15 +463,24 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       focusDebounceTimerRef.current = setTimeout(async () => {
         focusDebounceTimerRef.current = null
 
-        const [queueResult, sessionResult] = await Promise.all([
-          getQueue(),
-          getPlayerSession(),
-        ])
+        let queueResult: Awaited<ReturnType<typeof getQueue>>
+        let sessionResult: Awaited<ReturnType<typeof getPlayerSession>>
+        try {
+          ;[queueResult, sessionResult] = await Promise.all([
+            getQueue(),
+            getPlayerSession(),
+          ])
+        } catch (err) {
+          console.error("Focus refetch failed:", err)
+          return
+        }
 
         // Queue reconcile: skip if a local write is pending
         if (queueResult.success && !pendingQueueWriteRef.current) {
           lastAckedQueueRef.current = queueResult.data
           dispatch({ type: "INIT_QUEUE", queue: queueResult.data })
+        } else if (!queueResult.success) {
+          console.warn("Focus getQueue failed:", queueResult.error)
         }
 
         // Session reconcile
@@ -478,6 +510,8 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
               startAt: serverSession.currentTime,
             })
           }
+        } else if (!sessionResult.success) {
+          console.warn("Focus getPlayerSession failed:", sessionResult.error)
         }
       }, 200)
     }
@@ -553,7 +587,12 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       if (queueDebounceTimerRef.current) {
         clearTimeout(queueDebounceTimerRef.current)
         queueDebounceTimerRef.current = null
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- pendingQueueWriteRef is a plain counter ref, not a DOM ref; stale-value warning does not apply
+        // pendingQueueWriteRef is a plain counter, not a DOM ref. The lint
+        // warning about stale-closure ref values in cleanup does not apply —
+        // we explicitly want to decrement the live counter here to balance the
+        // increment that ran when this effect body scheduled the debounced
+        // write above.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         pendingQueueWriteRef.current--
       }
     }
@@ -780,7 +819,11 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       cancelFade()
       if (options?.clearSession) {
         clearPlayerSession() // localStorage cache
-        void clearPlayerSessionAction() // server source of truth
+        clearPlayerSessionAction() // server source of truth
+          .then((r) => {
+            if (!r.success) console.warn("clearPlayerSession failed:", r.error)
+          })
+          .catch((err) => console.warn("clearPlayerSession threw:", err))
       }
       if (sessionSaveTimerRef.current) {
         clearTimeout(sessionSaveTimerRef.current)
@@ -987,7 +1030,14 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           const ep = stateRef.current.currentEpisode
           if (ep) {
             savePlayerSession(ep, audio.currentTime) // localStorage cache
-            void savePlayerSessionAction(ep, audio.currentTime) // server source of truth
+            savePlayerSessionAction(ep, audio.currentTime) // server source of truth
+              .then((r) => {
+                if (!r.success)
+                  console.warn("savePlayerSession failed:", r.error)
+              })
+              .catch((err) =>
+                console.warn("savePlayerSession threw:", err)
+              )
           }
         }, 5000)
       }
@@ -1075,9 +1125,16 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     const onPause = () => {
       dispatch({ type: "SET_PLAYING", isPlaying: false })
       clearStallTimer()
-      // Save exact pause position immediately
+      // Save exact pause position immediately (locally AND to the server so a
+      // pause on Device A reflects on Device B without waiting for the 5s throttle).
       if (isSessionRestored.current && stateRef.current.currentEpisode) {
-        savePlayerSession(stateRef.current.currentEpisode, audio.currentTime)
+        const ep = stateRef.current.currentEpisode
+        savePlayerSession(ep, audio.currentTime) // localStorage cache
+        savePlayerSessionAction(ep, audio.currentTime) // server source of truth
+          .then((r) => {
+            if (!r.success) console.warn("savePlayerSession (pause) failed:", r.error)
+          })
+          .catch((err) => console.warn("savePlayerSession (pause) threw:", err))
       }
     }
 
@@ -1195,7 +1252,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       const audio = audioRef.current
       if (ep && audio && isSessionRestored.current) {
         savePlayerSession(ep, audio.currentTime) // localStorage cache
-        void savePlayerSessionAction(ep, audio.currentTime) // fire-and-forget to server
+        // beforeunload can't await; the browser may drop the request, but we
+        // still attach a catch so a synchronous rejection isn't unhandled.
+        savePlayerSessionAction(ep, audio.currentTime).catch(() => {})
       }
     }
     window.addEventListener("beforeunload", onBeforeUnload)

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -34,7 +34,6 @@ import { recordListenEvent } from "@/app/actions/listen-history"
 import {
   getQueue,
   setQueue as setQueueAction,
-  clearQueue as clearQueueAction,
 } from "@/app/actions/listening-queue"
 import {
   getPlayerSession,

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -12,6 +12,16 @@ import {
 } from "react"
 import { toast } from "sonner"
 import { arrayMove } from "@dnd-kit/sortable"
+import { useAuth } from "@clerk/nextjs"
+import {
+  clearAllUserLocalData,
+  getLastUserId,
+  hasQueueMigrated,
+  hasSessionMigrated,
+  markQueueMigrated,
+  markSessionMigrated,
+  setLastUserId,
+} from "@/lib/migration-marker"
 import {
   updateMediaSessionMetadata,
   setupMediaSessionHandlers,
@@ -298,6 +308,7 @@ const initialState: AudioPlayerState = {
 }
 
 export function AudioPlayerProvider({ children }: { children: ReactNode }) {
+  const { userId, isLoaded: isAuthLoaded } = useAuth()
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const ariaTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -384,6 +395,24 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     let cancelled = false
 
     async function syncOnMount() {
+      // User-switch guard (ADR-036): if a different user is signed in on this
+      // browser, wipe the prior user's localStorage BEFORE reconciling against
+      // the server — otherwise User A's cached queue/session would leak into
+      // User B's account on the first write.
+      if (isAuthLoaded && userId) {
+        const lastUserId = getLastUserId()
+        if (lastUserId && lastUserId !== userId) {
+          clearAllUserLocalData()
+          suppressQueueWriteRef.current = true
+          dispatch({ type: "INIT_QUEUE", queue: [] })
+          lastAckedQueueRef.current = []
+          // Reset player state (no clearSession flag — the server session
+          // belongs to the new user, we don't want to delete it).
+          teardownPlayer()
+        }
+        setLastUserId(userId)
+      }
+
       let queueResult: Awaited<ReturnType<typeof getQueue>>
       let sessionResult: Awaited<ReturnType<typeof getPlayerSession>>
       try {
@@ -398,51 +427,92 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
       if (cancelled) return
 
-      // Reconcile queue
+      // Reconcile queue — gated by per-user migration marker so a queue
+      // cleared on another device isn't resurrected by this browser's cache.
       const localQueue = loadQueue()
-      if (queueResult.success) {
+      if (queueResult.success && userId) {
         const serverQueue = queueResult.data
-        if (serverQueue.length === 0 && localQueue.length > 0) {
-          // One-time migration: upload local queue to server
-          pendingQueueWriteRef.current++
-          try {
-            const result = await setQueueAction(localQueue)
-            if (result.success) {
-              lastAckedQueueRef.current = localQueue
-            } else {
-              console.error("Queue migration failed:", result.error)
+        const hasMigrated = hasQueueMigrated(userId)
+        if (serverQueue.length === 0) {
+          if (localQueue.length > 0 && !hasMigrated) {
+            // One-time upload of pre-sync local queue
+            pendingQueueWriteRef.current++
+            try {
+              const result = await setQueueAction(localQueue)
+              if (result.success) {
+                lastAckedQueueRef.current = localQueue
+                markQueueMigrated(userId)
+              } else {
+                console.error("Queue migration failed:", result.error)
+                toast.error("Couldn't sync your queue", {
+                  description:
+                    "Your local queue didn't upload. We'll try again on the next change.",
+                })
+              }
+            } catch (err) {
+              console.error("Queue migration threw:", err)
               toast.error("Couldn't sync your queue", {
                 description:
                   "Your local queue didn't upload. We'll try again on the next change.",
               })
+            } finally {
+              pendingQueueWriteRef.current--
             }
-          } catch (err) {
-            console.error("Queue migration threw:", err)
-            toast.error("Couldn't sync your queue", {
-              description:
-                "Your local queue didn't upload. We'll try again on the next change.",
-            })
-          } finally {
-            pendingQueueWriteRef.current--
+          } else if (localQueue.length > 0 && hasMigrated) {
+            // Server is authoritative empty — user cleared on another device.
+            suppressQueueWriteRef.current = true
+            lastAckedQueueRef.current = []
+            dispatch({ type: "INIT_QUEUE", queue: [] })
+            saveQueue([])
+          } else {
+            lastAckedQueueRef.current = []
+            if (!hasMigrated) markQueueMigrated(userId)
           }
         } else if (serverQueue.length > 0) {
           if (!pendingQueueWriteRef.current) {
             lastAckedQueueRef.current = serverQueue
             dispatch({ type: "INIT_QUEUE", queue: serverQueue })
+            if (!hasMigrated) markQueueMigrated(userId)
           }
-        } else {
-          lastAckedQueueRef.current = []
         }
-      } else {
+      } else if (!queueResult.success) {
         console.warn("Mount getQueue failed:", queueResult.error)
       }
 
       if (cancelled) return
 
-      // Reconcile session
-      if (sessionResult.success && sessionResult.data) {
-        reconcileServerSession(sessionResult.data)
-      } else if (!sessionResult.success) {
+      // Reconcile session — symmetric to queue. Empty server + migrated user
+      // means "explicitly cleared elsewhere"; empty server + unmigrated means
+      // "never synced before — upload local as one-time migration."
+      if (sessionResult.success) {
+        if (sessionResult.data) {
+          reconcileServerSession(sessionResult.data)
+          if (userId && !hasSessionMigrated(userId)) markSessionMigrated(userId)
+        } else if (userId) {
+          const localEp = stateRef.current.currentEpisode
+          const audio = audioRef.current
+          const hasLocal = localEp !== null
+          const migrated = hasSessionMigrated(userId)
+          if (hasLocal && !migrated) {
+            // One-time upload of pre-sync local session
+            const t = audio?.currentTime ?? 0
+            savePlayerSessionAction(localEp, t)
+              .then((r) => {
+                if (!r.success)
+                  console.warn("[player] session migration failed", r.error)
+              })
+              .catch((err) =>
+                console.warn("[player] session migration threw", err)
+              )
+            markSessionMigrated(userId)
+          } else if (hasLocal && migrated) {
+            // Server authoritative empty — close the locally restored player.
+            teardownPlayer({ clearSession: true })
+          } else if (!hasLocal && !migrated) {
+            markSessionMigrated(userId)
+          }
+        }
+      } else {
         console.warn("Mount getPlayerSession failed:", sessionResult.error)
       }
     }

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -43,6 +43,32 @@ import {
 } from "@/app/actions/player-session"
 
 // ---------------------------------------------------------------------------
+// Server-sync helpers (fire-and-forget; best-effort with warn-on-failure)
+// ---------------------------------------------------------------------------
+
+type SessionSaveSite = "throttle" | "pause" | "beforeunload"
+
+function persistSessionToServer(
+  episode: AudioEpisode,
+  currentTime: number,
+  site: SessionSaveSite
+): void {
+  savePlayerSessionAction(episode, currentTime)
+    .then((r) => {
+      if (!r.success) console.warn("[player] save failed", { site, error: r.error })
+    })
+    .catch((err) => console.warn("[player] save threw", { site, err }))
+}
+
+function clearSessionOnServer(): void {
+  clearPlayerSessionAction()
+    .then((r) => {
+      if (!r.success) console.warn("[player] clear failed:", r.error)
+    })
+    .catch((err) => console.warn("[player] clear threw:", err))
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -400,15 +426,11 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
             pendingQueueWriteRef.current--
           }
         } else if (serverQueue.length > 0) {
-          // Server has data — reconcile only if no pending local write.
-          // `lastAckedQueueRef` is updated BEFORE dispatch so the persist
-          // effect's id comparison sees a match and skips the server write.
           if (!pendingQueueWriteRef.current) {
             lastAckedQueueRef.current = serverQueue
             dispatch({ type: "INIT_QUEUE", queue: serverQueue })
           }
         } else {
-          // Both empty — set lastAcked to empty
           lastAckedQueueRef.current = []
         }
       } else {
@@ -419,31 +441,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
       // Reconcile session
       if (sessionResult.success && sessionResult.data) {
-        const serverSession = sessionResult.data
-        const currentEp = stateRef.current.currentEpisode
-        const audio = audioRef.current
-        const isActivelyPlaying = audio ? !audio.paused : stateRef.current.isPlaying
-        const sameEpisode = currentEp && currentEp.id === serverSession.episode.id
-
-        if (sameEpisode && isActivelyPlaying) {
-          // Never rewind active playback
-        } else if (sameEpisode && !isActivelyPlaying) {
-          // Same episode, paused — safe to seek to server currentTime
-          if (audio && Number.isFinite(serverSession.currentTime)) {
-            pendingSeekRef.current = serverSession.currentTime
-            if (audio.duration > 0 && !isNaN(audio.duration)) {
-              audio.currentTime = Math.min(serverSession.currentTime, audio.duration)
-              pendingSeekRef.current = null
-            }
-          }
-        } else {
-          // Different episode OR no episode — load server session (no auto-play)
-          isRestoringSession.current = true
-          loadEpisodeIntoPlayer(serverSession.episode, {
-            andPlay: false,
-            startAt: serverSession.currentTime,
-          })
-        }
+        reconcileServerSession(sessionResult.data)
       } else if (!sessionResult.success) {
         console.warn("Mount getPlayerSession failed:", sessionResult.error)
       }
@@ -451,6 +449,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
     void syncOnMount()
     return () => { cancelled = true }
+  // Runs once on mount. `reconcileServerSession`, `loadEpisodeIntoPlayer`, and
+  // the imported server actions are referenced via closure; re-running on
+  // their identity churn would re-trigger cross-device fetch every render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -485,31 +486,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
         // Session reconcile
         if (sessionResult.success && sessionResult.data) {
-          const serverSession = sessionResult.data
-          const currentEp = stateRef.current.currentEpisode
-          const audio = audioRef.current
-          const isActivelyPlaying = audio ? !audio.paused : stateRef.current.isPlaying
-          const sameEpisode = currentEp && currentEp.id === serverSession.episode.id
-
-          if (sameEpisode && isActivelyPlaying) {
-            // Never rewind active playback
-          } else if (sameEpisode && !isActivelyPlaying) {
-            // Same episode, paused — safe to seek to server currentTime
-            if (audio && Number.isFinite(serverSession.currentTime)) {
-              pendingSeekRef.current = serverSession.currentTime
-              if (audio.duration > 0 && !isNaN(audio.duration)) {
-                audio.currentTime = Math.min(serverSession.currentTime, audio.duration)
-                pendingSeekRef.current = null
-              }
-            }
-          } else {
-            // Different episode OR no episode — load server session (no auto-play)
-            isRestoringSession.current = true
-            loadEpisodeIntoPlayer(serverSession.episode, {
-              andPlay: false,
-              startAt: serverSession.currentTime,
-            })
-          }
+          reconcileServerSession(sessionResult.data)
         } else if (!sessionResult.success) {
           console.warn("Focus getPlayerSession failed:", sessionResult.error)
         }
@@ -530,6 +507,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
         focusDebounceTimerRef.current = null
       }
     }
+  // Mount-only: registers focus + visibilitychange listeners once. The
+  // `reconcileServerSession` closure captures refs only, so listener
+  // reinstallation on every render would thrash for no behavior change.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -587,15 +567,15 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       if (queueDebounceTimerRef.current) {
         clearTimeout(queueDebounceTimerRef.current)
         queueDebounceTimerRef.current = null
-        // pendingQueueWriteRef is a plain counter, not a DOM ref. The lint
-        // warning about stale-closure ref values in cleanup does not apply —
-        // we explicitly want to decrement the live counter here to balance the
-        // increment that ran when this effect body scheduled the debounced
-        // write above.
+        // Balance the increment that scheduled this debounced write. The
+        // lint rule assumes refs point to DOM nodes that may unmount; this
+        // one is a plain counter, so reading the live value is intentional.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         pendingQueueWriteRef.current--
       }
     }
+  // Only `state.queue` is a reactive dep. `setQueueAction` is a stable import,
+  // and the refs / `dispatch` are stable by React contract.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.queue])
 
@@ -802,6 +782,45 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  // ---- Reconcile a server-fetched session into the player ----
+  // Shared by mount-sync and focus-refetch. Preserves the never-rewind
+  // invariant: if the same episode is actively playing, server currentTime
+  // is ignored.
+  const reconcileServerSession = (serverSession: {
+    episode: AudioEpisode
+    currentTime: number
+  }) => {
+    const currentEp = stateRef.current.currentEpisode
+    const audio = audioRef.current
+    const isActivelyPlaying = audio
+      ? !audio.paused
+      : stateRef.current.isPlaying
+    const sameEpisode =
+      currentEp && currentEp.id === serverSession.episode.id
+
+    if (sameEpisode && isActivelyPlaying) {
+      return
+    }
+    if (sameEpisode && !isActivelyPlaying) {
+      if (audio && Number.isFinite(serverSession.currentTime)) {
+        pendingSeekRef.current = serverSession.currentTime
+        if (audio.duration > 0 && !isNaN(audio.duration)) {
+          audio.currentTime = Math.min(
+            serverSession.currentTime,
+            audio.duration
+          )
+          pendingSeekRef.current = null
+        }
+      }
+      return
+    }
+    isRestoringSession.current = true
+    loadEpisodeIntoPlayer(serverSession.episode, {
+      andPlay: false,
+      startAt: serverSession.currentTime,
+    })
+  }
+
   // ---- Shared player teardown ----
   // Resets the audio element and all player state. Only clears the persisted
   // session when the user explicitly closes the player (not on auto-advance errors).
@@ -819,11 +838,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       cancelFade()
       if (options?.clearSession) {
         clearPlayerSession() // localStorage cache
-        clearPlayerSessionAction() // server source of truth
-          .then((r) => {
-            if (!r.success) console.warn("clearPlayerSession failed:", r.error)
-          })
-          .catch((err) => console.warn("clearPlayerSession threw:", err))
+        clearSessionOnServer() // server source of truth
       }
       if (sessionSaveTimerRef.current) {
         clearTimeout(sessionSaveTimerRef.current)
@@ -1030,14 +1045,7 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
           const ep = stateRef.current.currentEpisode
           if (ep) {
             savePlayerSession(ep, audio.currentTime) // localStorage cache
-            savePlayerSessionAction(ep, audio.currentTime) // server source of truth
-              .then((r) => {
-                if (!r.success)
-                  console.warn("savePlayerSession failed:", r.error)
-              })
-              .catch((err) =>
-                console.warn("savePlayerSession threw:", err)
-              )
+            persistSessionToServer(ep, audio.currentTime, "throttle")
           }
         }, 5000)
       }
@@ -1127,14 +1135,15 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       clearStallTimer()
       // Save exact pause position immediately (locally AND to the server so a
       // pause on Device A reflects on Device B without waiting for the 5s throttle).
+      // Clear any pending throttled save — the immediate pause save supersedes it.
+      if (sessionSaveTimerRef.current) {
+        clearTimeout(sessionSaveTimerRef.current)
+        sessionSaveTimerRef.current = null
+      }
       if (isSessionRestored.current && stateRef.current.currentEpisode) {
         const ep = stateRef.current.currentEpisode
         savePlayerSession(ep, audio.currentTime) // localStorage cache
-        savePlayerSessionAction(ep, audio.currentTime) // server source of truth
-          .then((r) => {
-            if (!r.success) console.warn("savePlayerSession (pause) failed:", r.error)
-          })
-          .catch((err) => console.warn("savePlayerSession (pause) threw:", err))
+        persistSessionToServer(ep, audio.currentTime, "pause")
       }
     }
 
@@ -1252,9 +1261,9 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
       const audio = audioRef.current
       if (ep && audio && isSessionRestored.current) {
         savePlayerSession(ep, audio.currentTime) // localStorage cache
-        // beforeunload can't await; the browser may drop the request, but we
-        // still attach a catch so a synchronous rejection isn't unhandled.
-        savePlayerSessionAction(ep, audio.currentTime).catch(() => {})
+        // beforeunload can't await; the browser may drop the request, but
+        // the helper attaches its own .catch so rejections aren't unhandled.
+        persistSessionToServer(ep, audio.currentTime, "beforeunload")
       }
     }
     window.addEventListener("beforeunload", onBeforeUnload)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -359,14 +359,62 @@ export const listenHistory = pgTable(
   ]
 );
 
+// User Queue Items table (denormalized episode fields for cross-device queue sync)
+export const userQueueItems = pgTable(
+  "user_queue_items",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    position: integer("position").notNull(),
+    episodeId: text("episode_id").notNull(),
+    title: text("title").notNull(),
+    podcastTitle: text("podcast_title").notNull(),
+    audioUrl: text("audio_url").notNull(),
+    artwork: text("artwork"),
+    duration: integer("duration"),
+    chaptersUrl: text("chapters_url"),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("user_queue_items_user_episode_idx").on(
+      table.userId,
+      table.episodeId
+    ),
+    uniqueIndex("user_queue_items_user_position_idx").on(
+      table.userId,
+      table.position
+    ),
+  ]
+);
+
+// User Player Session table (per-user resume state, one row per user)
+export const userPlayerSession = pgTable("user_player_session", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  episodeId: text("episode_id").notNull(),
+  title: text("title").notNull(),
+  podcastTitle: text("podcast_title").notNull(),
+  audioUrl: text("audio_url").notNull(),
+  artwork: text("artwork"),
+  duration: integer("duration"),
+  chaptersUrl: text("chapters_url"),
+  currentTime: decimal("current_time", { precision: 12, scale: 3 }).notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
 // Relations
-export const usersRelations = relations(users, ({ many }) => ({
+export const usersRelations = relations(users, ({ many, one }) => ({
   subscriptions: many(userSubscriptions),
   library: many(userLibrary),
   collections: many(collections),
   notifications: many(notifications),
   pushSubscriptions: many(pushSubscriptions),
   listenHistory: many(listenHistory),
+  queueItems: many(userQueueItems),
+  playerSession: one(userPlayerSession),
 }));
 
 export const podcastsRelations = relations(podcasts, ({ many }) => ({
@@ -476,6 +524,23 @@ export const listenHistoryRelations = relations(listenHistory, ({ one }) => ({
   }),
 }));
 
+export const userQueueItemsRelations = relations(userQueueItems, ({ one }) => ({
+  user: one(users, {
+    fields: [userQueueItems.userId],
+    references: [users.id],
+  }),
+}));
+
+export const userPlayerSessionRelations = relations(
+  userPlayerSession,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [userPlayerSession.userId],
+      references: [users.id],
+    }),
+  })
+);
+
 // Type exports for use in the application
 export type RateLimit = typeof rateLimits.$inferSelect;
 export type NewRateLimit = typeof rateLimits.$inferInsert;
@@ -539,3 +604,9 @@ export const IN_PROGRESS_STATUSES: SummaryStatus[] = [
   "running",
   "summarizing",
 ];
+
+export type UserQueueItem = typeof userQueueItems.$inferSelect;
+export type NewUserQueueItem = typeof userQueueItems.$inferInsert;
+
+export type UserPlayerSession = typeof userPlayerSession.$inferSelect;
+export type NewUserPlayerSession = typeof userPlayerSession.$inferInsert;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -610,3 +610,43 @@ export type NewUserQueueItem = typeof userQueueItems.$inferInsert;
 
 export type UserPlayerSession = typeof userPlayerSession.$inferSelect;
 export type NewUserPlayerSession = typeof userPlayerSession.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// Denormalization bridge check (ADR-036)
+//
+// `user_queue_items` and `user_player_session` intentionally denormalize the
+// episode metadata instead of joining to `episodes`. ADR-036 accepts cosmetic
+// drift on retitle — but silently losing a field when someone adds one to
+// `AudioEpisode` without adding a column is not acceptable. The type-level
+// assertion below fails the build if the denormalized columns stop being a
+// superset of `AudioEpisode` (key-wise; column nullability does not have to
+// match `?` optionality).
+// ---------------------------------------------------------------------------
+
+type _AudioEpisodeNonIdKeys = keyof Omit<
+  import("@/lib/schemas/listening-queue").AudioEpisode,
+  "id"
+>;
+
+type _QueueDenormKeys = keyof Omit<
+  UserQueueItem,
+  "id" | "userId" | "position" | "updatedAt" | "episodeId"
+>;
+
+type _SessionDenormKeys = keyof Omit<
+  UserPlayerSession,
+  "userId" | "episodeId" | "currentTime" | "updatedAt"
+>;
+
+type _Assert<T extends true> = T;
+type _KeysMatch<A, B> = [A, B] extends [B, A] ? true : false;
+
+// If either of these fails to compile, the denormalized columns and
+// AudioEpisode have drifted. Fix by adding/removing a column on
+// user_queue_items / user_player_session to match AudioEpisode's shape.
+export type _QueueDenormInvariant = _Assert<
+  _KeysMatch<_QueueDenormKeys, _AudioEpisodeNonIdKeys>
+>;
+export type _SessionDenormInvariant = _Assert<
+  _KeysMatch<_SessionDenormKeys, _AudioEpisodeNonIdKeys>
+>;

--- a/src/hooks/__tests__/use-pwa-install.test.ts
+++ b/src/hooks/__tests__/use-pwa-install.test.ts
@@ -18,6 +18,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { usePwaInstall } from "@/hooks/use-pwa-install";
+import { createLocalStorageMock } from "@/test/mocks/local-storage";
 
 function createMockMatchMedia(overrides: Record<string, boolean> = {}) {
   return (query: string): MediaQueryList => ({
@@ -43,27 +44,6 @@ function fireBeforeInstallPrompt(): BeforeInstallPromptEvent {
   Object.defineProperty(event, "platforms", { value: ["web"] });
   window.dispatchEvent(event);
   return event;
-}
-
-// Simple in-memory localStorage mock that has all standard methods
-function createLocalStorageMock(): Storage {
-  const store: Record<string, string> = {};
-  return {
-    getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => {
-      store[key] = value;
-    },
-    removeItem: (key: string) => {
-      delete store[key];
-    },
-    clear: () => {
-      for (const key of Object.keys(store)) delete store[key];
-    },
-    get length() {
-      return Object.keys(store).length;
-    },
-    key: (index: number) => Object.keys(store)[index] ?? null,
-  };
 }
 
 describe("usePwaInstall", () => {

--- a/src/hooks/__tests__/use-pwa-install.test.ts
+++ b/src/hooks/__tests__/use-pwa-install.test.ts
@@ -18,7 +18,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { usePwaInstall } from "@/hooks/use-pwa-install";
-import { createLocalStorageMock } from "@/test/mocks/local-storage";
+import { installLocalStorageMock } from "@/test/mocks/local-storage";
 
 function createMockMatchMedia(overrides: Record<string, boolean> = {}) {
   return (query: string): MediaQueryList => ({
@@ -55,11 +55,7 @@ describe("usePwaInstall", () => {
     originalMatchMedia = window.matchMedia;
 
     // Install a proper localStorage mock
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    });
+    installLocalStorageMock();
 
     // Default: not standalone, is mobile
     window.matchMedia = createMockMatchMedia({

--- a/src/lib/__tests__/migration-marker.test.ts
+++ b/src/lib/__tests__/migration-marker.test.ts
@@ -8,15 +8,11 @@ import {
   markSessionMigrated,
   setLastUserId,
 } from "@/lib/migration-marker"
-import { createLocalStorageMock } from "@/test/mocks/local-storage"
+import { installLocalStorageMock } from "@/test/mocks/local-storage"
 
 describe("migration-marker", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("hasQueueMigrated returns false before markQueueMigrated", () => {

--- a/src/lib/__tests__/migration-marker.test.ts
+++ b/src/lib/__tests__/migration-marker.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  clearAllUserLocalData,
+  getLastUserId,
+  hasQueueMigrated,
+  hasSessionMigrated,
+  markQueueMigrated,
+  markSessionMigrated,
+  setLastUserId,
+} from "@/lib/migration-marker"
+
+function createLocalStorageMock(): Storage {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) delete store[key]
+    },
+    get length() {
+      return Object.keys(store).length
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+}
+
+describe("migration-marker", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: createLocalStorageMock(),
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it("hasQueueMigrated returns false before markQueueMigrated", () => {
+    expect(hasQueueMigrated("u1")).toBe(false)
+    markQueueMigrated("u1")
+    expect(hasQueueMigrated("u1")).toBe(true)
+  })
+
+  it("markQueueMigrated is scoped per user", () => {
+    markQueueMigrated("u1")
+    expect(hasQueueMigrated("u1")).toBe(true)
+    expect(hasQueueMigrated("u2")).toBe(false)
+  })
+
+  it("markSessionMigrated is independent from markQueueMigrated", () => {
+    markQueueMigrated("u1")
+    expect(hasSessionMigrated("u1")).toBe(false)
+    markSessionMigrated("u1")
+    expect(hasSessionMigrated("u1")).toBe(true)
+  })
+
+  it("getLastUserId roundtrips via setLastUserId", () => {
+    expect(getLastUserId()).toBeNull()
+    setLastUserId("u1")
+    expect(getLastUserId()).toBe("u1")
+    setLastUserId("u2")
+    expect(getLastUserId()).toBe("u2")
+  })
+
+  it("clearAllUserLocalData wipes queue, session, last-user-id, and every marker", () => {
+    window.localStorage.setItem("contentgenie-player-queue", "[]")
+    window.localStorage.setItem("contentgenie-player-session", "{}")
+    setLastUserId("u1")
+    markQueueMigrated("u1")
+    markSessionMigrated("u1")
+    markQueueMigrated("u2")
+    // Keep an unrelated key — should NOT be wiped.
+    window.localStorage.setItem("unrelated-key", "keep")
+
+    clearAllUserLocalData()
+
+    expect(window.localStorage.getItem("contentgenie-player-queue")).toBeNull()
+    expect(window.localStorage.getItem("contentgenie-player-session")).toBeNull()
+    expect(getLastUserId()).toBeNull()
+    expect(hasQueueMigrated("u1")).toBe(false)
+    expect(hasSessionMigrated("u1")).toBe(false)
+    expect(hasQueueMigrated("u2")).toBe(false)
+    expect(window.localStorage.getItem("unrelated-key")).toBe("keep")
+  })
+})

--- a/src/lib/__tests__/migration-marker.test.ts
+++ b/src/lib/__tests__/migration-marker.test.ts
@@ -8,26 +8,7 @@ import {
   markSessionMigrated,
   setLastUserId,
 } from "@/lib/migration-marker"
-
-function createLocalStorageMock(): Storage {
-  const store: Record<string, string> = {}
-  return {
-    getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => {
-      store[key] = value
-    },
-    removeItem: (key: string) => {
-      delete store[key]
-    },
-    clear: () => {
-      for (const key of Object.keys(store)) delete store[key]
-    },
-    get length() {
-      return Object.keys(store).length
-    },
-    key: (index: number) => Object.keys(store)[index] ?? null,
-  }
-}
+import { createLocalStorageMock } from "@/test/mocks/local-storage"
 
 describe("migration-marker", () => {
   beforeEach(() => {

--- a/src/lib/__tests__/player-session.test.ts
+++ b/src/lib/__tests__/player-session.test.ts
@@ -6,8 +6,9 @@ import {
 } from "@/lib/player-session"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
-  createLocalStorageMock,
   installLocalStorageMock,
+  installQuotaExceededLocalStorage,
+  withoutWindow,
 } from "@/test/mocks/local-storage"
 import { validEpisode } from "@/test/fixtures/audio-episode"
 
@@ -176,14 +177,9 @@ describe("loadPlayerSession", () => {
   })
 
   it("returns null in SSR environment", () => {
-    const originalWindow = globalThis.window
-    try {
-      // @ts-expect-error -- simulating SSR
-      delete globalThis.window
+    withoutWindow(() => {
       expect(loadPlayerSession()).toBeNull()
-    } finally {
-      globalThis.window = originalWindow
-    }
+    })
   })
 
   it("returns null when artwork is invalid (non-string)", () => {
@@ -296,27 +292,14 @@ describe("savePlayerSession", () => {
   })
 
   it("handles quota exceeded error gracefully", () => {
-    const mockStorage = createLocalStorageMock()
-    mockStorage.setItem = () => {
-      throw new DOMException("QuotaExceededError")
-    }
-    Object.defineProperty(window, "localStorage", {
-      value: mockStorage,
-      writable: true,
-      configurable: true,
-    })
+    installQuotaExceededLocalStorage()
     expect(() => savePlayerSession(validEpisode, 300)).not.toThrow()
   })
 
   it("does nothing in SSR environment", () => {
-    const originalWindow = globalThis.window
-    try {
-      // @ts-expect-error -- simulating SSR
-      delete globalThis.window
+    withoutWindow(() => {
       expect(() => savePlayerSession(validEpisode, 300)).not.toThrow()
-    } finally {
-      globalThis.window = originalWindow
-    }
+    })
   })
 })
 
@@ -337,13 +320,8 @@ describe("clearPlayerSession", () => {
   })
 
   it("does nothing in SSR environment", () => {
-    const originalWindow = globalThis.window
-    try {
-      // @ts-expect-error -- simulating SSR
-      delete globalThis.window
+    withoutWindow(() => {
       expect(() => clearPlayerSession()).not.toThrow()
-    } finally {
-      globalThis.window = originalWindow
-    }
+    })
   })
 })

--- a/src/lib/__tests__/player-session.test.ts
+++ b/src/lib/__tests__/player-session.test.ts
@@ -5,6 +5,7 @@ import {
   clearPlayerSession,
 } from "@/lib/player-session"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
+import { createLocalStorageMock } from "@/test/mocks/local-storage"
 
 const validEpisode: AudioEpisode = {
   id: "ep-1",
@@ -16,26 +17,6 @@ const validEpisode: AudioEpisode = {
 }
 
 const STORAGE_KEY = "contentgenie-player-session"
-
-function createLocalStorageMock(): Storage {
-  const store: Record<string, string> = {}
-  return {
-    getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => {
-      store[key] = value
-    },
-    removeItem: (key: string) => {
-      delete store[key]
-    },
-    clear: () => {
-      for (const key of Object.keys(store)) delete store[key]
-    },
-    get length() {
-      return Object.keys(store).length
-    },
-    key: (index: number) => Object.keys(store)[index] ?? null,
-  }
-}
 
 function storeSession(
   episode: AudioEpisode,

--- a/src/lib/__tests__/player-session.test.ts
+++ b/src/lib/__tests__/player-session.test.ts
@@ -5,16 +5,11 @@ import {
   clearPlayerSession,
 } from "@/lib/player-session"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
-import { createLocalStorageMock } from "@/test/mocks/local-storage"
-
-const validEpisode: AudioEpisode = {
-  id: "ep-1",
-  title: "Test Episode",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio.mp3",
-  artwork: "https://example.com/art.jpg",
-  duration: 600,
-}
+import {
+  createLocalStorageMock,
+  installLocalStorageMock,
+} from "@/test/mocks/local-storage"
+import { validEpisode } from "@/test/fixtures/audio-episode"
 
 const STORAGE_KEY = "contentgenie-player-session"
 
@@ -35,11 +30,7 @@ function storeSession(
 
 describe("loadPlayerSession", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("returns null when nothing stored", () => {
@@ -283,11 +274,7 @@ describe("loadPlayerSession", () => {
 
 describe("savePlayerSession", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("saves session to localStorage with correct key", () => {
@@ -335,11 +322,7 @@ describe("savePlayerSession", () => {
 
 describe("clearPlayerSession", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("removes session from localStorage", () => {

--- a/src/lib/__tests__/player-session.test.ts
+++ b/src/lib/__tests__/player-session.test.ts
@@ -187,14 +187,15 @@ describe("loadPlayerSession", () => {
     expect(loadPlayerSession()).toBeNull()
   })
 
-  it("returns null and clears storage when session expired", () => {
-    const expiredAt = Date.now() - 25 * 60 * 60 * 1000 // 25 hours ago
-    storeSession(validEpisode, 120, expiredAt)
-    expect(loadPlayerSession()).toBeNull()
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  it("returns valid session regardless of how old savedAt is (no TTL)", () => {
+    const oldAt = Date.now() - 25 * 60 * 60 * 1000 // 25 hours ago
+    storeSession(validEpisode, 120, oldAt)
+    const result = loadPlayerSession()
+    expect(result).not.toBeNull()
+    expect(result!.currentTime).toBe(120)
   })
 
-  it("returns valid session when savedAt is within 24h", () => {
+  it("returns valid session when savedAt is recent", () => {
     const recentAt = Date.now() - 23 * 60 * 60 * 1000 // 23 hours ago
     storeSession(validEpisode, 120, recentAt)
     const result = loadPlayerSession()

--- a/src/lib/__tests__/queue-persistence.test.ts
+++ b/src/lib/__tests__/queue-persistence.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach } from "vitest"
 import { loadQueue, saveQueue } from "@/lib/queue-persistence"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 import {
-  createLocalStorageMock,
   installLocalStorageMock,
+  installQuotaExceededLocalStorage,
+  withoutWindow,
 } from "@/test/mocks/local-storage"
 import { validEpisode, validEpisode2 } from "@/test/fixtures/audio-episode"
 
@@ -128,14 +129,9 @@ describe("loadQueue", () => {
   })
 
   it("returns empty array in SSR environment", () => {
-    const originalWindow = globalThis.window
-    try {
-      // @ts-expect-error -- simulating SSR
-      delete globalThis.window
+    withoutWindow(() => {
       expect(loadQueue()).toEqual([])
-    } finally {
-      globalThis.window = originalWindow
-    }
+    })
   })
 })
 
@@ -160,26 +156,13 @@ describe("saveQueue", () => {
   })
 
   it("handles quota exceeded error gracefully", () => {
-    const mockStorage = createLocalStorageMock()
-    mockStorage.setItem = () => {
-      throw new DOMException("QuotaExceededError")
-    }
-    Object.defineProperty(window, "localStorage", {
-      value: mockStorage,
-      writable: true,
-      configurable: true,
-    })
+    installQuotaExceededLocalStorage()
     expect(() => saveQueue([validEpisode])).not.toThrow()
   })
 
   it("does nothing in SSR environment", () => {
-    const originalWindow = globalThis.window
-    try {
-      // @ts-expect-error -- simulating SSR
-      delete globalThis.window
+    withoutWindow(() => {
       expect(() => saveQueue([validEpisode])).not.toThrow()
-    } finally {
-      globalThis.window = originalWindow
-    }
+    })
   })
 })

--- a/src/lib/__tests__/queue-persistence.test.ts
+++ b/src/lib/__tests__/queue-persistence.test.ts
@@ -1,31 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { loadQueue, saveQueue } from "@/lib/queue-persistence"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
-import { createLocalStorageMock } from "@/test/mocks/local-storage"
-
-const validEpisode: AudioEpisode = {
-  id: "ep-1",
-  title: "Test Episode",
-  podcastTitle: "Test Podcast",
-  audioUrl: "https://example.com/audio.mp3",
-  artwork: "https://example.com/art.jpg",
-  duration: 600,
-}
-
-const validEpisode2: AudioEpisode = {
-  id: "ep-2",
-  title: "Second Episode",
-  podcastTitle: "Another Podcast",
-  audioUrl: "https://example.com/audio2.mp3",
-}
+import {
+  createLocalStorageMock,
+  installLocalStorageMock,
+} from "@/test/mocks/local-storage"
+import { validEpisode, validEpisode2 } from "@/test/fixtures/audio-episode"
 
 describe("loadQueue", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("returns empty array when nothing stored", () => {
@@ -157,11 +141,7 @@ describe("loadQueue", () => {
 
 describe("saveQueue", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createLocalStorageMock(),
-      writable: true,
-      configurable: true,
-    })
+    installLocalStorageMock()
   })
 
   it("saves queue to localStorage", () => {

--- a/src/lib/__tests__/queue-persistence.test.ts
+++ b/src/lib/__tests__/queue-persistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { loadQueue, saveQueue } from "@/lib/queue-persistence"
 import type { AudioEpisode } from "@/contexts/audio-player-context"
+import { createLocalStorageMock } from "@/test/mocks/local-storage"
 
 const validEpisode: AudioEpisode = {
   id: "ep-1",
@@ -16,26 +17,6 @@ const validEpisode2: AudioEpisode = {
   title: "Second Episode",
   podcastTitle: "Another Podcast",
   audioUrl: "https://example.com/audio2.mp3",
-}
-
-function createLocalStorageMock(): Storage {
-  const store: Record<string, string> = {}
-  return {
-    getItem: (key: string) => store[key] ?? null,
-    setItem: (key: string, value: string) => {
-      store[key] = value
-    },
-    removeItem: (key: string) => {
-      delete store[key]
-    },
-    clear: () => {
-      for (const key of Object.keys(store)) delete store[key]
-    },
-    get length() {
-      return Object.keys(store).length
-    },
-    key: (index: number) => Object.keys(store)[index] ?? null,
-  }
 }
 
 describe("loadQueue", () => {

--- a/src/lib/__tests__/queue-persistence.test.ts
+++ b/src/lib/__tests__/queue-persistence.test.ts
@@ -119,6 +119,38 @@ describe("loadQueue", () => {
     expect(loadQueue()).toEqual([])
   })
 
+  it("accepts items with a valid chaptersUrl string", () => {
+    const withChapters: AudioEpisode = {
+      ...validEpisode,
+      chaptersUrl: "https://example.com/chapters.json",
+    }
+    window.localStorage.setItem(
+      "contentgenie-player-queue",
+      JSON.stringify([withChapters])
+    )
+    const result = loadQueue()
+    expect(result).toHaveLength(1)
+    expect(result[0].chaptersUrl).toBe("https://example.com/chapters.json")
+  })
+
+  it("filters out items with empty-string chaptersUrl", () => {
+    const items = [{ ...validEpisode, chaptersUrl: "" }]
+    window.localStorage.setItem(
+      "contentgenie-player-queue",
+      JSON.stringify(items)
+    )
+    expect(loadQueue()).toEqual([])
+  })
+
+  it("filters out items with non-string chaptersUrl", () => {
+    const items = [{ ...validEpisode, chaptersUrl: 42 }]
+    window.localStorage.setItem(
+      "contentgenie-player-queue",
+      JSON.stringify(items)
+    )
+    expect(loadQueue()).toEqual([])
+  })
+
   it("filters out null items in the array", () => {
     const items = [null, validEpisode, undefined, 42, "string"]
     window.localStorage.setItem(

--- a/src/lib/auth-wrapper.ts
+++ b/src/lib/auth-wrapper.ts
@@ -1,0 +1,31 @@
+/**
+ * Auth-guarded server action wrapper.
+ *
+ * Every server action in the codebase needs the same check: `auth()` returns
+ * a `userId`, and if not we bail with a `{ success: false, error: "Unauthorized" }`
+ * response. Writing that guard manually at every call site is error-prone —
+ * forgetting it in a new action means an unauthenticated request flows into
+ * the DB. Funneling through `withAuthAction` makes the check a type-level
+ * requirement: a server action either wraps its body in `withAuthAction` or
+ * it has to spell the guard out manually (reviewable).
+ *
+ * The wrapper is a plain helper (no `"use server"` directive), so importing
+ * it into an action file doesn't expose it as a server action — only the
+ * module's own exports become server actions.
+ */
+import { auth } from "@clerk/nextjs/server"
+
+type UnauthorizedFailure = { success: false; error: "Unauthorized" }
+
+/**
+ * Runs `fn` with the authenticated `userId`. Returns an `Unauthorized`
+ * failure (matching every action's existing failure shape) when no session
+ * is present, short-circuiting before `fn` executes.
+ */
+export async function withAuthAction<T>(
+  fn: (userId: string) => Promise<T>,
+): Promise<T | UnauthorizedFailure> {
+  const { userId } = await auth()
+  if (!userId) return { success: false, error: "Unauthorized" }
+  return fn(userId)
+}

--- a/src/lib/migration-marker.ts
+++ b/src/lib/migration-marker.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-user localStorage migration markers for the cross-device sync feature.
+ * See ADR-036. Once a user has successfully reconciled with the server, the
+ * "server-empty" state is authoritative: without a marker, a queue cleared on
+ * Device A could be resurrected by Device B's stale localStorage on its next
+ * mount.
+ *
+ * Also tracks the last signed-in user to wipe stale localStorage when a
+ * different user signs in on the same browser (otherwise User A's cached
+ * queue would leak into User B's account on B's first sync).
+ */
+
+const QUEUE_MIGRATED_PREFIX = "contentgenie-queue-migrated-"
+const SESSION_MIGRATED_PREFIX = "contentgenie-session-migrated-"
+const LAST_USER_ID_KEY = "contentgenie-last-user-id"
+
+const QUEUE_STORAGE_KEY = "contentgenie-player-queue"
+const SESSION_STORAGE_KEY = "contentgenie-player-session"
+
+function safeGet(key: string): string | null {
+  if (typeof window === "undefined") return null
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSet(key: string, val: string): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(key, val)
+  } catch {
+    // localStorage unavailable (private mode / quota exceeded) — ignore.
+  }
+}
+
+function safeRemove(key: string): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // ignore
+  }
+}
+
+export function hasQueueMigrated(userId: string): boolean {
+  return safeGet(QUEUE_MIGRATED_PREFIX + userId) === "1"
+}
+
+export function markQueueMigrated(userId: string): void {
+  safeSet(QUEUE_MIGRATED_PREFIX + userId, "1")
+}
+
+export function hasSessionMigrated(userId: string): boolean {
+  return safeGet(SESSION_MIGRATED_PREFIX + userId) === "1"
+}
+
+export function markSessionMigrated(userId: string): void {
+  safeSet(SESSION_MIGRATED_PREFIX + userId, "1")
+}
+
+export function getLastUserId(): string | null {
+  return safeGet(LAST_USER_ID_KEY)
+}
+
+export function setLastUserId(userId: string): void {
+  safeSet(LAST_USER_ID_KEY, userId)
+}
+
+/**
+ * Wipes the queue cache, session cache, last-user-id, and every per-user
+ * migration marker. Called when a different user signs in on the same browser
+ * so we don't carry the previous user's data into the new account.
+ */
+export function clearAllUserLocalData(): void {
+  if (typeof window === "undefined") return
+  try {
+    safeRemove(QUEUE_STORAGE_KEY)
+    safeRemove(SESSION_STORAGE_KEY)
+    safeRemove(LAST_USER_ID_KEY)
+    // Remove all per-user migration markers — iterate in reverse since
+    // removeItem mutates localStorage.length.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i)
+      if (!key) continue
+      if (
+        key.startsWith(QUEUE_MIGRATED_PREFIX) ||
+        key.startsWith(SESSION_MIGRATED_PREFIX)
+      ) {
+        safeRemove(key)
+      }
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/player-session.ts
+++ b/src/lib/player-session.ts
@@ -3,8 +3,15 @@
  * Source of truth is the server — see `src/app/actions/player-session.ts`.
  * No TTL: the server has no TTL either. `savedAt` is kept for debugging /
  * cache-invalidation telemetry only.
+ *
+ * Episode validation is delegated to `audioEpisodeSchema` so the cache and
+ * the server agree on shape (see ADR-036).
  */
-import type { AudioEpisode } from "@/contexts/audio-player-context"
+import { z } from "zod"
+import {
+  audioEpisodeSchema,
+  type AudioEpisode,
+} from "@/lib/schemas/listening-queue"
 
 const STORAGE_KEY = "contentgenie-player-session"
 
@@ -14,57 +21,13 @@ interface PlayerSession {
   savedAt: number
 }
 
-function isValidSession(data: unknown): data is PlayerSession {
-  if (typeof data !== "object" || data === null) return false
-  const obj = data as Record<string, unknown>
-
-  const ep = obj.episode
-  if (typeof ep !== "object" || ep === null) return false
-  const episode = ep as Record<string, unknown>
-
-  const requiredFields = ["id", "title", "podcastTitle", "audioUrl"] as const
-  if (
-    !requiredFields.every(
-      (field) => typeof episode[field] === "string" && episode[field] !== ""
-    )
-  ) {
-    return false
-  }
-
-  if (Object.hasOwn(episode, "artwork") && episode.artwork !== undefined) {
-    if (typeof episode.artwork !== "string" || episode.artwork === "") return false
-  }
-  if (Object.hasOwn(episode, "duration") && episode.duration !== undefined) {
-    if (
-      typeof episode.duration !== "number" ||
-      !Number.isFinite(episode.duration) ||
-      episode.duration < 0
-    )
-      return false
-  }
-  if (Object.hasOwn(episode, "chaptersUrl") && episode.chaptersUrl !== undefined) {
-    if (typeof episode.chaptersUrl !== "string" || episode.chaptersUrl === "")
-      return false
-  }
-
-  if (
-    typeof obj.currentTime !== "number" ||
-    !Number.isFinite(obj.currentTime) ||
-    obj.currentTime < 0
-  ) {
-    return false
-  }
-
-  if (
-    typeof obj.savedAt !== "number" ||
-    !Number.isFinite(obj.savedAt) ||
-    obj.savedAt <= 0
-  ) {
-    return false
-  }
-
-  return true
-}
+const storedSessionSchema = z
+  .object({
+    episode: audioEpisodeSchema,
+    currentTime: z.number().nonnegative().finite(),
+    savedAt: z.number().positive().finite(),
+  })
+  .strip()
 
 export function loadPlayerSession(): {
   episode: AudioEpisode
@@ -77,12 +40,16 @@ export function loadPlayerSession(): {
     if (!raw) return null
 
     const parsed: unknown = JSON.parse(raw)
-    if (!isValidSession(parsed)) {
+    const result = storedSessionSchema.safeParse(parsed)
+    if (!result.success) {
       clearPlayerSession()
       return null
     }
 
-    return { episode: parsed.episode, currentTime: parsed.currentTime }
+    return {
+      episode: result.data.episode,
+      currentTime: result.data.currentTime,
+    }
   } catch {
     clearPlayerSession()
     return null

--- a/src/lib/player-session.ts
+++ b/src/lib/player-session.ts
@@ -15,12 +15,6 @@ import {
 
 const STORAGE_KEY = "contentgenie-player-session"
 
-interface PlayerSession {
-  episode: AudioEpisode
-  currentTime: number
-  savedAt: number
-}
-
 const storedSessionSchema = z
   .object({
     episode: audioEpisodeSchema,
@@ -28,6 +22,8 @@ const storedSessionSchema = z
     savedAt: z.number().positive().finite(),
   })
   .strip()
+
+type PlayerSession = z.infer<typeof storedSessionSchema>
 
 export function loadPlayerSession(): {
   episode: AudioEpisode

--- a/src/lib/player-session.ts
+++ b/src/lib/player-session.ts
@@ -10,6 +10,7 @@
 import { z } from "zod"
 import {
   audioEpisodeSchema,
+  MAX_TIME_SECONDS,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -18,7 +19,9 @@ const STORAGE_KEY = "contentgenie-player-session"
 const storedSessionSchema = z
   .object({
     episode: audioEpisodeSchema,
-    currentTime: z.number().nonnegative().finite(),
+    // Cap matches `savePlayerSessionSchema` so a tampered localStorage value
+    // can't hydrate locally and then fail the next server sync.
+    currentTime: z.number().nonnegative().finite().max(MAX_TIME_SECONDS),
     savedAt: z.number().nonnegative().finite().optional(),
   })
   .strip()

--- a/src/lib/player-session.ts
+++ b/src/lib/player-session.ts
@@ -1,7 +1,12 @@
+/**
+ * localStorage cache for the player session (resume position).
+ * Source of truth is the server — see `src/app/actions/player-session.ts`.
+ * No TTL: the server has no TTL either. `savedAt` is kept for debugging /
+ * cache-invalidation telemetry only.
+ */
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 
 const STORAGE_KEY = "contentgenie-player-session"
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 
 interface PlayerSession {
   episode: AudioEpisode
@@ -13,7 +18,6 @@ function isValidSession(data: unknown): data is PlayerSession {
   if (typeof data !== "object" || data === null) return false
   const obj = data as Record<string, unknown>
 
-  // Validate episode
   const ep = obj.episode
   if (typeof ep !== "object" || ep === null) return false
   const episode = ep as Record<string, unknown>
@@ -27,11 +31,10 @@ function isValidSession(data: unknown): data is PlayerSession {
     return false
   }
 
-  // Validate optional episode fields
-  if ("artwork" in episode && episode.artwork !== undefined) {
+  if (Object.hasOwn(episode, "artwork") && episode.artwork !== undefined) {
     if (typeof episode.artwork !== "string" || episode.artwork === "") return false
   }
-  if ("duration" in episode && episode.duration !== undefined) {
+  if (Object.hasOwn(episode, "duration") && episode.duration !== undefined) {
     if (
       typeof episode.duration !== "number" ||
       !Number.isFinite(episode.duration) ||
@@ -39,12 +42,11 @@ function isValidSession(data: unknown): data is PlayerSession {
     )
       return false
   }
-  if ("chaptersUrl" in episode && episode.chaptersUrl !== undefined) {
+  if (Object.hasOwn(episode, "chaptersUrl") && episode.chaptersUrl !== undefined) {
     if (typeof episode.chaptersUrl !== "string" || episode.chaptersUrl === "")
       return false
   }
 
-  // Validate currentTime
   if (
     typeof obj.currentTime !== "number" ||
     !Number.isFinite(obj.currentTime) ||
@@ -53,7 +55,6 @@ function isValidSession(data: unknown): data is PlayerSession {
     return false
   }
 
-  // Validate savedAt
   if (
     typeof obj.savedAt !== "number" ||
     !Number.isFinite(obj.savedAt) ||
@@ -61,9 +62,6 @@ function isValidSession(data: unknown): data is PlayerSession {
   ) {
     return false
   }
-
-  // TTL check
-  if (Date.now() - obj.savedAt >= SESSION_TTL_MS) return false
 
   return true
 }

--- a/src/lib/player-session.ts
+++ b/src/lib/player-session.ts
@@ -19,7 +19,7 @@ const storedSessionSchema = z
   .object({
     episode: audioEpisodeSchema,
     currentTime: z.number().nonnegative().finite(),
-    savedAt: z.number().positive().finite(),
+    savedAt: z.number().nonnegative().finite().optional(),
   })
   .strip()
 

--- a/src/lib/queue-persistence.ts
+++ b/src/lib/queue-persistence.ts
@@ -3,40 +3,18 @@
  * Source of truth is the server — see `src/app/actions/listening-queue.ts`.
  * This module is write-through cache only: reads hydrate the UI instantly on
  * mount; writes are a best-effort local mirror of the server state.
+ *
+ * Validation is delegated to `audioEpisodeSchema` so the cache and the server
+ * agree on shape. An item that fails the cache check would also fail the
+ * server Zod — dropping it early prevents a stale localStorage queue from
+ * silently failing the migration upload (see ADR-036).
  */
-import type { AudioEpisode } from "@/contexts/audio-player-context"
+import {
+  audioEpisodeSchema,
+  type AudioEpisode,
+} from "@/lib/schemas/listening-queue"
 
 const STORAGE_KEY = "contentgenie-player-queue"
-
-const REQUIRED_FIELDS: (keyof AudioEpisode)[] = [
-  "id",
-  "title",
-  "podcastTitle",
-  "audioUrl",
-]
-
-function isValidQueueItem(item: unknown): item is AudioEpisode {
-  if (typeof item !== "object" || item === null) return false
-  const obj = item as Record<string, unknown>
-  if (
-    !REQUIRED_FIELDS.every(
-      (field) => typeof obj[field] === "string" && obj[field] !== ""
-    )
-  ) {
-    return false
-  }
-  // Validate optional fields from untrusted localStorage
-  if (Object.hasOwn(obj, "artwork") && obj.artwork !== undefined) {
-    if (typeof obj.artwork !== "string" || obj.artwork === "") return false
-  }
-  if (Object.hasOwn(obj, "duration") && obj.duration !== undefined) {
-    if (typeof obj.duration !== "number" || !Number.isFinite(obj.duration) || obj.duration < 0) return false
-  }
-  if (Object.hasOwn(obj, "chaptersUrl") && obj.chaptersUrl !== undefined) {
-    if (typeof obj.chaptersUrl !== "string" || obj.chaptersUrl === "") return false
-  }
-  return true
-}
 
 export function loadQueue(): AudioEpisode[] {
   if (typeof window === "undefined") return []
@@ -48,14 +26,17 @@ export function loadQueue(): AudioEpisode[] {
     const parsed: unknown = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
 
-    const validItems = parsed.filter(isValidQueueItem)
-    // De-duplicate by ID (keep first occurrence) to prevent dnd-kit key conflicts
     const seen = new Set<string>()
-    return validItems.filter((item) => {
-      if (seen.has(item.id)) return false
-      seen.add(item.id)
-      return true
-    })
+    const valid: AudioEpisode[] = []
+    for (const item of parsed) {
+      const result = audioEpisodeSchema.safeParse(item)
+      if (!result.success) continue
+      // De-duplicate by ID (keep first occurrence) to prevent dnd-kit key conflicts
+      if (seen.has(result.data.id)) continue
+      seen.add(result.data.id)
+      valid.push(result.data)
+    }
+    return valid
   } catch {
     return []
   }

--- a/src/lib/queue-persistence.ts
+++ b/src/lib/queue-persistence.ts
@@ -1,11 +1,13 @@
+/**
+ * localStorage cache for the listening queue.
+ * Source of truth is the server — see `src/app/actions/listening-queue.ts`.
+ * This module is write-through cache only: reads hydrate the UI instantly on
+ * mount; writes are a best-effort local mirror of the server state.
+ */
 import type { AudioEpisode } from "@/contexts/audio-player-context"
 
 const STORAGE_KEY = "contentgenie-player-queue"
 
-/**
- * Required fields every queue item must have.
- * Items missing any of these are silently dropped.
- */
 const REQUIRED_FIELDS: (keyof AudioEpisode)[] = [
   "id",
   "title",
@@ -24,11 +26,14 @@ function isValidQueueItem(item: unknown): item is AudioEpisode {
     return false
   }
   // Validate optional fields from untrusted localStorage
-  if ("artwork" in obj && obj.artwork !== undefined) {
+  if (Object.hasOwn(obj, "artwork") && obj.artwork !== undefined) {
     if (typeof obj.artwork !== "string" || obj.artwork === "") return false
   }
-  if ("duration" in obj && obj.duration !== undefined) {
+  if (Object.hasOwn(obj, "duration") && obj.duration !== undefined) {
     if (typeof obj.duration !== "number" || !Number.isFinite(obj.duration) || obj.duration < 0) return false
+  }
+  if (Object.hasOwn(obj, "chaptersUrl") && obj.chaptersUrl !== undefined) {
+    if (typeof obj.chaptersUrl !== "string" || obj.chaptersUrl === "") return false
   }
   return true
 }

--- a/src/lib/queue-persistence.ts
+++ b/src/lib/queue-persistence.ts
@@ -11,6 +11,7 @@
  */
 import {
   audioEpisodeSchema,
+  MAX_QUEUE_ITEMS,
   type AudioEpisode,
 } from "@/lib/schemas/listening-queue"
 
@@ -35,6 +36,9 @@ export function loadQueue(): AudioEpisode[] {
       if (seen.has(result.data.id)) continue
       seen.add(result.data.id)
       valid.push(result.data)
+      // Stop at the shared server cap — otherwise an oversized local queue
+      // would hydrate the UI but fail `setQueue` during migration.
+      if (valid.length >= MAX_QUEUE_ITEMS) break
     }
     return valid
   } catch {

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -1,25 +1,42 @@
 import { z } from "zod";
 
 const trimmedNonEmpty = z.string().trim().min(1).max(500);
-const optionalUrl = z.url().max(2048).optional();
+
+// Restrict URL schemes to http/https so user-supplied payloads can't land
+// javascript:, data:, file:, ftp:, etc. into the denormalized columns.
+const httpsUrl = z.url({ protocol: /^https?$/ }).max(2048);
+const optionalHttpsUrl = httpsUrl.optional();
 
 // Cap duration and currentTime at 1,000,000 seconds (~11.5 days). Keeps Zod
 // rejections semantic rather than bubbling up from the decimal(12,3) column.
 const MAX_TIME_SECONDS = 1_000_000;
+
+// Server queue cap. Shared with `loadQueue()` so localStorage hydration
+// truncates before ever handing off to `setQueue`, which rejects oversized
+// arrays via `queueSchema.max(MAX_QUEUE_ITEMS)`.
+export const MAX_QUEUE_ITEMS = 200;
 
 export const audioEpisodeSchema = z
   .object({
     id: trimmedNonEmpty,
     title: trimmedNonEmpty,
     podcastTitle: trimmedNonEmpty,
-    audioUrl: z.url().max(2048),
-    artwork: optionalUrl,
-    duration: z.number().nonnegative().finite().max(MAX_TIME_SECONDS).optional(),
-    chaptersUrl: optionalUrl,
+    audioUrl: httpsUrl,
+    artwork: optionalHttpsUrl,
+    // Mirror the integer("duration") DB column — fractional seconds would be
+    // silently truncated on insert (or fail, depending on the driver).
+    duration: z.number().int().nonnegative().finite().max(MAX_TIME_SECONDS).optional(),
+    chaptersUrl: optionalHttpsUrl,
   })
   .strip();
 
-export const queueSchema = z.array(audioEpisodeSchema).max(200);
+export const queueSchema = z
+  .array(audioEpisodeSchema)
+  .max(MAX_QUEUE_ITEMS)
+  .refine(
+    (queue) => new Set(queue.map((ep) => ep.id)).size === queue.length,
+    { message: "Queue cannot contain duplicate episodes" },
+  );
 
 export const savePlayerSessionSchema = z
   .object({

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -3,13 +3,15 @@ import { z } from "zod";
 const trimmedNonEmpty = z.string().trim().min(1).max(500);
 
 // Restrict URL schemes to http/https so user-supplied payloads can't land
-// javascript:, data:, file:, ftp:, etc. into the denormalized columns.
-const httpsUrl = z.url({ protocol: /^https?$/ }).max(2048);
-const optionalHttpsUrl = httpsUrl.optional();
+// javascript:, data:, file:, ftp:, etc. into the denormalized columns. HTTP is
+// intentionally allowed because legacy podcast RSS feeds still serve plain-HTTP
+// audio URLs; tightening to HTTPS-only would break playback for those feeds.
+const httpOrHttpsUrl = z.url({ protocol: /^https?$/ }).max(2048);
+const optionalHttpOrHttpsUrl = httpOrHttpsUrl.optional();
 
 // Cap duration and currentTime at 1,000,000 seconds (~11.5 days). Keeps Zod
 // rejections semantic rather than bubbling up from the decimal(12,3) column.
-const MAX_TIME_SECONDS = 1_000_000;
+export const MAX_TIME_SECONDS = 1_000_000;
 
 // Server queue cap. Shared with `loadQueue()` so localStorage hydration
 // truncates before ever handing off to `setQueue`, which rejects oversized
@@ -21,12 +23,12 @@ export const audioEpisodeSchema = z
     id: trimmedNonEmpty,
     title: trimmedNonEmpty,
     podcastTitle: trimmedNonEmpty,
-    audioUrl: httpsUrl,
-    artwork: optionalHttpsUrl,
+    audioUrl: httpOrHttpsUrl,
+    artwork: optionalHttpOrHttpsUrl,
     // Mirror the integer("duration") DB column — fractional seconds would be
     // silently truncated on insert (or fail, depending on the driver).
     duration: z.number().int().nonnegative().finite().max(MAX_TIME_SECONDS).optional(),
-    chaptersUrl: optionalHttpsUrl,
+    chaptersUrl: optionalHttpOrHttpsUrl,
   })
   .strip();
 

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const trimmedNonEmpty = z.string().trim().min(1).max(500);
+const optionalUrl = z.url().max(2048).optional();
+
+export const audioEpisodeSchema = z
+  .object({
+    id: trimmedNonEmpty,
+    title: trimmedNonEmpty,
+    podcastTitle: trimmedNonEmpty,
+    audioUrl: z.url().max(2048),
+    artwork: optionalUrl,
+    duration: z.number().nonnegative().finite().optional(),
+    chaptersUrl: optionalUrl,
+  })
+  .strip();
+
+export const queueSchema = z.array(audioEpisodeSchema).max(200);
+
+export const savePlayerSessionSchema = z
+  .object({
+    episode: audioEpisodeSchema,
+    currentTime: z.number().nonnegative().finite(),
+  })
+  .strip();

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 const trimmedNonEmpty = z.string().trim().min(1).max(500);
 const optionalUrl = z.url().max(2048).optional();
 
+// Cap duration and currentTime at 1,000,000 seconds (~11.5 days). Keeps Zod
+// rejections semantic rather than bubbling up from the decimal(12,3) column.
+const MAX_TIME_SECONDS = 1_000_000;
+
 export const audioEpisodeSchema = z
   .object({
     id: trimmedNonEmpty,
@@ -10,7 +14,7 @@ export const audioEpisodeSchema = z
     podcastTitle: trimmedNonEmpty,
     audioUrl: z.url().max(2048),
     artwork: optionalUrl,
-    duration: z.number().nonnegative().finite().optional(),
+    duration: z.number().nonnegative().finite().max(MAX_TIME_SECONDS).optional(),
     chaptersUrl: optionalUrl,
   })
   .strip();
@@ -20,6 +24,8 @@ export const queueSchema = z.array(audioEpisodeSchema).max(200);
 export const savePlayerSessionSchema = z
   .object({
     episode: audioEpisodeSchema,
-    currentTime: z.number().nonnegative().finite(),
+    currentTime: z.number().nonnegative().finite().max(MAX_TIME_SECONDS),
   })
   .strip();
+
+export type AudioEpisode = z.infer<typeof audioEpisodeSchema>;

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -74,3 +74,21 @@ export function toAudioEpisode(row: EpisodeDenormRow): AudioEpisode {
   if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl;
   return episode;
 }
+
+/**
+ * Reverse of `toAudioEpisode`: flattens an `AudioEpisode` into the
+ * denormalized shape shared by `userQueueItems` and `userPlayerSession`.
+ * Callers spread table-specific extras (`userId`, `position`, `currentTime`,
+ * `updatedAt`) on top.
+ */
+export function toEpisodeDenormRow(ep: AudioEpisode): EpisodeDenormRow {
+  return {
+    episodeId: ep.id,
+    title: ep.title,
+    podcastTitle: ep.podcastTitle,
+    audioUrl: ep.audioUrl,
+    artwork: ep.artwork ?? null,
+    duration: ep.duration ?? null,
+    chaptersUrl: ep.chaptersUrl ?? null,
+  };
+}

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -29,3 +29,31 @@ export const savePlayerSessionSchema = z
   .strip();
 
 export type AudioEpisode = z.infer<typeof audioEpisodeSchema>;
+
+/**
+ * Denormalized row shared by `userQueueItems` and `userPlayerSession`.
+ * The compile-time `_QueueDenormInvariant` / `_SessionDenormInvariant`
+ * assertions in `@/db/schema` guarantee these field sets stay aligned.
+ */
+export interface EpisodeDenormRow {
+  episodeId: string;
+  title: string;
+  podcastTitle: string;
+  audioUrl: string;
+  artwork: string | null;
+  duration: number | null;
+  chaptersUrl: string | null;
+}
+
+export function toAudioEpisode(row: EpisodeDenormRow): AudioEpisode {
+  const episode: AudioEpisode = {
+    id: row.episodeId,
+    title: row.title,
+    podcastTitle: row.podcastTitle,
+    audioUrl: row.audioUrl,
+  };
+  if (row.artwork != null) episode.artwork = row.artwork;
+  if (row.duration != null) episode.duration = row.duration;
+  if (row.chaptersUrl != null) episode.chaptersUrl = row.chaptersUrl;
+  return episode;
+}

--- a/src/test/fixtures/audio-episode.ts
+++ b/src/test/fixtures/audio-episode.ts
@@ -1,0 +1,17 @@
+import type { AudioEpisode } from "@/contexts/audio-player-context"
+
+export const validEpisode: AudioEpisode = {
+  id: "ep-1",
+  title: "Test Episode",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio.mp3",
+  artwork: "https://example.com/art.jpg",
+  duration: 600,
+}
+
+export const validEpisode2: AudioEpisode = {
+  id: "ep-2",
+  title: "Test Episode 2",
+  podcastTitle: "Test Podcast",
+  audioUrl: "https://example.com/audio2.mp3",
+}

--- a/src/test/mocks/local-storage.ts
+++ b/src/test/mocks/local-storage.ts
@@ -7,22 +7,24 @@
  * `window.localStorage` with a fresh instance of this mock per test.
  */
 export function createLocalStorageMock(): Storage {
-  const store: Record<string, string> = {}
+  // Map (not plain object) so inherited prototype keys like `toString` can't
+  // be returned from getItem/length/key, and `__proto__` stays immutable.
+  const store = new Map<string, string>()
   return {
-    getItem: (key: string) => store[key] ?? null,
+    getItem: (key: string) => store.get(key) ?? null,
     setItem: (key: string, value: string) => {
-      store[key] = value
+      store.set(key, value)
     },
     removeItem: (key: string) => {
-      delete store[key]
+      store.delete(key)
     },
     clear: () => {
-      for (const key of Object.keys(store)) delete store[key]
+      store.clear()
     },
     get length() {
-      return Object.keys(store).length
+      return store.size
     },
-    key: (index: number) => Object.keys(store)[index] ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
   }
 }
 
@@ -49,7 +51,9 @@ export function installLocalStorageMock(): Storage {
 export function installQuotaExceededLocalStorage(): Storage {
   const mock = createLocalStorageMock()
   mock.setItem = () => {
-    throw new DOMException("QuotaExceededError")
+    // Pass the error name as the second argument so `error.name ===
+    // "QuotaExceededError"` checks in production code match.
+    throw new DOMException("Quota exceeded", "QuotaExceededError")
   }
   Object.defineProperty(window, "localStorage", {
     value: mock,

--- a/src/test/mocks/local-storage.ts
+++ b/src/test/mocks/local-storage.ts
@@ -25,3 +25,18 @@ export function createLocalStorageMock(): Storage {
     key: (index: number) => Object.keys(store)[index] ?? null,
   }
 }
+
+/**
+ * Install a fresh in-memory localStorage mock on `window`. Returns the mock
+ * so callers can further customize it (e.g. make `setItem` throw for a quota
+ * test). Use in `beforeEach` to guarantee an isolated storage per case.
+ */
+export function installLocalStorageMock(): Storage {
+  const mock = createLocalStorageMock()
+  Object.defineProperty(window, "localStorage", {
+    value: mock,
+    writable: true,
+    configurable: true,
+  })
+  return mock
+}

--- a/src/test/mocks/local-storage.ts
+++ b/src/test/mocks/local-storage.ts
@@ -1,0 +1,27 @@
+/**
+ * In-memory `Storage` mock for tests that install a fresh localStorage per
+ * case (via `Object.defineProperty(window, "localStorage", ...)`).
+ *
+ * jsdom ships a real localStorage, but its state persists across tests in
+ * the same worker. Test files that want deterministic isolation replace
+ * `window.localStorage` with a fresh instance of this mock per test.
+ */
+export function createLocalStorageMock(): Storage {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) delete store[key]
+    },
+    get length() {
+      return Object.keys(store).length
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  }
+}

--- a/src/test/mocks/local-storage.ts
+++ b/src/test/mocks/local-storage.ts
@@ -40,3 +40,36 @@ export function installLocalStorageMock(): Storage {
   })
   return mock
 }
+
+/**
+ * Install a localStorage mock whose `setItem` always throws
+ * `QuotaExceededError`. Use to verify that save-side code handles quota
+ * gracefully without throwing.
+ */
+export function installQuotaExceededLocalStorage(): Storage {
+  const mock = createLocalStorageMock()
+  mock.setItem = () => {
+    throw new DOMException("QuotaExceededError")
+  }
+  Object.defineProperty(window, "localStorage", {
+    value: mock,
+    writable: true,
+    configurable: true,
+  })
+  return mock
+}
+
+/**
+ * Run `fn` with `globalThis.window` temporarily removed, simulating SSR.
+ * Restores the original `window` even if `fn` throws.
+ */
+export function withoutWindow(fn: () => void): void {
+  const originalWindow = globalThis.window
+  try {
+    // @ts-expect-error -- simulating SSR
+    delete globalThis.window
+    fn()
+  } finally {
+    globalThis.window = originalWindow
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,20 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+
+// Clear localStorage between tests so per-user migration markers, cached
+// queue/session blobs, and other persisted state can't leak across tests in
+// the same worker. Some test files install their own mock localStorage via
+// `Object.defineProperty(window, "localStorage", ...)`; this guard only
+// touches the currently-installed storage, whichever that is.
+beforeEach(() => {
+  try {
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.clear();
+    }
+  } catch {
+    // ignore — some tests install a read-only or missing-clear mock
+  }
+});
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({


### PR DESCRIPTION
## Summary

- Server-backed cross-device sync for the listening queue and currently-playing episode/position. `localStorage` is retained as an instant-hydration cache; the server is now the source of truth.
- Two new Drizzle tables (`user_queue_items`, `user_player_session`) with denormalized episode fields (per ADR-036). Three server actions per resource: `getQueue` / `setQueue` / `clearQueue` and `getPlayerSession` / `savePlayerSession` / `clearPlayerSession`. `setQueue` is the only queue mutation path (replace-all, last-commit-wins).
- `audio-player-context` refactor: parallel hydration, 1500ms trailing-edge debounced `setQueue` writes, 200ms focus/visibility refetch, pending-write guard (covers both normal writes and the one-time localStorage → server migration race), never-rewind-active-playback guard on every reconcile path, `lastAckedQueue` rollback with toast on server failure.
- ADR-036 captures the architectural choice and supersedes ADR-014.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 1804/1804 pass, zero regressions
- [x] `bun run build` succeeds
- [x] `bun run db:generate` — additive only (migration `0020_wooden_darkstar.sql`: 2 CREATE TABLE, 2 unique indexes, 2 FKs with ON DELETE CASCADE)
- [x] Coverage: `listening-queue.ts` 97.67% lines / 95.45% branch; `player-session.ts` 97.43% lines / 75% branch
- [x] Context tests cover: mount-time parallel fetch ordering, migration path, migration-race guard, never-rewind guard, pending-write guard, `lastAckedQueue` rollback, session server-write on 5s throttle, paused-seek reconcile, different-episode reconcile
- [ ] Manual cross-device verification (two browsers, same Clerk user, queue + resume-position round-trip) — to run before production deploy

## Post-merge

- Run `doppler run --config prd -- bunx drizzle-kit push` against the production Neon main branch before the Vercel deploy finalizes (per memory: production schema push is manual).

Closes #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-backed cross-device sync for listening queue and resume state: debounced queue commits, last-write-wins, one‑time local→server migration, focus/visibility refetch, and never‑rewind active playback.

* **Database**
  * Added persistent per‑user queue and player‑session storage with schema migration and snapshot.

* **Documentation**
  * Added ADR documenting cross‑device sync and superseded prior ADR; updated changelog.

* **Tests**
  * Expanded tests for actions, client reconciliation, migration, visibility, persistence, and failure cases.

* **Chores**
  * Added migration‑marker and local cache validation utilities and shared test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->