### PR TITLE
feat: add getPinnedSubscriptions server action

### DIFF
--- a/src/app/actions/__tests__/subscriptions.test.ts
+++ b/src/app/actions/__tests__/subscriptions.test.ts
@@ -112,6 +112,7 @@ vi.mock("@/db/schema", async () => {
       title: "title",
       latestEpisodeDate: "latest_episode_date",
       description: "description",
+      imageUrl: "image_url",
     },
     episodes: {
       id: "id",
@@ -916,5 +917,161 @@ describe("getUserSubscriptionSort", () => {
     const result = await getUserSubscriptionSort();
 
     expect(result).toBe(DEFAULT_SUBSCRIPTION_SORT);
+  });
+});
+
+// Chain shape: select → from → innerJoin → where → orderBy → Promise<rows>
+function makePinnedListChain(rows: unknown[]) {
+  const mockOrderBy = vi.fn().mockResolvedValue(rows);
+  const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+  const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+  return {
+    chain: { from: mockFrom },
+    mocks: { mockFrom, mockInnerJoin, mockWhere, mockOrderBy },
+  };
+}
+
+describe("getPinnedSubscriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user_123" });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns error when not authenticated", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/signed in/i),
+    });
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when user has no pinned subscriptions", async () => {
+    const { chain } = makePinnedListChain([]);
+    mockSelect.mockReturnValue(chain);
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(result).toEqual({ success: true, data: [] });
+  });
+
+  it("returns single pin with correct fields and no extras", async () => {
+    const row = {
+      id: 1,
+      podcastId: 10,
+      podcastIndexId: "pi-10",
+      title: "Solo",
+      imageUrl: "https://img/1.png",
+    };
+    const { chain } = makePinnedListChain([row]);
+    mockSelect.mockReturnValue(chain);
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toEqual({
+      id: 1,
+      podcastId: 10,
+      podcastIndexId: "pi-10",
+      title: "Solo",
+      imageUrl: "https://img/1.png",
+    });
+    expect(result.data[0]).not.toHaveProperty("description");
+  });
+
+  it("orders by podcasts.title ASC — passes DB-sorted rows through unchanged", async () => {
+    const rows = [
+      { id: 1, podcastId: 10, podcastIndexId: "pi-10", title: "Apple Pod", imageUrl: "https://img/10.png" },
+      { id: 2, podcastId: 20, podcastIndexId: "pi-20", title: "Mango Pod", imageUrl: null },
+      { id: 3, podcastId: 30, podcastIndexId: "pi-30", title: "Zebra Pod", imageUrl: "https://img/30.png" },
+    ];
+    const { chain, mocks } = makePinnedListChain(rows);
+    mockSelect.mockReturnValue(chain);
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(mocks.mockOrderBy).toHaveBeenCalledTimes(1);
+    expect(mocks.mockOrderBy).toHaveBeenCalledWith({ __op: "asc", col: "title" });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((r) => r.title)).toEqual(["Apple Pod", "Mango Pod", "Zebra Pod"]);
+  });
+
+  it("does not re-sort DB results client-side (non-alphabetical seed)", async () => {
+    const unsortedRows = [
+      { id: 3, podcastId: 30, podcastIndexId: "pi-30", title: "Zebra Pod", imageUrl: null },
+      { id: 1, podcastId: 10, podcastIndexId: "pi-10", title: "Apple Pod", imageUrl: null },
+      { id: 2, podcastId: 20, podcastIndexId: "pi-20", title: "Mango Pod", imageUrl: null },
+    ];
+    const { chain } = makePinnedListChain(unsortedRows);
+    mockSelect.mockReturnValue(chain);
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.map((r) => r.title)).toEqual(["Zebra Pod", "Apple Pod", "Mango Pod"]);
+  });
+
+  it("WHERE includes isPinned=true and userId predicates", async () => {
+    const { chain, mocks } = makePinnedListChain([]);
+    mockSelect.mockReturnValue(chain);
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    await getPinnedSubscriptions();
+
+    expect(mocks.mockWhere).toHaveBeenCalledTimes(1);
+    const whereArg = mocks.mockWhere.mock.calls[0][0] as {
+      __op: string;
+      args: Array<{ __op: string; a: unknown; b: unknown }>;
+    };
+    expect(whereArg.__op).toBe("and");
+    const userIdPredicate = whereArg.args.find((p) => p.a === "user_id");
+    const isPinnedPredicate = whereArg.args.find((p) => p.a === "is_pinned");
+    expect(userIdPredicate?.b).toBe("user_123");
+    expect(isPinnedPredicate?.b).toBe(true);
+  });
+
+  it("returns error envelope on database failure", async () => {
+    mockSelect.mockImplementation(() => {
+      throw new Error("db exploded");
+    });
+
+    const { getPinnedSubscriptions } = await import(
+      "@/app/actions/subscriptions"
+    );
+    const result = await getPinnedSubscriptions();
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringMatching(/failed to load/i),
+    });
   });
 });

--- a/src/app/actions/__tests__/subscriptions.test.ts
+++ b/src/app/actions/__tests__/subscriptions.test.ts
@@ -995,7 +995,10 @@ describe("getPinnedSubscriptions", () => {
       title: "Solo",
       imageUrl: "https://img/1.png",
     });
-    expect(result.data[0]).not.toHaveProperty("description");
+    const projection = mockSelect.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(projection).sort()).toEqual(
+      ["id", "imageUrl", "podcastId", "podcastIndexId", "title"],
+    );
   });
 
   it("orders by podcasts.title ASC — passes DB-sorted rows through unchanged", async () => {
@@ -1013,7 +1016,10 @@ describe("getPinnedSubscriptions", () => {
     const result = await getPinnedSubscriptions();
 
     expect(mocks.mockOrderBy).toHaveBeenCalledTimes(1);
-    expect(mocks.mockOrderBy).toHaveBeenCalledWith({ __op: "asc", col: "title" });
+    expect(mocks.mockOrderBy).toHaveBeenCalledWith(
+      { __op: "asc", col: "title" },
+      { __op: "asc", col: "id" },
+    );
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data.map((r) => r.title)).toEqual(["Apple Pod", "Mango Pod", "Zebra Pod"]);
@@ -1053,6 +1059,7 @@ describe("getPinnedSubscriptions", () => {
       args: Array<{ __op: string; a: unknown; b: unknown }>;
     };
     expect(whereArg.__op).toBe("and");
+    expect(whereArg.args).toHaveLength(2);
     const userIdPredicate = whereArg.args.find((p) => p.a === "user_id");
     const isPinnedPredicate = whereArg.args.find((p) => p.a === "is_pinned");
     expect(userIdPredicate?.b).toBe("user_123");

--- a/src/app/actions/subscriptions.ts
+++ b/src/app/actions/subscriptions.ts
@@ -610,10 +610,10 @@ export async function getPinnedSubscriptions(): Promise<
           eq(userSubscriptions.isPinned, true),
         ),
       )
-      .orderBy(asc(podcasts.title));
+      .orderBy(asc(podcasts.title), asc(userSubscriptions.id));
     return { success: true, data: rows };
   } catch (error) {
-    console.error("[getPinnedSubscriptions] failed", { userId, error });
+    console.error("[getPinnedSubscriptions] failed", error, { userId });
     return { success: false, error: "Failed to load pinned subscriptions" };
   }
 }

--- a/src/app/actions/subscriptions.ts
+++ b/src/app/actions/subscriptions.ts
@@ -575,6 +575,49 @@ export type SubscriptionWithPodcast = Awaited<
   ReturnType<typeof getUserSubscriptions>
 >["subscriptions"][number];
 
+export interface PinnedSubscription {
+  id: number;
+  podcastId: number;
+  podcastIndexId: string;
+  title: string;
+  imageUrl: string | null;
+}
+
+export async function getPinnedSubscriptions(): Promise<
+  ActionResult<PinnedSubscription[]>
+> {
+  const { userId } = await auth();
+  if (!userId) {
+    return {
+      success: false,
+      error: "You must be signed in to view pinned subscriptions",
+    };
+  }
+  try {
+    const rows = await db
+      .select({
+        id: userSubscriptions.id,
+        podcastId: podcasts.id,
+        podcastIndexId: podcasts.podcastIndexId,
+        title: podcasts.title,
+        imageUrl: podcasts.imageUrl,
+      })
+      .from(userSubscriptions)
+      .innerJoin(podcasts, eq(userSubscriptions.podcastId, podcasts.id))
+      .where(
+        and(
+          eq(userSubscriptions.userId, userId),
+          eq(userSubscriptions.isPinned, true),
+        ),
+      )
+      .orderBy(asc(podcasts.title));
+    return { success: true, data: rows };
+  } catch (error) {
+    console.error("[getPinnedSubscriptions] failed", { userId, error });
+    return { success: false, error: "Failed to load pinned subscriptions" };
+  }
+}
+
 export async function getUserSubscriptionSort(): Promise<SubscriptionSort> {
   const { userId } = await auth();
   if (!userId) return DEFAULT_SUBSCRIPTION_SORT;


### PR DESCRIPTION
## Summary
- Adds `getPinnedSubscriptions()` server action to `src/app/actions/subscriptions.ts` — a narrow read for the sidebar-pinned-podcasts surface (see #341).
- Exports `PinnedSubscription` type with exactly 5 fields (`id`, `podcastId`, `podcastIndexId`, `title`, `imageUrl`) — `description` deliberately omitted.
- Auth-gated via Clerk; unauthenticated callers get `ActionResult` error shape (no throw). Uses existing `user_subscriptions_pinned_idx` partial index (no schema change).

## Test plan
- [x] Unit tests: 7 new cases in `subscriptions.test.ts` — auth guard, empty result, single pin, A–Z ordering (4a: pre-sorted + orderBy assertion), non-alphabetical seed regression guard (4b), WHERE-predicate includes `is_pinned = true`, DB error path.
- [x] `bun run lint` — clean
- [x] `bun run test` — 2186/2186 across 163 files
- [x] `bun run build` — type-check confirms exported signature + interface shape
- [x] No changes to `getUserSubscriptions`, `togglePinSubscription`, `setSubscriptionSort`, or `src/db/schema.ts`
- [x] No new `revalidatePath` calls (pure read)

## Plan
`.dev/cdt/plans/plan-20260424-1826.md` — PM-approved; reviewer approved on first cycle.

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and displaying user's pinned subscriptions with secure authentication

* **Tests**
  * Comprehensive test coverage for pinned subscriptions retrieval, including authentication verification, data validation, sorting by title, and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->