### PR TITLE
test: add coverage for topic rank enrichment edge cases (#267)

### DIFF
--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -458,6 +458,48 @@ describe("getRecommendedEpisodes", () => {
     expect(result.episodes[0].topRankedTopic).toBe("Artificial Intelligence");
   });
 
+  it("partially enriches episodes — only those with rank rows get populated fields", async () => {
+    const mockEpisodes = [
+      {
+        id: 1,
+        podcastIndexId: "ep-111",
+        title: "Has Rank",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "9.00",
+        podcastTitle: "Pod A",
+        podcastImageUrl: null,
+      },
+      {
+        id: 2,
+        podcastIndexId: "ep-222",
+        title: "No Rank",
+        description: null,
+        audioUrl: null,
+        duration: null,
+        publishDate: null,
+        worthItScore: "7.00",
+        podcastTitle: "Pod B",
+        podcastImageUrl: null,
+      },
+    ];
+    mockLimit.mockResolvedValue(mockEpisodes);
+    // Only episode 1 has a rank row; episode 2 falls through to null
+    mockGroupBy.mockResolvedValue([
+      { episodeId: 1, bestRank: 3, topTopic: "Climate Tech" },
+    ]);
+
+    const { getRecommendedEpisodes } = await import("@/app/actions/dashboard");
+    const result = await getRecommendedEpisodes();
+
+    expect(result.episodes[0].bestTopicRank).toBe(3);
+    expect(result.episodes[0].topRankedTopic).toBe("Climate Tech");
+    expect(result.episodes[1].bestTopicRank).toBeNull();
+    expect(result.episodes[1].topRankedTopic).toBeNull();
+  });
+
   it("uses default limit of 10 when called with no arguments", async () => {
     mockLimit.mockResolvedValue([]);
 

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -486,7 +486,6 @@ describe("getRecommendedEpisodes", () => {
       },
     ];
     mockLimit.mockResolvedValue(mockEpisodes);
-    // Only episode 1 has a rank row; episode 2 falls through to null
     mockGroupBy.mockResolvedValue([
       { episodeId: 1, bestRank: 3, topTopic: "Climate Tech" },
     ]);

--- a/src/lib/__tests__/score-utils.test.ts
+++ b/src/lib/__tests__/score-utils.test.ts
@@ -172,7 +172,7 @@ describe("clampAdjustment", () => {
 });
 
 describe("parseScore", () => {
-  it('parses a valid decimal string "7.50" to 7.5', () => {
+  it("parses a decimal string to a number", () => {
     expect(parseScore("7.50")).toBe(7.5);
   });
 
@@ -192,7 +192,7 @@ describe("parseScore", () => {
     expect(parseScore("10")).toBe(10);
   });
 
-  it('parses "0.00" to 0 without triggering the empty-string guard', () => {
+  it("parses a zero decimal string to 0", () => {
     expect(parseScore("0.00")).toBe(0);
   });
 });

--- a/src/lib/__tests__/score-utils.test.ts
+++ b/src/lib/__tests__/score-utils.test.ts
@@ -6,6 +6,7 @@ import {
   clampAdjustment,
   coerceSignals,
   computeSignalScore,
+  parseScore,
 } from "@/lib/score-utils";
 import { WORTH_IT_SIGNAL_KEYS } from "@/lib/openrouter";
 import type { WorthItSignals } from "@/lib/openrouter";
@@ -167,6 +168,24 @@ describe("clampAdjustment", () => {
 
   it("returns 0 for null", () => {
     expect(clampAdjustment(null)).toBe(0);
+  });
+});
+
+describe("parseScore", () => {
+  it('parses a valid decimal string "7.50" to 7.5', () => {
+    expect(parseScore("7.50")).toBe(7.5);
+  });
+
+  it("returns 0 for null", () => {
+    expect(parseScore(null)).toBe(0);
+  });
+
+  it("returns 0 for an empty string", () => {
+    expect(parseScore("")).toBe(0);
+  });
+
+  it("returns 0 for a non-numeric string", () => {
+    expect(parseScore("garbage")).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/score-utils.test.ts
+++ b/src/lib/__tests__/score-utils.test.ts
@@ -187,6 +187,14 @@ describe("parseScore", () => {
   it("returns 0 for a non-numeric string", () => {
     expect(parseScore("garbage")).toBe(0);
   });
+
+  it("parses an integer string without decimals", () => {
+    expect(parseScore("10")).toBe(10);
+  });
+
+  it('parses "0.00" to 0 without triggering the empty-string guard', () => {
+    expect(parseScore("0.00")).toBe(0);
+  });
 });
 
 describe("coerceSignals", () => {

--- a/src/trigger/__tests__/rank-episode-topics.test.ts
+++ b/src/trigger/__tests__/rank-episode-topics.test.ts
@@ -205,7 +205,6 @@ describe("rank-episode-topics task", () => {
 
     setupSelectSequence(topicRows, episodeRows);
     mockGenerateCompletion.mockResolvedValue("ok");
-    // Middle pair returns an invalid winner — should hit the throw at rank-episode-topics.ts
     mockParseJsonResponse
       .mockReturnValueOnce({ winner: "A", reason: "ok" })
       .mockReturnValueOnce({ winner: "invalid", reason: "bad response" })

--- a/src/trigger/__tests__/rank-episode-topics.test.ts
+++ b/src/trigger/__tests__/rank-episode-topics.test.ts
@@ -195,6 +195,29 @@ describe("rank-episode-topics task", () => {
     expect(mockUpdate).toHaveBeenCalledTimes(4);
   });
 
+  it("increments comparisonsFailed when LLM returns an invalid winner value", async () => {
+    const topicRows = [{ topic: "AI", episodeCount: 3 }];
+    const episodeRows = [
+      { episodeId: 1, title: "Ep 1", summary: "Summary 1", worthItScore: "8.00" },
+      { episodeId: 2, title: "Ep 2", summary: "Summary 2", worthItScore: "7.00" },
+      { episodeId: 3, title: "Ep 3", summary: "Summary 3", worthItScore: "6.00" },
+    ];
+
+    setupSelectSequence(topicRows, episodeRows);
+    mockGenerateCompletion.mockResolvedValue("ok");
+    // Middle pair returns an invalid winner — should hit the throw at rank-episode-topics.ts
+    mockParseJsonResponse
+      .mockReturnValueOnce({ winner: "A", reason: "ok" })
+      .mockReturnValueOnce({ winner: "invalid", reason: "bad response" })
+      .mockReturnValueOnce({ winner: "B", reason: "ok" });
+
+    const result = await taskConfig.run();
+
+    expect(result.comparisonsRun).toBe(2);
+    expect(result.comparisonsFailed).toBe(1);
+    expect(result.topicsRanked).toBe(1);
+  });
+
   it("skips topic entirely when all comparisons fail", async () => {
     const { logger } = await import("@trigger.dev/sdk");
     const topicRows = [{ topic: "Broken", episodeCount: 3 }];


### PR DESCRIPTION
## Summary

Closes the three test-coverage gaps from PR #266 review (issue #267):

- **Dashboard partial enrichment** (`src/app/actions/__tests__/dashboard.test.ts`): new test where only one of two episodes has a rank row — verifies the `?? null` fallback branch in the `rankMap` enrichment.
- **Invalid LLM winner** (`src/trigger/__tests__/rank-episode-topics.test.ts`): new test mocks `parseJsonResponse` returning `{ winner: "invalid" }`; asserts `comparisonsFailed` increments and `comparisonsRun` does not. Exercises the `throw new Error("Invalid winner value: …")` branch.
- **`parseScore` in canonical location** (`src/lib/__tests__/score-utils.test.ts`): direct tests for `"7.50" → 7.5`, `null → 0`, `"" → 0`, `"garbage" → 0`. The existing re-export tests in `topic-ranking.test.ts` stay as-is.

Tests only — no production code changes.

Closes #267.

## Test plan

- [x] `bun run test src/app/actions/__tests__/dashboard.test.ts` — 43 tests pass, includes new mixed-enrichment case
- [x] `bun run test src/trigger/__tests__/rank-episode-topics.test.ts` — 11 tests pass, includes invalid-winner case
- [x] `bun run test src/lib/__tests__/score-utils.test.ts` — 41 tests pass, includes parseScore block
- [x] `bun run test` — full suite green (1923 tests)
- [x] `bun run lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for episode recommendation enrichment to validate correct handling when ranking data is available for only a subset of episodes
  * Added comprehensive test suite for score value parsing, covering edge cases including null values, empty strings, and non-numeric inputs
  * Expanded ranking comparison validation tests to ensure proper failure counting and topic ranking completion when encountering invalid comparison results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->