### PR TITLE
docs(skill): run pre-pr-validation inline, not in a subagent

### DIFF
--- a/.claude/skills/pre-pr-validation/SKILL.md
+++ b/.claude/skills/pre-pr-validation/SKILL.md
@@ -17,7 +17,7 @@ You should invoke this skill proactively the moment a PR is discussed — don't 
 
 Run this pipeline inline in the calling session. Don't wrap it in a `Task` subagent.
 
-The sub-tools this skill invokes (`/codex:review`, `/pr-review-toolkit:review-pr`, `/simplify`) already isolate their heavy review work in their own freshly-spawned subagents — each reviewer (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier) gets a clean context. Context hygiene is handled there, not here. Wrapping the whole pipeline in an outer subagent adds a layer that can't dispatch further Task/Agent calls (subagents can't spawn subagents), which breaks the Codex-review path (Phase 2a requires `Task({run_in_background: true})`) and may also affect Skill availability for the other two reviewers. Net result: weaker review coverage, no context win.
+Phase 2 itself dispatches a background `Task({run_in_background: true})` for the Codex review, and `/pr-review-toolkit:review-pr all` dispatches further `Task` calls for each specialist reviewer. Subagents can't spawn further subagents — so wrapping this skill in an outer Task blocks the Codex step entirely, and may prevent `/pr-review-toolkit:review-pr` from launching its specialists. Net result: weaker review coverage, no context win (the heavy work was already going to happen in a fresh context; you'd just be stacking one more).
 
 If the caller's context is cluttered, the cost is mildly worse triage in Phase 3 — not broken reviews. That trade-off goes in favour of running inline.
 

--- a/.claude/skills/pre-pr-validation/SKILL.md
+++ b/.claude/skills/pre-pr-validation/SKILL.md
@@ -13,48 +13,13 @@ The hook is a best-effort guardrail — not a security boundary. A sufficiently 
 
 You should invoke this skill proactively the moment a PR is discussed — don't wait for the hook to reject `gh pr create`.
 
-## Context hygiene — decide how to run this
+## Run inline — do not dispatch to a subagent
 
-Before starting the pipeline, decide: **run inline in this session, or dispatch to a fresh Task subagent?**
+Run this pipeline inline in the calling session. Don't wrap it in a `Task` subagent.
 
-Skills run inline in the calling agent's context. Sub-tools (`/codex:review`, `/pr-review-toolkit:review-pr`, `/simplify`) delegate their heavy thinking to fresh contexts, but the skill's orchestration — Phase 3 (validate findings), Phase 4 (apply fixes), and the git/verification phases — runs wherever you invoked it. If the caller has been doing feature work (lots of file reads, debugging conversations, long planning threads), that cluttered context will hurt triage quality and risks hitting limits mid-pipeline.
+The sub-tools this skill invokes (`/codex:review`, `/pr-review-toolkit:review-pr`, `/simplify`) already isolate their heavy review work in their own freshly-spawned subagents — each reviewer (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier) gets a clean context. Context hygiene is handled there, not here. Wrapping the whole pipeline in an outer subagent adds a layer that can't dispatch further Task/Agent calls (subagents can't spawn subagents), which breaks the Codex-review path (Phase 2a requires `Task({run_in_background: true})`) and may also affect Skill availability for the other two reviewers. Net result: weaker review coverage, no context win.
 
-**Rule of thumb:**
-
-- **Inline** is fine if the session is fresh — you just started, or you're coming off light work (docs, a small fix, a config change).
-- **Dispatch** otherwise. Reviewers are meant to judge the diff on its merits, not on the story of how it got written; losing the conversational context is a feature, not a bug.
-
-When in doubt, dispatch.
-
-### How to dispatch
-
-Launch a `Task` subagent. The subagent has the same skill registry, so it re-invokes this skill in its own fresh context and drives the pipeline end-to-end:
-
-```
-Task({
-  subagent_type: "general-purpose",
-  description: "Pre-PR validation pipeline",
-  prompt: `Run the full pre-PR validation pipeline for this branch.
-
-Working directory: <absolute path to repo>
-Branch: <current branch name>
-Base branch: origin/main
-
-Invoke the \`pre-pr-validation\` skill and execute every phase (0 through 8) in order. Apply the validated findings unattended — do NOT pause to ask for approval. Report back only after Phase 8 (PR created) or on genuine escalation (see below).
-
-Stop and surface to the caller only if:
-- Phase 0 rebase conflicts are non-trivial
-- Reviewers disagree and project conventions don't resolve it
-- Phase 5 fails after 2 retry rounds
-- The external Codex review is stuck > 15 minutes
-
-On escalation, dump: phases completed, full findings list with validity marks, commits made, failing command + output, and what you tried. Don't truncate — the caller needs the state to decide next steps.
-
-On success, report: PR URL and a one-sentence summary of the scope.`
-})
-```
-
-Wait for the subagent's completion message, then relay the PR URL to the user. If the subagent stopped mid-pipeline, read its escalation report and handle it yourself.
+If the caller's context is cluttered, the cost is mildly worse triage in Phase 3 — not broken reviews. That trade-off goes in favour of running inline.
 
 ## Core principle
 


### PR DESCRIPTION
## Summary
- Removes the \"Context hygiene — decide how to run this\" + \"How to dispatch\" sections from the \`pre-pr-validation\` skill and replaces them with a shorter \"Run inline\" directive.
- Reason: Phase 2 itself dispatches a background \`Task({run_in_background: true})\` for Codex review, and \`/pr-review-toolkit:review-pr all\` dispatches further \`Task\` calls per specialist. Subagents can't spawn further subagents — wrapping the skill in an outer \`Task\` blocks Codex entirely and can prevent \`/pr-review-toolkit:review-pr\` from launching its specialists. Net: weaker review coverage for no context win (heavy work was already going to a fresh context).
- Motivated by a real incident on PR #358 where the skill was dispatched via Task and the Codex + toolkit reviewers were quietly replaced with inline checklists.

## Test plan
- [x] \`bun run build\` — exit 0
- [x] \`bun run lint\` + \`bun run test\` — ran via husky pre-commit on both commits (2179 tests green)
- [x] Codex review (\`codex review --base main\`) — no findings
- [x] \`/pr-review-toolkit:code-reviewer\` + \`/pr-review-toolkit:comment-analyzer\` — both flagged two inaccuracies in the first draft (fabricated \"Phase 2a\" label; overstated \"fresh context\" claim); fix applied in the second commit
- [x] Diff scope: 1 file, \`.claude/skills/pre-pr-validation/SKILL.md\` (–39/+4 overall)