### PR TITLE
feat: add public episode share pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Cross-device sync for the listening queue and currently-playing episode. Queue and resume-position now round-trip through the server and reconcile on app mount or window focus. Concurrent mutations use last-commit-wins; active playback is never rewound by a server refetch. (#282)
+- Public episode share pages for anonymous viewers at `/episode/[id]`, with a signed-out shell, read-only episode details, share/external links, existing summaries, and sign-up redirects for save/queue/library actions (#293)
 - Trending topic detail page at /trending/<slug> with horizontal topic switcher and ranked episode list sorted by worth-it score (#280)
 - Personal topic overlap indicators — shows contextual labels (e.g. "You've heard 3 similar episodes", "New topic for you") based on listen history and saved episodes. Recommendations deprioritize heavily-consumed topics (#262)
 - `rank-episode-topics` daily Trigger.dev scheduled task (7 AM UTC) that ranks episodes within each topic via exhaustive pairwise LLM comparison; win-count aggregation with worthItScore tiebreaker; adaptive episode cap (10/topic for ≤20 topics, 5/topic for >20); up to 50 topics per run (#261)

--- a/src/app/(episode)/episode/[id]/__tests__/layout.test.tsx
+++ b/src/app/(episode)/episode/[id]/__tests__/layout.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockAuth = vi.fn();
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/components/layout/app-shell", () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/layout/landing-header", () => ({
+  LandingHeader: () => <div data-testid="landing-header" />,
+}));
+
+import EpisodeLayout from "@/app/(episode)/episode/[id]/layout";
+
+describe("EpisodeLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the public shell for anonymous viewers", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const result = await EpisodeLayout({ children: <div>episode content</div> });
+    render(result as React.ReactElement);
+
+    expect(screen.getByTestId("landing-header")).toBeInTheDocument();
+    expect(screen.getByText("episode content")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-shell")).not.toBeInTheDocument();
+  });
+
+  it("renders AppShell for authenticated viewers", async () => {
+    mockAuth.mockResolvedValue({ userId: "user-1" });
+
+    const result = await EpisodeLayout({ children: <div>episode content</div> });
+    render(result as React.ReactElement);
+
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
+    expect(screen.getByText("episode content")).toBeInTheDocument();
+    expect(screen.queryByTestId("landing-header")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(episode)/episode/[id]/__tests__/page.test.tsx
+++ b/src/app/(episode)/episode/[id]/__tests__/page.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockAuth = vi.fn();
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/components/episodes/authenticated-episode-detail", () => ({
+  AuthenticatedEpisodeDetail: ({
+    episodeId,
+    isAdmin,
+    userId,
+  }: {
+    episodeId: string;
+    isAdmin: boolean;
+    userId: string;
+  }) => (
+    <div data-testid="authenticated-episode-detail">
+      auth:{episodeId}:{userId}:{String(isAdmin)}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/episodes/public-episode-detail", () => ({
+  PublicEpisodeDetail: ({ episodeId }: { episodeId: string }) => (
+    <div data-testid="public-episode-detail">public:{episodeId}</div>
+  ),
+}));
+
+import EpisodePage from "@/app/(episode)/episode/[id]/page";
+
+describe("EpisodePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the public detail component for anonymous viewers", async () => {
+    mockAuth.mockResolvedValue({ userId: null, has: () => false });
+
+    render(
+      (await EpisodePage({
+        params: { id: "123" },
+      })) as React.ReactElement
+    );
+
+    expect(screen.getByTestId("public-episode-detail")).toHaveTextContent(
+      "public:123"
+    );
+    expect(
+      screen.queryByTestId("authenticated-episode-detail")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the authenticated detail component for signed-in viewers", async () => {
+    mockAuth.mockResolvedValue({
+      userId: "user-1",
+      has: ({ role }: { role: string }) => role === "org:admin",
+    });
+
+    render(
+      (await EpisodePage({
+        params: { id: "123" },
+      })) as React.ReactElement
+    );
+
+    expect(
+      screen.getByTestId("authenticated-episode-detail")
+    ).toHaveTextContent("auth:123:user-1:true");
+    expect(screen.queryByTestId("public-episode-detail")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(episode)/episode/[id]/layout.tsx
+++ b/src/app/(episode)/episode/[id]/layout.tsx
@@ -1,0 +1,22 @@
+import { auth } from "@clerk/nextjs/server";
+import { LandingHeader } from "@/components/layout/landing-header";
+import { AppShell } from "@/components/layout/app-shell";
+
+export default async function EpisodeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { userId } = await auth();
+
+  if (userId) {
+    return <AppShell>{children}</AppShell>;
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <LandingHeader />
+      <main className="mx-auto max-w-6xl px-4 py-6 sm:px-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(episode)/episode/[id]/page.tsx
+++ b/src/app/(episode)/episode/[id]/page.tsx
@@ -1,0 +1,26 @@
+import { auth } from "@clerk/nextjs/server";
+import { AuthenticatedEpisodeDetail } from "@/components/episodes/authenticated-episode-detail";
+import { PublicEpisodeDetail } from "@/components/episodes/public-episode-detail";
+import { ADMIN_ROLE } from "@/lib/auth-roles";
+
+interface EpisodePageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default async function EpisodePage({ params }: EpisodePageProps) {
+  const { userId, has } = await auth();
+
+  if (!userId) {
+    return <PublicEpisodeDetail episodeId={params.id} />;
+  }
+
+  return (
+    <AuthenticatedEpisodeDetail
+      episodeId={params.id}
+      userId={userId}
+      isAdmin={has?.({ role: ADMIN_ROLE }) ?? false}
+    />
+  );
+}

--- a/src/app/__tests__/middleware.test.ts
+++ b/src/app/__tests__/middleware.test.ts
@@ -90,4 +90,41 @@ describe("middleware", () => {
 
     expect(mockProtect).toHaveBeenCalled();
   });
+
+  it("allows anonymous access to public episode pages", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/episode/123");
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).not.toHaveBeenCalled();
+  });
+
+  it("allows anonymous GET access to the public episode API", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/api/episodes/123", {
+      method: "GET",
+    });
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the summarize API protected for anonymous users", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/api/episodes/summarize", {
+      method: "GET",
+    });
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).toHaveBeenCalled();
+  });
 });

--- a/src/app/__tests__/middleware.test.ts
+++ b/src/app/__tests__/middleware.test.ts
@@ -150,6 +150,19 @@ describe("middleware", () => {
     expect(mockProtect).not.toHaveBeenCalled();
   });
 
+  it("keeps POST requests to the episode API protected", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/api/episodes/123", {
+      method: "POST",
+    });
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).toHaveBeenCalled();
+  });
+
   it("keeps the summarize API protected for anonymous users", async () => {
     const mockProtect = vi.fn();
     vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));

--- a/src/app/__tests__/middleware.test.ts
+++ b/src/app/__tests__/middleware.test.ts
@@ -102,12 +102,47 @@ describe("middleware", () => {
     expect(mockProtect).not.toHaveBeenCalled();
   });
 
+  it("allows anonymous access to public RSS episode pages", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/episode/rss-abc");
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-public episode slugs protected", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/episode/not-a-public-id");
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).toHaveBeenCalled();
+  });
+
   it("allows anonymous GET access to the public episode API", async () => {
     const mockProtect = vi.fn();
     vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
 
     const { default: middleware } = await import("@/middleware");
     const req = new NextRequest("http://localhost:3000/api/episodes/123", {
+      method: "GET",
+    });
+    await middleware(req, stubEvent);
+
+    expect(mockProtect).not.toHaveBeenCalled();
+  });
+
+  it("allows anonymous GET access to the public episode API for rss ids", async () => {
+    const mockProtect = vi.fn();
+    vi.doMock("@clerk/nextjs/server", () => createClerkMock(null, mockProtect));
+
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("http://localhost:3000/api/episodes/rss-abc", {
       method: "GET",
     });
     await middleware(req, stubEvent);

--- a/src/app/api/__tests__/episodes-id.test.ts
+++ b/src/app/api/__tests__/episodes-id.test.ts
@@ -229,6 +229,36 @@ describe("GET /api/episodes/[id]", () => {
     expect(data.retryAfterMs).toBe(120000);
   });
 
+  it("uses the Vercel-forwarded client IP for anonymous rate limiting when present", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+
+    const mockEpisode = { id: 123, title: "Ep", feedId: 456 };
+    const mockPodcast = { id: 456, title: "Pod" };
+    vi.mocked(getEpisodeById).mockResolvedValue({
+      status: "true",
+      episode: mockEpisode as never,
+      description: "",
+    });
+    vi.mocked(getPodcastById).mockResolvedValue({
+      status: "true",
+      feed: mockPodcast as never,
+      description: "",
+    });
+    vi.mocked(db.query.episodes.findFirst).mockResolvedValue(undefined as never);
+
+    const request = new NextRequest("http://localhost:3000/api/episodes/123", {
+      headers: {
+        "x-forwarded-for": "203.0.113.9",
+        "x-real-ip": "203.0.113.10",
+        "x-vercel-forwarded-for": "198.51.100.24",
+      },
+    });
+    const response = await GET(request, { params: { id: "123" } });
+
+    expect(response.status).toBe(200);
+    expect(mockPublicEpisodeRateLimit).toHaveBeenCalledWith("198.51.100.24");
+  });
+
   it("returns 404 when episode not found", async () => {
     vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as never);
 

--- a/src/app/api/__tests__/episodes-id.test.ts
+++ b/src/app/api/__tests__/episodes-id.test.ts
@@ -5,6 +5,10 @@ import { db } from "@/db";
 import { getEpisodeById, getPodcastById } from "@/lib/podcastindex";
 import { GET } from "@/app/api/episodes/[id]/route";
 
+const { mockPublicEpisodeRateLimit } = vi.hoisted(() => ({
+  mockPublicEpisodeRateLimit: vi.fn(),
+}));
+
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),
 }));
@@ -28,9 +32,14 @@ vi.mock("@/lib/podcastindex", () => ({
   getPodcastById: vi.fn(),
 }));
 
+vi.mock("@/lib/rate-limit", () => ({
+  createRateLimitChecker: vi.fn(() => mockPublicEpisodeRateLimit),
+}));
+
 describe("GET /api/episodes/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPublicEpisodeRateLimit.mockResolvedValue({ allowed: true });
   });
 
   afterEach(() => {
@@ -40,15 +49,32 @@ describe("GET /api/episodes/[id]", () => {
     vi.resetModules();
   });
 
-  it("returns 401 when unauthenticated", async () => {
+  it("allows unauthenticated requests for numeric episode IDs", async () => {
     vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+
+    const mockEpisode = { id: 123, title: "Ep", feedId: 456 };
+    const mockPodcast = { id: 456, title: "Pod" };
+    vi.mocked(getEpisodeById).mockResolvedValue({
+      status: "true",
+      episode: mockEpisode as never,
+      description: "",
+    });
+    vi.mocked(getPodcastById).mockResolvedValue({
+      status: "true",
+      feed: mockPodcast as never,
+      description: "",
+    });
+    vi.mocked(db.query.episodes.findFirst).mockResolvedValue(undefined as never);
 
     const request = new NextRequest("http://localhost:3000/api/episodes/123");
     const response = await GET(request, { params: { id: "123" } });
     const data = await response.json();
 
-    expect(response.status).toBe(401);
-    expect(data.error).toBe("Unauthorized");
+    expect(response.status).toBe(200);
+    expect(data.episode).toEqual(mockEpisode);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=600"
+    );
   });
 
   it("returns 400 for non-numeric ID", async () => {
@@ -60,6 +86,67 @@ describe("GET /api/episodes/[id]", () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toBe("Invalid episode ID");
+  });
+
+  it("allows unauthenticated requests for RSS-sourced episode IDs", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+    vi.mocked(db.query.episodes.findFirst).mockResolvedValue({
+      id: 99,
+      title: "RSS Ep",
+      description: "desc",
+      publishDate: new Date("2024-01-01"),
+      audioUrl: "https://example.com/ep.mp3",
+      duration: 3600,
+      podcastId: 5,
+      podcastIndexId: "rss-abc",
+      rssGuid: "guid-123",
+      transcriptSource: "podcastindex",
+      transcriptStatus: "missing",
+      summary: null,
+      processedAt: null,
+      keyTakeaways: [],
+      worthItScore: null,
+      worthItReason: null,
+      worthItDimensions: null,
+      podcast: {
+        podcastIndexId: "rss-abc",
+        title: "RSS Pod",
+        publisher: "Author",
+        imageUrl: "https://example.com/img.png",
+      },
+    } as never);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/episodes/rss-abc"
+    );
+    const response = await GET(request, { params: { id: "rss-abc" } });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.episode.id).toBe("rss-abc");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=600"
+    );
+  });
+
+  it("returns 429 when anonymous requests exceed the public episode rate limit", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+    mockPublicEpisodeRateLimit.mockResolvedValue({
+      allowed: false,
+      retryAfterMs: 120000,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/episodes/123", {
+      headers: {
+        "x-forwarded-for": "203.0.113.9",
+      },
+    });
+    const response = await GET(request, { params: { id: "123" } });
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toMatch(/rate limit/i);
+    expect(data.retryAfterMs).toBe(120000);
   });
 
   it("returns 404 when episode not found", async () => {

--- a/src/app/api/__tests__/episodes-id.test.ts
+++ b/src/app/api/__tests__/episodes-id.test.ts
@@ -77,6 +77,32 @@ describe("GET /api/episodes/[id]", () => {
     );
   });
 
+  it("does not apply shared-cache headers to authenticated numeric episode requests", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as never);
+
+    const mockEpisode = { id: 123, title: "Ep", feedId: 456 };
+    const mockPodcast = { id: 456, title: "Pod" };
+    vi.mocked(getEpisodeById).mockResolvedValue({
+      status: "true",
+      episode: mockEpisode as never,
+      description: "",
+    });
+    vi.mocked(getPodcastById).mockResolvedValue({
+      status: "true",
+      feed: mockPodcast as never,
+      description: "",
+    });
+    vi.mocked(db.query.episodes.findFirst).mockResolvedValue(undefined as never);
+
+    const request = new NextRequest("http://localhost:3000/api/episodes/123");
+    const response = await GET(request, { params: { id: "123" } });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).not.toBe(
+      "public, s-maxage=300, stale-while-revalidate=600"
+    );
+  });
+
   it("returns 400 for non-numeric ID", async () => {
     vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as never);
 
@@ -125,6 +151,45 @@ describe("GET /api/episodes/[id]", () => {
     expect(response.status).toBe(200);
     expect(data.episode.id).toBe("rss-abc");
     expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=300, stale-while-revalidate=600"
+    );
+  });
+
+  it("does not apply shared-cache headers to authenticated RSS episode requests", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as never);
+    vi.mocked(db.query.episodes.findFirst).mockResolvedValue({
+      id: 99,
+      title: "RSS Ep",
+      description: "desc",
+      publishDate: new Date("2024-01-01"),
+      audioUrl: "https://example.com/ep.mp3",
+      duration: 3600,
+      podcastId: 5,
+      podcastIndexId: "rss-abc",
+      rssGuid: "guid-123",
+      transcriptSource: "podcastindex",
+      transcriptStatus: "missing",
+      summary: null,
+      processedAt: null,
+      keyTakeaways: [],
+      worthItScore: null,
+      worthItReason: null,
+      worthItDimensions: null,
+      podcast: {
+        podcastIndexId: "rss-abc",
+        title: "RSS Pod",
+        publisher: "Author",
+        imageUrl: "https://example.com/img.png",
+      },
+    } as never);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/episodes/rss-abc"
+    );
+    const response = await GET(request, { params: { id: "rss-abc" } });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).not.toBe(
       "public, s-maxage=300, stale-while-revalidate=600"
     );
   });

--- a/src/app/api/__tests__/episodes-id.test.ts
+++ b/src/app/api/__tests__/episodes-id.test.ts
@@ -75,6 +75,7 @@ describe("GET /api/episodes/[id]", () => {
     expect(response.headers.get("cache-control")).toBe(
       "public, s-maxage=300, stale-while-revalidate=600"
     );
+    expect(response.headers.get("vary")?.split(/,\s*/)).toContain("Cookie");
   });
 
   it("does not apply shared-cache headers to authenticated numeric episode requests", async () => {
@@ -153,6 +154,20 @@ describe("GET /api/episodes/[id]", () => {
     expect(response.headers.get("cache-control")).toBe(
       "public, s-maxage=300, stale-while-revalidate=600"
     );
+    expect(response.headers.get("vary")?.split(/,\s*/)).toContain("Cookie");
+  });
+
+  it("returns a generic 500 payload without internal error details", async () => {
+    vi.mocked(auth).mockRejectedValue(new Error("Clerk exploded") as never);
+
+    const request = new NextRequest("http://localhost:3000/api/episodes/123");
+    const response = await GET(request, { params: { id: "123" } });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      error: "Failed to fetch episode",
+    });
   });
 
   it("does not apply shared-cache headers to authenticated RSS episode requests", async () => {

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -161,8 +161,14 @@ export async function GET(
     }
 
     // PodcastIndex-sourced episode (existing behavior)
-    const episodeId = parseInt(id, 10);
-    if (isNaN(episodeId)) {
+    if (!/^\d+$/.test(id)) {
+      return NextResponse.json(
+        { error: "Invalid episode ID" },
+        { status: 400 }
+      );
+    }
+    const episodeId = Number(id);
+    if (!Number.isSafeInteger(episodeId)) {
       return NextResponse.json(
         { error: "Invalid episode ID" },
         { status: 400 }

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { episodes, podcasts } from "@/db/schema";
+import { episodes } from "@/db/schema";
 import { getEpisodeById, getPodcastById } from "@/lib/podcastindex";
 import { createRateLimitChecker } from "@/lib/rate-limit";
 

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -18,6 +18,15 @@ function isRssSourced(id: string): boolean {
 }
 
 function getClientIp(request: NextRequest): string {
+  // This route assumes Vercel-managed ingress. Vercel documents that it
+  // overwrites X-Forwarded-For with the client public IP unless Trusted Proxy
+  // is explicitly enabled, and exposes the same value via x-vercel-forwarded-for.
+  const vercelForwardedFor = request.headers.get("x-vercel-forwarded-for");
+  if (vercelForwardedFor) {
+    const firstIp = vercelForwardedFor.split(",")[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
   const forwardedFor = request.headers.get("x-forwarded-for");
   if (forwardedFor) {
     const firstIp = forwardedFor.split(",")[0]?.trim();

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -35,14 +35,22 @@ function withPublicCache(response: NextResponse): NextResponse {
   return response;
 }
 
+function withConditionalPublicCache(
+  response: NextResponse,
+  isAnonymousRequest: boolean
+): NextResponse {
+  return isAnonymousRequest ? withPublicCache(response) : response;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
     const { userId } = await auth();
+    const isAnonymousRequest = !userId;
 
-    if (!userId) {
+    if (isAnonymousRequest) {
       const rateLimit = await checkPublicEpisodeRateLimit(getClientIp(request));
       if (!rateLimit.allowed) {
         return NextResponse.json(
@@ -129,7 +137,7 @@ export async function GET(
         };
       }
 
-      return withPublicCache(
+      return withConditionalPublicCache(
         NextResponse.json({
           episode,
           podcast,
@@ -137,7 +145,8 @@ export async function GET(
           transcriptSource: dbEpisode.transcriptSource ?? null,
           transcriptStatus: dbEpisode.transcriptStatus ?? null,
           episodeDbId: dbEpisode.id,
-        })
+        }),
+        isAnonymousRequest
       );
     }
 
@@ -223,7 +232,7 @@ export async function GET(
       // Continue without cached summary if DB query fails
     }
 
-    return withPublicCache(
+    return withConditionalPublicCache(
       NextResponse.json({
         episode,
         podcast,
@@ -231,7 +240,8 @@ export async function GET(
         transcriptSource,
         transcriptStatus,
         episodeDbId,
-      })
+      }),
+      isAnonymousRequest
     );
   } catch (error) {
     console.error("Error fetching episode:", error);

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -32,6 +32,7 @@ function getClientIp(request: NextRequest): string {
 
 function withPublicCache(response: NextResponse): NextResponse {
   response.headers.set("Cache-Control", PUBLIC_CACHE_CONTROL);
+  response.headers.set("Vary", "Cookie");
   return response;
 }
 
@@ -246,10 +247,7 @@ export async function GET(
   } catch (error) {
     console.error("Error fetching episode:", error);
     return NextResponse.json(
-      {
-        error: "Failed to fetch episode",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
+      { error: "Failed to fetch episode" },
       { status: 500 }
     );
   }

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -63,12 +63,17 @@ export async function GET(
     if (isAnonymousRequest) {
       const rateLimit = await checkPublicEpisodeRateLimit(getClientIp(request));
       if (!rateLimit.allowed) {
+        const retryAfterMs = rateLimit.retryAfterMs ?? 0;
+        const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
         return NextResponse.json(
           {
             error: "Rate limit exceeded. Please try again later.",
-            retryAfterMs: rateLimit.retryAfterMs,
+            retryAfterMs,
           },
-          { status: 429 }
+          {
+            status: 429,
+            headers: { "Retry-After": String(retryAfterSeconds) },
+          }
         );
       }
     }

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -4,9 +4,35 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { episodes, podcasts } from "@/db/schema";
 import { getEpisodeById, getPodcastById } from "@/lib/podcastindex";
+import { createRateLimitChecker } from "@/lib/rate-limit";
+
+const PUBLIC_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600";
+const checkPublicEpisodeRateLimit = createRateLimitChecker({
+  points: 60,
+  duration: 300,
+  keyPrefix: "public-episode-read",
+});
 
 function isRssSourced(id: string): boolean {
   return id.startsWith("rss-");
+}
+
+function getClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const firstIp = forwardedFor.split(",")[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp.trim();
+
+  return "unknown";
+}
+
+function withPublicCache(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", PUBLIC_CACHE_CONTROL);
+  return response;
 }
 
 export async function GET(
@@ -14,10 +40,19 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    // Verify authentication
     const { userId } = await auth();
+
     if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      const rateLimit = await checkPublicEpisodeRateLimit(getClientIp(request));
+      if (!rateLimit.allowed) {
+        return NextResponse.json(
+          {
+            error: "Rate limit exceeded. Please try again later.",
+            retryAfterMs: rateLimit.retryAfterMs,
+          },
+          { status: 429 }
+        );
+      }
     }
 
     const id = params.id;
@@ -94,14 +129,16 @@ export async function GET(
         };
       }
 
-      return NextResponse.json({
-        episode,
-        podcast,
-        summary,
-        transcriptSource: dbEpisode.transcriptSource ?? null,
-        transcriptStatus: dbEpisode.transcriptStatus ?? null,
-        episodeDbId: dbEpisode.id,
-      });
+      return withPublicCache(
+        NextResponse.json({
+          episode,
+          podcast,
+          summary,
+          transcriptSource: dbEpisode.transcriptSource ?? null,
+          transcriptStatus: dbEpisode.transcriptStatus ?? null,
+          episodeDbId: dbEpisode.id,
+        })
+      );
     }
 
     // PodcastIndex-sourced episode (existing behavior)
@@ -186,14 +223,16 @@ export async function GET(
       // Continue without cached summary if DB query fails
     }
 
-    return NextResponse.json({
-      episode,
-      podcast,
-      summary,
-      transcriptSource,
-      transcriptStatus,
-      episodeDbId,
-    });
+    return withPublicCache(
+      NextResponse.json({
+        episode,
+        podcast,
+        summary,
+        transcriptSource,
+        transcriptStatus,
+        episodeDbId,
+      })
+    );
   } catch (error) {
     console.error("Error fetching episode:", error);
     return NextResponse.json(

--- a/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthenticatedEpisodeDetail } from "@/components/episodes/authenticated-episode-detail";
+
+const mocks = vi.hoisted(() => ({
+  useAudioPlayerState: vi.fn(() => ({
+    currentEpisode: null,
+    isPlaying: false,
+  })),
+  useAudioPlayerAPI: vi.fn(() => ({
+    togglePlay: vi.fn(),
+    playEpisode: vi.fn(),
+  })),
+  useRealtimeRun: vi.fn(() => ({ run: null })),
+  useOnlineStatus: vi.fn(() => true),
+  isEpisodeSaved: vi.fn(),
+  getEpisodeTopicOverlap: vi.fn(),
+  cacheEpisode: vi.fn(),
+  getCachedEpisode: vi.fn(),
+}));
+
+vi.mock("@/contexts/audio-player-context", () => ({
+  useAudioPlayerState: mocks.useAudioPlayerState,
+  useAudioPlayerAPI: mocks.useAudioPlayerAPI,
+}));
+
+vi.mock("@trigger.dev/react-hooks", () => ({
+  useRealtimeRun: mocks.useRealtimeRun,
+}));
+
+vi.mock("@/hooks/use-online-status", () => ({
+  useOnlineStatus: mocks.useOnlineStatus,
+}));
+
+vi.mock("@/app/actions/library", () => ({
+  isEpisodeSaved: mocks.isEpisodeSaved,
+  revalidatePodcastPage: vi.fn(),
+}));
+
+vi.mock("@/app/actions/dashboard", () => ({
+  getEpisodeTopicOverlap: mocks.getEpisodeTopicOverlap,
+}));
+
+vi.mock("@/lib/offline-cache", () => ({
+  cacheEpisode: mocks.cacheEpisode,
+  getCachedEpisode: mocks.getCachedEpisode,
+}));
+
+vi.mock("@/components/episodes/save-button", () => ({
+  SaveButton: () => <div data-testid="save-button" />,
+}));
+
+vi.mock("@/components/audio-player/add-to-queue-button", () => ({
+  AddToQueueButton: () => <div data-testid="queue-button" />,
+}));
+
+vi.mock("@/components/ui/share-button", () => ({
+  ShareButton: () => <div data-testid="share-button" />,
+}));
+
+vi.mock("@/components/episodes/community-rating", () => ({
+  CommunityRating: () => <div data-testid="community-rating" />,
+}));
+
+vi.mock("@/components/episodes/episode-transcript-fetch-button", () => ({
+  EpisodeTranscriptFetchButton: () => (
+    <div data-testid="transcript-fetch-button" />
+  ),
+}));
+
+vi.mock("@/components/episodes/summary-display", () => ({
+  SummaryDisplay: ({
+    onGenerateSummary,
+  }: {
+    onGenerateSummary?: () => void;
+  }) => (
+    <div data-testid="summary-display">
+      can-generate:{String(Boolean(onGenerateSummary))}
+    </div>
+  ),
+}));
+
+describe("AuthenticatedEpisodeDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isEpisodeSaved.mockResolvedValue(false);
+    mocks.getEpisodeTopicOverlap.mockResolvedValue({
+      label: null,
+      labelKind: null,
+    });
+    mocks.getCachedEpisode.mockResolvedValue(undefined);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string) => {
+        if (input === "/api/episodes/rss-abc") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              episode: {
+                id: "rss-abc",
+                title: "RSS Episode",
+                description: "Episode description",
+                datePublished: 1711929600,
+                duration: 1800,
+                enclosureUrl: "https://example.com/episode.mp3",
+                episode: 10,
+                episodeType: "full",
+                season: 2,
+                feedId: 456,
+                feedImage: "https://example.com/feed.jpg",
+                image: "https://example.com/episode.jpg",
+                link: "https://publisher.example.com/rss-episode",
+              },
+              podcast: {
+                id: "rss-podcast",
+                title: "RSS Podcast",
+                author: "Podcast Author",
+                ownerName: "Podcast Author",
+                image: "https://example.com/podcast.jpg",
+                artwork: "https://example.com/podcast.jpg",
+                categories: {
+                  1: "AI",
+                },
+              },
+              summary: null,
+              transcriptSource: null,
+              transcriptStatus: null,
+              episodeDbId: 12,
+            }),
+          });
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch call: ${input}`));
+      })
+    );
+  });
+
+  it("hides numeric-only processing actions for rss episodes", async () => {
+    render(
+      <AuthenticatedEpisodeDetail
+        episodeId="rss-abc"
+        userId="user-1"
+        isAdmin={true}
+      />
+    );
+
+    await screen.findByRole("heading", { name: "RSS Episode" });
+
+    expect(fetch).toHaveBeenCalledWith("/api/episodes/rss-abc");
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/episodes/summarize")
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summary-display")).toHaveTextContent(
+        "can-generate:false"
+      );
+    });
+
+    expect(
+      screen.queryByTestId("transcript-fetch-button")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /re-summarize/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/episodes/__tests__/episode-detail-shared.test.ts
+++ b/src/components/episodes/__tests__/episode-detail-shared.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSignUpHref,
+  supportsEpisodeProcessing,
+} from "@/components/episodes/episode-detail-shared";
+
+describe("episode-detail-shared", () => {
+  it("builds sign-up redirects for internal paths", () => {
+    expect(buildSignUpHref("/episode/123")).toBe(
+      "/sign-up?redirect_url=%2Fepisode%2F123"
+    );
+  });
+
+  it("falls back to the bare sign-up page for unsafe redirect targets", () => {
+    expect(buildSignUpHref("https://evil.example")).toBe("/sign-up");
+    expect(buildSignUpHref("//evil.example")).toBe("/sign-up");
+    expect(buildSignUpHref("javascript:alert(1)")).toBe("/sign-up");
+  });
+
+  it("only allows numeric episode ids for processing actions", () => {
+    expect(supportsEpisodeProcessing("123")).toBe(true);
+    expect(supportsEpisodeProcessing("rss-abc")).toBe(false);
+  });
+});

--- a/src/components/episodes/__tests__/public-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/public-episode-detail.test.tsx
@@ -164,4 +164,99 @@ describe("PublicEpisodeDetail", () => {
       screen.getByText(/sign up to request one/i)
     ).toBeInTheDocument();
   });
+
+  it("ignores stale fetch responses after episodeId changes", async () => {
+    type MockEpisodeResponse = {
+      ok: boolean;
+      json: () => Promise<unknown>;
+    };
+
+    let resolveFirstRequest: ((value: MockEpisodeResponse) => void) | null =
+      null;
+    const secondResponse = {
+      ok: true,
+      json: async () => ({
+        episode: {
+          id: 456,
+          title: "Second Episode",
+          description: "Episode description",
+          datePublished: 1711929600,
+          duration: 1800,
+          enclosureUrl: "https://example.com/second-episode.mp3",
+          episode: 11,
+          episodeType: "full",
+          season: 2,
+          feedId: 456,
+          feedImage: "https://example.com/feed.jpg",
+          image: "https://example.com/episode.jpg",
+          link: "https://publisher.example.com/second-episode",
+        },
+        podcast: null,
+        summary: null,
+        transcriptSource: null,
+        transcriptStatus: null,
+        episodeDbId: null,
+      }),
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string) => {
+        if (input === "/api/episodes/123") {
+          return new Promise((resolve) => {
+            resolveFirstRequest = resolve;
+          });
+        }
+
+        if (input === "/api/episodes/456") {
+          return Promise.resolve(secondResponse);
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch call: ${input}`));
+      })
+    );
+
+    const { rerender } = render(<PublicEpisodeDetail episodeId="123" />);
+    rerender(<PublicEpisodeDetail episodeId="456" />);
+
+    await screen.findByRole("heading", { name: "Second Episode" });
+
+    expect(resolveFirstRequest).not.toBeNull();
+
+    resolveFirstRequest!({
+      ok: true,
+      json: async () => ({
+        episode: {
+          id: 123,
+          title: "First Episode",
+          description: "Episode description",
+          datePublished: 1711929600,
+          duration: 1800,
+          enclosureUrl: "https://example.com/first-episode.mp3",
+          episode: 10,
+          episodeType: "full",
+          season: 2,
+          feedId: 456,
+          feedImage: "https://example.com/feed.jpg",
+          image: "https://example.com/episode.jpg",
+          link: "https://publisher.example.com/first-episode",
+        },
+        podcast: null,
+        summary: null,
+        transcriptSource: null,
+        transcriptStatus: null,
+        episodeDbId: null,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Second Episode" })
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: "First Episode" })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/episodes/__tests__/public-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/public-episode-detail.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { PublicEpisodeDetail } from "@/components/episodes/public-episode-detail";
+
+const mockIsEpisodeSaved = vi.fn();
+const mockGetEpisodeTopicOverlap = vi.fn();
+const mockGetEpisodeAverageRating = vi.fn();
+
+vi.mock("@/app/actions/library", () => ({
+  isEpisodeSaved: (...args: unknown[]) => mockIsEpisodeSaved(...args),
+  getEpisodeAverageRating: (...args: unknown[]) =>
+    mockGetEpisodeAverageRating(...args),
+}));
+
+vi.mock("@/app/actions/dashboard", () => ({
+  getEpisodeTopicOverlap: (...args: unknown[]) =>
+    mockGetEpisodeTopicOverlap(...args),
+}));
+
+vi.mock("@/hooks/use-online-status", () => ({
+  useOnlineStatus: () => true,
+}));
+
+describe("PublicEpisodeDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEpisodeAverageRating.mockResolvedValue({
+      averageRating: 4.5,
+      ratingCount: 12,
+      error: null,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string) => {
+        if (input === "/api/episodes/123") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              episode: {
+                id: 123,
+                title: "Public Episode",
+                description: "Episode description",
+                datePublished: 1711929600,
+                duration: 1800,
+                enclosureUrl: "https://example.com/public-episode.mp3",
+                episode: 10,
+                episodeType: "full",
+                season: 2,
+                feedId: 456,
+                feedImage: "https://example.com/feed.jpg",
+                image: "https://example.com/episode.jpg",
+                link: "https://publisher.example.com/public-episode",
+              },
+              podcast: {
+                id: 456,
+                title: "Public Podcast",
+                author: "Podcast Author",
+                ownerName: "Podcast Author",
+                image: "https://example.com/podcast.jpg",
+                artwork: "https://example.com/podcast.jpg",
+                categories: {
+                  1: "AI",
+                  2: "Leadership",
+                },
+              },
+              summary: {
+                summary: "AI summary",
+                keyTakeaways: ["One", "Two"],
+                worthItScore: 8.2,
+                worthItReason: "Worth your time",
+                worthItDimensions: null,
+              },
+              transcriptSource: null,
+              transcriptStatus: null,
+              episodeDbId: null,
+            }),
+          });
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch call: ${input}`));
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the public CTA, standalone audio player, and sign-up redirects without authenticated lookups", async () => {
+    const { container } = render(<PublicEpisodeDetail episodeId="123" />);
+
+    await screen.findByRole("heading", { name: "Public Episode" });
+
+    expect(
+      screen.getByText(/sign up to save episodes and discover more/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /sign up/i })
+    ).toHaveAttribute(
+      "href",
+      "/sign-up?redirect_url=%2Fepisode%2F123"
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Public Podcast" })
+    ).toHaveAttribute("href", "/sign-up?redirect_url=%2Fpodcast%2F456");
+
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    expect(audio).toHaveAttribute(
+      "src",
+      "https://example.com/public-episode.mp3"
+    );
+
+    await waitFor(() => {
+      expect(mockIsEpisodeSaved).not.toHaveBeenCalled();
+      expect(mockGetEpisodeTopicOverlap).not.toHaveBeenCalled();
+    });
+
+    expect(fetch).toHaveBeenCalledWith("/api/episodes/123");
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/episodes/summarize")
+    );
+  });
+
+  it("shows a public summary placeholder when no summary is available", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          episode: {
+            id: 123,
+            title: "Public Episode",
+            description: "Episode description",
+            datePublished: 1711929600,
+            duration: 1800,
+            enclosureUrl: "https://example.com/public-episode.mp3",
+            episode: 10,
+            episodeType: "full",
+            season: 2,
+            feedId: 456,
+            feedImage: "https://example.com/feed.jpg",
+            image: "https://example.com/episode.jpg",
+            link: "https://publisher.example.com/public-episode",
+          },
+          podcast: null,
+          summary: null,
+          transcriptSource: null,
+          transcriptStatus: null,
+          episodeDbId: null,
+        }),
+      })
+    );
+
+    render(<PublicEpisodeDetail episodeId="123" />);
+
+    await screen.findByRole("heading", { name: "Public Episode" });
+    expect(
+      screen.getByText(/summary not yet available/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/sign up to request one/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -58,6 +58,7 @@ import {
   formatTranscriptSource,
   getEpisodeArtworkUrl,
   getSafeEpisodeLink,
+  supportsEpisodeProcessing,
 } from "@/components/episodes/episode-detail-shared";
 
 interface AuthenticatedEpisodeDetailProps {
@@ -89,6 +90,7 @@ export function AuthenticatedEpisodeDetail({
   const [transcriptStatus, setTranscriptStatus] = useState<TranscriptStatus | null>(null);
   const [episodeDbId, setEpisodeDbId] = useState<number | null>(null);
   const [overlapResult, setOverlapResult] = useState<{ label: string | null; labelKind: OverlapLabelKind | null }>({ label: null, labelKind: null });
+  const canRunEpisodeProcessing = supportsEpisodeProcessing(episodeId);
 
   // Realtime subscription to the Trigger.dev run
   const { run } = useRealtimeRun<typeof summarizeEpisode>(runId ?? "", {
@@ -143,7 +145,7 @@ export function AuthenticatedEpisodeDetail({
     try {
       // Fetch episode from PodcastIndex via API
       const response = await fetch(
-        `/api/episodes/${episodeId}`
+        `/api/episodes/${encodeURIComponent(episodeId)}`
       );
       const data = await response.json();
 
@@ -184,28 +186,30 @@ export function AuthenticatedEpisodeDetail({
       } else {
         setSummaryData(null);
         // Check for in-progress or failed summarization run
-        try {
-          const statusResponse = await fetch(
-            `/api/episodes/summarize?episodeId=${episodeId}`
-          );
-          const statusData = await statusResponse.json();
-          if (
-            statusData.runId &&
-            statusData.publicAccessToken &&
-            IN_PROGRESS_STATUSES.includes(statusData.status)
-          ) {
-            setRunId(statusData.runId);
-            setAccessToken(statusData.publicAccessToken);
-            setIsLoadingSummary(true);
-          } else if (statusData.status === "failed") {
-            setSummaryError(
-              statusData.processingError ||
-                "Summary generation failed. Please try again."
+        if (canRunEpisodeProcessing) {
+          try {
+            const statusResponse = await fetch(
+              `/api/episodes/summarize?episodeId=${encodeURIComponent(episodeId)}`
             );
-            setIsLoadingSummary(false);
+            const statusData = await statusResponse.json();
+            if (
+              statusData.runId &&
+              statusData.publicAccessToken &&
+              IN_PROGRESS_STATUSES.includes(statusData.status)
+            ) {
+              setRunId(statusData.runId);
+              setAccessToken(statusData.publicAccessToken);
+              setIsLoadingSummary(true);
+            } else if (statusData.status === "failed") {
+              setSummaryError(
+                statusData.processingError ||
+                  "Summary generation failed. Please try again."
+              );
+              setIsLoadingSummary(false);
+            }
+          } catch (error) {
+            console.warn("Failed to check for in-progress summary run:", error);
           }
-        } catch (error) {
-          console.warn("Failed to check for in-progress summary run:", error);
         }
       }
 
@@ -227,7 +231,7 @@ export function AuthenticatedEpisodeDetail({
     } finally {
       setIsLoadingEpisode(false);
     }
-  }, [episodeId, userId]);
+  }, [canRunEpisodeProcessing, episodeId, userId]);
 
   // Load episode data from cache
   const loadFromCache = useCallback(async () => {
@@ -519,7 +523,7 @@ export function AuthenticatedEpisodeDetail({
             )}
             {episode.season > 0 && <span>Season {episode.season}</span>}
             {/* Admins with no transcript see the fetch button instead */}
-            {!(isAdmin && !transcriptSource) && (
+            {!(isAdmin && canRunEpisodeProcessing && !transcriptSource) && (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -539,7 +543,7 @@ export function AuthenticatedEpisodeDetail({
                 </Tooltip>
               </TooltipProvider>
             )}
-            {isAdmin && (
+            {isAdmin && canRunEpisodeProcessing && (
               <EpisodeTranscriptFetchButton
                 episodeDbId={episodeDbId}
                 podcastIndexId={episodeId}
@@ -662,7 +666,7 @@ export function AuthenticatedEpisodeDetail({
       <div>
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold">AI-Powered Insights</h2>
-          {isAdmin && summaryData?.summary && isOnline && !isLoadingSummary && (
+          {isAdmin && canRunEpisodeProcessing && summaryData?.summary && isOnline && !isLoadingSummary && (
             <Button
               variant="outline"
               size="sm"
@@ -684,7 +688,9 @@ export function AuthenticatedEpisodeDetail({
           currentStep={
             (run?.metadata?.step as SummarizationStep | undefined) ?? null
           }
-          onGenerateSummary={isOnline ? generateSummary : undefined}
+          onGenerateSummary={
+            isOnline && canRunEpisodeProcessing ? generateSummary : undefined
+          }
           overlapLabel={overlapResult.label}
           overlapLabelKind={overlapResult.labelKind}
         />

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { toast } from "sonner";
-import { useAuth } from "@clerk/nextjs";
 import { useRealtimeRun } from "@trigger.dev/react-hooks";
 import {
   ArrowLeft,
@@ -47,84 +46,31 @@ import { useOnlineStatus } from "@/hooks/use-online-status";
 import { OfflineBanner } from "@/components/ui/offline-banner";
 import { cacheEpisode, getCachedEpisode } from "@/lib/offline-cache";
 import { IN_PROGRESS_STATUSES, type TranscriptStatus } from "@/db/schema";
-import { ADMIN_ROLE } from "@/lib/auth-roles";
-import type { WorthItDimensionsData } from "@/lib/openrouter";
 import type { summarizeEpisode } from "@/trigger/summarize-episode";
+import type {
+  EpisodeData,
+  PodcastData,
+  SummaryData,
+} from "@/components/episodes/episode-detail-shared";
+import {
+  formatDuration,
+  formatPublishDate,
+  formatTranscriptSource,
+  getEpisodeArtworkUrl,
+  getSafeEpisodeLink,
+} from "@/components/episodes/episode-detail-shared";
 
-interface EpisodePageProps {
-  params: {
-    id: string;
-  };
+interface AuthenticatedEpisodeDetailProps {
+  episodeId: string;
+  userId: string;
+  isAdmin: boolean;
 }
 
-interface EpisodeData {
-  id: number;
-  title: string;
-  description: string;
-  datePublished: number;
-  duration: number;
-  enclosureUrl: string;
-  episode: number | null;
-  episodeType: string;
-  season: number;
-  feedId: number;
-  feedImage: string;
-  image: string;
-  link: string;
-  chaptersUrl?: string | null;
-}
-
-interface PodcastData {
-  id: number;
-  title: string;
-  author: string;
-  ownerName: string;
-  image: string;
-  artwork: string;
-  categories: Record<string, string>;
-}
-
-interface SummaryData {
-  summary: string;
-  keyTakeaways: string[];
-  worthItScore: number | null;
-  worthItReason?: string;
-  worthItDimensions?: WorthItDimensionsData | null;
-  cached: boolean;
-}
-
-function formatDuration(seconds: number): string {
-  if (!seconds || seconds <= 0) return "Unknown";
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  if (hours > 0) {
-    return `${hours}h ${minutes}m`;
-  }
-  return `${minutes}m`;
-}
-
-function formatTranscriptSource(source: string | null): string {
-  switch (source) {
-    case "podcastindex": return "PodcastIndex";
-    case "assemblyai": return "AI Transcribed";
-    case "description-url": return "Episode Page";
-    default: return source ?? "Unknown";
-  }
-}
-
-function formatPublishDate(timestamp: number): string {
-  if (!timestamp) return "Unknown";
-  const date = new Date(timestamp * 1000);
-  return date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-export default function EpisodePage({ params }: EpisodePageProps) {
-  const episodeId = params.id;
-  const { userId, has, isLoaded } = useAuth();
+export function AuthenticatedEpisodeDetail({
+  episodeId,
+  userId,
+  isAdmin,
+}: AuthenticatedEpisodeDetailProps) {
   const isOnline = useOnlineStatus();
   const playerState = useAudioPlayerState();
   const playerAPI = useAudioPlayerAPI();
@@ -143,8 +89,6 @@ export default function EpisodePage({ params }: EpisodePageProps) {
   const [transcriptStatus, setTranscriptStatus] = useState<TranscriptStatus | null>(null);
   const [episodeDbId, setEpisodeDbId] = useState<number | null>(null);
   const [overlapResult, setOverlapResult] = useState<{ label: string | null; labelKind: OverlapLabelKind | null }>({ label: null, labelKind: null });
-
-  const isAdmin = isLoaded && has?.({ role: ADMIN_ROLE });
 
   // Realtime subscription to the Trigger.dev run
   const { run } = useRealtimeRun<typeof summarizeEpisode>(runId ?? "", {
@@ -166,7 +110,7 @@ export default function EpisodePage({ params }: EpisodePageProps) {
         cached: false,
       };
       setSummaryData(completedSummary);
-      if (userId && episode && podcast) {
+      if (episode && podcast) {
         void cacheEpisode(userId, episodeId, {
           episode,
           podcast,
@@ -214,20 +158,18 @@ export default function EpisodePage({ params }: EpisodePageProps) {
       setEpisodeDbId(data.episodeDbId ?? null);
 
       // Cache episode data for offline use
-      if (userId) {
-        void cacheEpisode(userId, episodeId, {
-          episode: data.episode,
-          podcast: data.podcast,
-          summary: data.summary ? {
-            summary: data.summary.summary,
-            keyTakeaways: data.summary.keyTakeaways || [],
-            worthItScore: data.summary.worthItScore,
-            worthItReason: data.summary.worthItReason,
-            worthItDimensions: data.summary.worthItDimensions ?? null,
-            cached: true,
-          } : null,
-        });
-      }
+      void cacheEpisode(userId, episodeId, {
+        episode: data.episode,
+        podcast: data.podcast,
+        summary: data.summary ? {
+          summary: data.summary.summary,
+          keyTakeaways: data.summary.keyTakeaways || [],
+          worthItScore: data.summary.worthItScore,
+          worthItReason: data.summary.worthItReason,
+          worthItDimensions: data.summary.worthItDimensions ?? null,
+          cached: true,
+        } : null,
+      });
 
       // Check if summary exists
       if (data.summary) {
@@ -272,14 +214,12 @@ export default function EpisodePage({ params }: EpisodePageProps) {
       setIsSaved(saved);
     } catch (error) {
       console.error("Error fetching episode:", error);
-      if (userId) {
-        const cached = await getCachedEpisode(userId, episodeId);
-        if (cached) {
-          setEpisode(cached.episode);
-          setPodcast(cached.podcast);
-          setSummaryData(cached.summary ?? null);
-          return;
-        }
+      const cached = await getCachedEpisode(userId, episodeId);
+      if (cached) {
+        setEpisode(cached.episode);
+        setPodcast(cached.podcast);
+        setSummaryData(cached.summary ?? null);
+        return;
       }
       setEpisodeError(
         error instanceof Error ? error.message : "Failed to load episode"
@@ -291,12 +231,6 @@ export default function EpisodePage({ params }: EpisodePageProps) {
 
   // Load episode data from cache
   const loadFromCache = useCallback(async () => {
-    if (!userId) {
-      setIsLoadingEpisode(false);
-      setEpisodeError("This episode hasn't been cached for offline viewing. Visit it while online first.");
-      return;
-    }
-
     setIsLoadingEpisode(true);
     setEpisodeError(null);
 
@@ -472,16 +406,8 @@ export default function EpisodePage({ params }: EpisodePageProps) {
     );
   }
 
-  const artworkUrl = episode.image || episode.feedImage || podcast?.artwork || podcast?.image;
-  const safeEpisodeLink = (() => {
-    if (!episode.link) return null;
-    try {
-      const parsed = new URL(episode.link);
-      return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.toString() : null;
-    } catch {
-      return null;
-    }
-  })();
+  const artworkUrl = getEpisodeArtworkUrl(episode, podcast);
+  const safeEpisodeLink = getSafeEpisodeLink(episode.link);
   const categories = podcast?.categories ? Object.values(podcast.categories) : [];
 
   const isCurrentEpisode = playerState.currentEpisode?.id === String(episode.id);

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -641,7 +641,7 @@ export function AuthenticatedEpisodeDetail({
               <ShareButton
                 title={episode.title}
                 text={episode.title}
-                url={`${process.env.NEXT_PUBLIC_APP_URL}/episode/${episodeId}`}
+                url={`${process.env.NEXT_PUBLIC_APP_URL}/episode/${encodeURIComponent(episodeId)}`}
                 summary={summaryData?.worthItReason ?? undefined}
                 size="lg"
               />

--- a/src/components/episodes/episode-detail-shared.ts
+++ b/src/components/episodes/episode-detail-shared.ts
@@ -70,7 +70,15 @@ export function formatPublishDate(timestamp: number): string {
 }
 
 export function buildSignUpHref(redirectPath: string): string {
+  if (!redirectPath.startsWith("/") || redirectPath.startsWith("//")) {
+    return "/sign-up";
+  }
+
   return `/sign-up?redirect_url=${encodeURIComponent(redirectPath)}`;
+}
+
+export function supportsEpisodeProcessing(episodeId: string): boolean {
+  return /^\d+$/.test(episodeId);
 }
 
 export function getEpisodeArtworkUrl(

--- a/src/components/episodes/episode-detail-shared.ts
+++ b/src/components/episodes/episode-detail-shared.ts
@@ -1,0 +1,95 @@
+import type { WorthItDimensionsData } from "@/lib/openrouter";
+
+export interface EpisodeData {
+  id: number | string;
+  title: string;
+  description: string;
+  datePublished: number;
+  duration: number;
+  enclosureUrl: string;
+  episode: number | null;
+  episodeType: string;
+  season: number;
+  feedId: number;
+  feedImage: string;
+  image: string;
+  link: string;
+  chaptersUrl?: string | null;
+}
+
+export interface PodcastData {
+  id: number | string;
+  title: string;
+  author: string;
+  ownerName: string;
+  image: string;
+  artwork: string;
+  categories: Record<string, string>;
+}
+
+export interface SummaryData {
+  summary: string;
+  keyTakeaways: string[];
+  worthItScore: number | null;
+  worthItReason?: string;
+  worthItDimensions?: WorthItDimensionsData | null;
+  cached: boolean;
+}
+
+export function formatDuration(seconds: number): string {
+  if (!seconds || seconds <= 0) return "Unknown";
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+export function formatTranscriptSource(source: string | null): string {
+  switch (source) {
+    case "podcastindex":
+      return "PodcastIndex";
+    case "assemblyai":
+      return "AI Transcribed";
+    case "description-url":
+      return "Episode Page";
+    default:
+      return source ?? "Unknown";
+  }
+}
+
+export function formatPublishDate(timestamp: number): string {
+  if (!timestamp) return "Unknown";
+  const date = new Date(timestamp * 1000);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function buildSignUpHref(redirectPath: string): string {
+  return `/sign-up?redirect_url=${encodeURIComponent(redirectPath)}`;
+}
+
+export function getEpisodeArtworkUrl(
+  episode: EpisodeData,
+  podcast: PodcastData | null
+): string {
+  return episode.image || episode.feedImage || podcast?.artwork || podcast?.image || "";
+}
+
+export function getSafeEpisodeLink(link: string): string | null {
+  if (!link) return null;
+
+  try {
+    const parsed = new URL(link);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/components/episodes/public-episode-cta.tsx
+++ b/src/components/episodes/public-episode-cta.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface PublicEpisodeCTAProps {
+  href: string;
+}
+
+export function PublicEpisodeCTA({ href }: PublicEpisodeCTAProps) {
+  return (
+    <div className="sticky top-16 z-40 rounded-xl border bg-background/95 p-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium">Enjoying this?</p>
+          <p className="text-sm text-muted-foreground">
+            Sign up to save episodes and discover more.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href={href}>Sign Up</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -59,7 +59,9 @@ export function PublicEpisodeDetail({
       setEpisodeError(null);
 
       try {
-        const response = await fetch(`/api/episodes/${episodeId}`);
+        const response = await fetch(
+          `/api/episodes/${encodeURIComponent(episodeId)}`
+        );
         const data = await response.json();
 
         if (!response.ok) {

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -51,44 +51,59 @@ export function PublicEpisodeDetail({
   const [isLoadingEpisode, setIsLoadingEpisode] = useState(true);
   const [episodeError, setEpisodeError] = useState<string | null>(null);
 
-  const fetchEpisodeData = useCallback(async () => {
-    setIsLoadingEpisode(true);
-    setEpisodeError(null);
-
-    try {
-      const response = await fetch(`/api/episodes/${episodeId}`);
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to fetch episode");
-      }
-
-      setEpisode(data.episode);
-      setPodcast(data.podcast);
-      setSummaryData(
-        data.summary
-          ? {
-              summary: data.summary.summary,
-              keyTakeaways: data.summary.keyTakeaways || [],
-              worthItScore: data.summary.worthItScore,
-              worthItReason: data.summary.worthItReason,
-              worthItDimensions: data.summary.worthItDimensions ?? null,
-              cached: true,
-            }
-          : null
-      );
-    } catch (error) {
-      setEpisodeError(
-        error instanceof Error ? error.message : "Failed to load episode"
-      );
-    } finally {
-      setIsLoadingEpisode(false);
-    }
-  }, [episodeId]);
-
   useEffect(() => {
+    let ignore = false;
+
+    async function fetchEpisodeData() {
+      setIsLoadingEpisode(true);
+      setEpisodeError(null);
+
+      try {
+        const response = await fetch(`/api/episodes/${episodeId}`);
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || "Failed to fetch episode");
+        }
+
+        if (ignore) return;
+
+        setEpisode(data.episode);
+        setPodcast(data.podcast);
+        setSummaryData(
+          data.summary
+            ? {
+                summary: data.summary.summary,
+                keyTakeaways: data.summary.keyTakeaways || [],
+                worthItScore: data.summary.worthItScore,
+                worthItReason: data.summary.worthItReason,
+                worthItDimensions: data.summary.worthItDimensions ?? null,
+                cached: true,
+              }
+            : null
+        );
+      } catch (error) {
+        if (ignore) return;
+
+        setEpisode(null);
+        setPodcast(null);
+        setSummaryData(null);
+        setEpisodeError(
+          error instanceof Error ? error.message : "Failed to load episode"
+        );
+      } finally {
+        if (!ignore) {
+          setIsLoadingEpisode(false);
+        }
+      }
+    }
+
     void fetchEpisodeData();
-  }, [fetchEpisodeData]);
+
+    return () => {
+      ignore = true;
+    };
+  }, [episodeId]);
 
   if (isLoadingEpisode) {
     return (

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Calendar,
+  Clock,
+  ExternalLink,
+  Mic,
+  Rss,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CommunityRating } from "@/components/episodes/community-rating";
+import { PublicEpisodeCTA } from "@/components/episodes/public-episode-cta";
+import { SummaryDisplay } from "@/components/episodes/summary-display";
+import { WorthItBadge } from "@/components/episodes/worth-it-badge";
+import { ShareButton } from "@/components/ui/share-button";
+import { OfflineBanner } from "@/components/ui/offline-banner";
+import { useOnlineStatus } from "@/hooks/use-online-status";
+import { stripHtml } from "@/lib/utils";
+import type {
+  EpisodeData,
+  PodcastData,
+  SummaryData,
+} from "@/components/episodes/episode-detail-shared";
+import {
+  buildSignUpHref,
+  formatDuration,
+  formatPublishDate,
+  getEpisodeArtworkUrl,
+  getSafeEpisodeLink,
+} from "@/components/episodes/episode-detail-shared";
+
+interface PublicEpisodeDetailProps {
+  episodeId: string;
+}
+
+export function PublicEpisodeDetail({
+  episodeId,
+}: PublicEpisodeDetailProps) {
+  const isOnline = useOnlineStatus();
+
+  const [episode, setEpisode] = useState<EpisodeData | null>(null);
+  const [podcast, setPodcast] = useState<PodcastData | null>(null);
+  const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
+  const [isLoadingEpisode, setIsLoadingEpisode] = useState(true);
+  const [episodeError, setEpisodeError] = useState<string | null>(null);
+
+  const fetchEpisodeData = useCallback(async () => {
+    setIsLoadingEpisode(true);
+    setEpisodeError(null);
+
+    try {
+      const response = await fetch(`/api/episodes/${episodeId}`);
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to fetch episode");
+      }
+
+      setEpisode(data.episode);
+      setPodcast(data.podcast);
+      setSummaryData(
+        data.summary
+          ? {
+              summary: data.summary.summary,
+              keyTakeaways: data.summary.keyTakeaways || [],
+              worthItScore: data.summary.worthItScore,
+              worthItReason: data.summary.worthItReason,
+              worthItDimensions: data.summary.worthItDimensions ?? null,
+              cached: true,
+            }
+          : null
+      );
+    } catch (error) {
+      setEpisodeError(
+        error instanceof Error ? error.message : "Failed to load episode"
+      );
+    } finally {
+      setIsLoadingEpisode(false);
+    }
+  }, [episodeId]);
+
+  useEffect(() => {
+    void fetchEpisodeData();
+  }, [fetchEpisodeData]);
+
+  if (isLoadingEpisode) {
+    return (
+      <div className="space-y-8">
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <Skeleton className="h-5 w-40" />
+        <div className="flex flex-col gap-6 md:flex-row">
+          <Skeleton className="h-48 w-48 rounded-xl" />
+          <div className="flex flex-1 flex-col gap-4">
+            <Skeleton className="h-8 w-3/4" />
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (episodeError || !episode) {
+    return (
+      <div className="space-y-4">
+        {!isOnline && <OfflineBanner isOffline={true} />}
+        <Link
+          href={buildSignUpHref("/discover")}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Discover
+        </Link>
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <p className="text-sm text-destructive">
+            {episodeError || "Episode not found"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const artworkUrl = getEpisodeArtworkUrl(episode, podcast);
+  const safeEpisodeLink = getSafeEpisodeLink(episode.link);
+  const categories = podcast?.categories ? Object.values(podcast.categories) : [];
+  const currentEpisodeHref = buildSignUpHref(`/episode/${episodeId}`);
+  const browseHref = podcast
+    ? buildSignUpHref(`/podcast/${podcast.id}`)
+    : buildSignUpHref("/discover");
+
+  return (
+    <div className="space-y-8">
+      <OfflineBanner isOffline={!isOnline} />
+      <PublicEpisodeCTA href={currentEpisodeHref} />
+
+      <Link
+        href={browseHref}
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {podcast ? `Back to ${podcast.title}` : "Back to Discover"}
+      </Link>
+
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="flex flex-row items-center gap-4 md:flex-col md:items-start">
+          <div className="relative h-48 w-48 shrink-0 overflow-hidden rounded-xl bg-muted shadow-lg">
+            {artworkUrl ? (
+              <Image
+                src={artworkUrl}
+                alt={episode.title}
+                fill
+                className="object-cover"
+                sizes="192px"
+                priority
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                <Rss className="h-16 w-16" />
+              </div>
+            )}
+          </div>
+          <WorthItBadge score={summaryData?.worthItScore ?? null} />
+        </div>
+
+        <div className="flex flex-1 flex-col gap-4">
+          <div>
+            {episode.episodeType && episode.episodeType !== "full" && (
+              <Badge variant="secondary" className="mb-2">
+                {episode.episodeType}
+              </Badge>
+            )}
+            <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+              {episode.title}
+            </h1>
+            {podcast && (
+              <Link
+                href={buildSignUpHref(`/podcast/${podcast.id}`)}
+                className="mt-1 text-lg text-muted-foreground hover:text-primary"
+              >
+                {podcast.title}
+              </Link>
+            )}
+          </div>
+
+          {categories.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {categories.slice(0, 4).map((category, index) => (
+                <Badge key={index} variant="outline">
+                  {category}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+            <div className="flex items-center gap-1">
+              <Calendar className="h-4 w-4" />
+              <span>{formatPublishDate(episode.datePublished)}</span>
+            </div>
+            {episode.duration > 0 && (
+              <div className="flex items-center gap-1">
+                <Clock className="h-4 w-4" />
+                <span>{formatDuration(episode.duration)}</span>
+              </div>
+            )}
+            {episode.episode !== null && (
+              <div className="flex items-center gap-1">
+                <Mic className="h-4 w-4" />
+                <span>Episode {episode.episode}</span>
+              </div>
+            )}
+            {episode.season > 0 && <span>Season {episode.season}</span>}
+          </div>
+
+          <Link href={currentEpisodeHref} className="block w-fit">
+            <span className="mr-2 text-sm text-muted-foreground">
+              Community Rating:
+            </span>
+            <CommunityRating
+              episodePodcastIndexId={String(episode.id)}
+              size="md"
+              showCount={true}
+            />
+          </Link>
+
+          {episode.enclosureUrl && (
+            <Card>
+              <CardContent className="p-4">
+                <p className="mb-3 text-sm font-medium">Listen to this episode</p>
+                <audio
+                  className="w-full"
+                  controls
+                  preload="none"
+                  src={episode.enclosureUrl}
+                />
+              </CardContent>
+            </Card>
+          )}
+
+          <div className="flex flex-wrap gap-3">
+            <Button size="lg" asChild>
+              <Link href={currentEpisodeHref}>Save</Link>
+            </Button>
+            <Button variant="outline" size="lg" asChild>
+              <Link href={currentEpisodeHref}>Add to Queue</Link>
+            </Button>
+            {safeEpisodeLink && (
+              <Button variant="outline" size="lg" asChild>
+                <a
+                  href={safeEpisodeLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Episode Page
+                </a>
+              </Button>
+            )}
+            {process.env.NEXT_PUBLIC_APP_URL && (
+              <ShareButton
+                title={episode.title}
+                text={episode.title}
+                url={`${process.env.NEXT_PUBLIC_APP_URL}/episode/${episodeId}`}
+                summary={summaryData?.worthItReason ?? undefined}
+                size="lg"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {episode.description && (
+        <Card>
+          <CardContent className="p-6">
+            <h2 className="mb-3 text-lg font-semibold">About This Episode</h2>
+            <p className="whitespace-pre-wrap text-muted-foreground">
+              {stripHtml(episode.description)}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">AI-Powered Insights</h2>
+        </div>
+        {summaryData?.summary ? (
+          <SummaryDisplay
+            summary={summaryData.summary}
+            keyTakeaways={summaryData.keyTakeaways || null}
+            worthItScore={summaryData.worthItScore ?? null}
+            worthItReason={summaryData.worthItReason}
+            worthItDimensions={summaryData.worthItDimensions}
+          />
+        ) : (
+          <Card>
+            <CardContent className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="font-medium">Summary not yet available</p>
+              <p className="text-sm text-muted-foreground">
+                Sign up to request one and unlock AI-powered insights for this
+                episode.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -284,7 +284,7 @@ export function PublicEpisodeDetail({
               <ShareButton
                 title={episode.title}
                 text={episode.title}
-                url={`${process.env.NEXT_PUBLIC_APP_URL}/episode/${episodeId}`}
+                url={`${process.env.NEXT_PUBLIC_APP_URL}/episode/${encodeURIComponent(episodeId)}`}
                 summary={summaryData?.worthItReason ?? undefined}
                 size="lg"
               />

--- a/src/lib/offline-cache.ts
+++ b/src/lib/offline-cache.ts
@@ -33,7 +33,7 @@ export interface CachedLibraryData {
 
 // Lightweight types matching the shapes used by the pages
 export interface EpisodeData {
-  id: number;
+  id: number | string;
   title: string;
   description: string;
   datePublished: number;
@@ -49,7 +49,7 @@ export interface EpisodeData {
 }
 
 export interface PodcastData {
-  id: number;
+  id: number | string;
   title: string;
   author: string;
   ownerName: string;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,13 +10,19 @@ const isPublicRoute = createRouteMatcher([
   "/api/webhooks(.*)",
 ]);
 
+const PUBLIC_EPISODE_ID_PATTERN = "(?:\\d+|rss-[^/]+)";
+
 function isPublicEpisodePageRequest(req: NextRequest): boolean {
-  return /^\/episode\/[^/]+$/.test(req.nextUrl.pathname);
+  return new RegExp(`^/episode/${PUBLIC_EPISODE_ID_PATTERN}$`).test(
+    req.nextUrl.pathname
+  );
 }
 
 function isPublicEpisodeApiRequest(req: NextRequest): boolean {
   if (req.method !== "GET") return false;
-  return /^\/api\/episodes\/(?:\d+|rss-[^/]+)$/.test(req.nextUrl.pathname);
+  return new RegExp(`^/api/episodes/${PUBLIC_EPISODE_ID_PATTERN}$`).test(
+    req.nextUrl.pathname
+  );
 }
 
 export default clerkMiddleware(async (auth, req) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -9,6 +10,15 @@ const isPublicRoute = createRouteMatcher([
   "/api/webhooks(.*)",
 ]);
 
+function isPublicEpisodePageRequest(req: NextRequest): boolean {
+  return /^\/episode\/[^/]+$/.test(req.nextUrl.pathname);
+}
+
+function isPublicEpisodeApiRequest(req: NextRequest): boolean {
+  if (req.method !== "GET") return false;
+  return /^\/api\/episodes\/(?:\d+|rss-[^/]+)$/.test(req.nextUrl.pathname);
+}
+
 export default clerkMiddleware(async (auth, req) => {
   const { userId } = await auth();
 
@@ -17,7 +27,11 @@ export default clerkMiddleware(async (auth, req) => {
     return NextResponse.redirect(new URL("/dashboard", req.url));
   }
 
-  if (!isPublicRoute(req)) {
+  if (
+    !isPublicRoute(req) &&
+    !isPublicEpisodePageRequest(req) &&
+    !isPublicEpisodeApiRequest(req)
+  ) {
     await auth.protect();
   }
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,19 +10,16 @@ const isPublicRoute = createRouteMatcher([
   "/api/webhooks(.*)",
 ]);
 
-const PUBLIC_EPISODE_ID_PATTERN = "(?:\\d+|rss-[^/]+)";
+const PUBLIC_EPISODE_PAGE_RE = /^\/episode\/(?:\d+|rss-[^/]+)$/;
+const PUBLIC_EPISODE_API_RE = /^\/api\/episodes\/(?:\d+|rss-[^/]+)$/;
 
 function isPublicEpisodePageRequest(req: NextRequest): boolean {
-  return new RegExp(`^/episode/${PUBLIC_EPISODE_ID_PATTERN}$`).test(
-    req.nextUrl.pathname
-  );
+  return PUBLIC_EPISODE_PAGE_RE.test(req.nextUrl.pathname);
 }
 
 function isPublicEpisodeApiRequest(req: NextRequest): boolean {
   if (req.method !== "GET") return false;
-  return new RegExp(`^/api/episodes/${PUBLIC_EPISODE_ID_PATTERN}$`).test(
-    req.nextUrl.pathname
-  );
+  return PUBLIC_EPISODE_API_RE.test(req.nextUrl.pathname);
 }
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Summary
- make `/episode/[id]` and anonymous `GET /api/episodes/[id]` public while keeping the rest of the app protected
- split the episode detail flow into authenticated and public shells, including sign-up CTAs and public-safe actions
- add middleware, API, layout, and component tests for the new anonymous episode experience

## Test plan
- [x] `bun run lint`
- [x] `bun run test`
- [x] `doppler run --project contentgenie --config dev -- ./node_modules/.bin/next build`
- [x] Browser-check signed-out `/episode/50656989319` and verified sign-up redirect + public API cache headers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public episode pages for anonymous viewers with read-only details, summaries, sharing and external links; sticky sign-up CTA for unsigned users
  * Authenticated episode view with account-specific actions and admin-only processing controls
* **Performance & Reliability**
  * Conditional public caching for anonymous responses; anonymous public requests are rate-limited (may return 429 with retry info)
  * Tighter episode ID validation and simpler error payloads
* **Tests & Changelog**
  * Expanded test coverage across pages, APIs, middleware, and shared utilities; CHANGELOG updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->