### PR TITLE
fix: skip no-op INIT_QUEUE at focus-refetch dispatch site

### DIFF
--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -2008,4 +2008,94 @@ describe("Cross-device sync: hydration and reconcile", () => {
 
     expect(toast.error).toHaveBeenCalled();
   });
+
+  it("focus refetch with content-equal server queue does not re-fire the persist effect", async () => {
+    const queue: AudioEpisode[] = [queueEpisode1, queueEpisode2];
+    mockLoadQueue.mockReturnValue(queue);
+    // Each call returns a fresh array reference with identical content —
+    // mirrors production, where getQueue() deserializes a new payload every
+    // call. Using a single shared array reference would mask the regression:
+    // both state.queue (from mockLoadQueue) and action.queue (from getQueue)
+    // would alias the same object, so even an unconditional reducer
+    // `{ ...state, queue: action.queue }` would preserve identity.
+    mockGetQueue.mockImplementation(async () => ({
+      success: true,
+      data: queue.map((ep) => ({ ...ep })),
+    }));
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>,
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // Mount hydration legitimately triggers one persist write; clear so we
+    // can isolate what the focus refetch produces.
+    mockSaveQueue.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await new Promise((r) => setTimeout(r, 300));
+    });
+
+    // Without the dispatch-site equality guard in the focus-refetch handler,
+    // INIT_QUEUE would have fired with a fresh array reference, the
+    // [state.queue] persist effect would have re-run, and saveQueue would
+    // have been called once more. The guard short-circuits the dispatch
+    // when content is unchanged.
+    expect(mockSaveQueue).not.toHaveBeenCalled();
+  });
+
+  it("focus refetch with mutated server metadata still applies the update", async () => {
+    const localQueue: AudioEpisode[] = [
+      {
+        id: "shared-id",
+        title: "Old Title",
+        podcastTitle: "Podcast",
+        audioUrl: "https://example.com/old.mp3",
+      },
+    ];
+    const serverQueue: AudioEpisode[] = [
+      {
+        id: "shared-id",
+        title: "New Title",
+        podcastTitle: "Podcast",
+        audioUrl: "https://example.com/new.mp3",
+      },
+    ];
+    mockLoadQueue.mockReturnValue(localQueue);
+    mockGetQueue.mockResolvedValueOnce({ success: true, data: localQueue });
+    mockGetQueue.mockResolvedValueOnce({ success: true, data: serverQueue });
+
+    render(
+      <AudioPlayerProvider>
+        <TestConsumer />
+      </AudioPlayerProvider>,
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    mockSaveQueue.mockClear();
+
+    // Trigger the focus refetch — the second mocked call returns updated
+    // metadata for the same id.
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await new Promise((r) => setTimeout(r, 300));
+    });
+
+    // The dispatch must NOT short-circuit just because IDs match: server-side
+    // metadata refreshes (title, audioUrl, artwork, chaptersUrl) must
+    // propagate to the client. The TestConsumer only renders ids, so we use
+    // the persist effect re-firing (saveQueue called) as the proxy signal —
+    // it only fires when state.queue identity changes, which only happens
+    // when the dispatch isn't short-circuited.
+    expect(mockSaveQueue).toHaveBeenCalled();
+  });
 });

--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -79,6 +79,36 @@ function clearSessionOnServer(): void {
     .catch((err) => console.warn("[player] clear threw:", err));
 }
 
+// Full-field equality on the persisted AudioEpisode shape. Used at the
+// focus-refetch dispatch site so a server reconcile returning content-
+// equal data can skip the dispatch entirely (preserving state.queue
+// reference identity and avoiding a spurious [state.queue] persist
+// effect re-fire). ID-only equality is insufficient: server-side metadata
+// refreshes (title corrections, artwork URLs, chaptersUrl backfill) must
+// still propagate to the client.
+function queuesEqualByContent(
+  a: readonly AudioEpisode[],
+  b: readonly AudioEpisode[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.id !== y.id ||
+      x.title !== y.title ||
+      x.podcastTitle !== y.podcastTitle ||
+      x.audioUrl !== y.audioUrl ||
+      x.artwork !== y.artwork ||
+      x.duration !== y.duration ||
+      x.chaptersUrl !== y.chaptersUrl
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -576,8 +606,18 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
 
         // Queue reconcile: skip if a local write is pending
         if (queueResult.success && !pendingQueueWriteRef.current) {
-          lastAckedQueueRef.current = queueResult.data;
-          dispatch({ type: "INIT_QUEUE", queue: queueResult.data });
+          const next = queueResult.data;
+          lastAckedQueueRef.current = next;
+          // Skip the dispatch when the server returned content-equal data.
+          // INIT_QUEUE always allocates a new state.queue array, which would
+          // re-fire the [state.queue] persist effect (one wasted localStorage
+          // write per focus event). The reducer must stay pure — its
+          // INIT_QUEUE invariant is "always produces new state" and the
+          // rollback path at the persist effect depends on that to consume
+          // suppressQueueWriteRef. Filter at the dispatch site instead.
+          if (!queuesEqualByContent(stateRef.current.queue, next)) {
+            dispatch({ type: "INIT_QUEUE", queue: next });
+          }
         } else if (!queueResult.success) {
           console.warn("Focus getQueue failed:", queueResult.error);
         }


### PR DESCRIPTION
## Summary

The audio-player provider's focus/visibilitychange handler dispatches `INIT_QUEUE` on every tab focus, even when the server returns a queue that's content-equal to what's already in state. Each unconditional dispatch produces a fresh `state.queue` array reference, re-firing the `[state.queue]` persist effect — one wasted localStorage write per focus event, plus a full reconcile of every component subscribed to queue state. On a podcast detail page rendering ~200 affordance buttons, this is a real re-render storm on every tab focus.

This PR adds a content-equality check at the **dispatch site** (not in the reducer) so the dispatch is skipped entirely when the server payload matches `state.queue` field-by-field.

### Why dispatch-site, not reducer-level

Initial draft of this fix lived in the reducer. The pre-PR review surfaced two real correctness issues with that approach:

- **The reducer `INIT_QUEUE` invariant ("always produces new state") is load-bearing.** The persist effect's rollback path sets `suppressQueueWriteRef = true` and dispatches `INIT_QUEUE` expecting the `[state.queue]` effect to fire and consume the flag. A reducer-level no-op would strand the flag and silently drop the next user mutation from server sync. The existing comment at `src/contexts/audio-player-context.tsx:622-624` explicitly warns about this exact failure mode.
- **ID-only equality discards legitimate metadata refreshes.** The server may update `title` / `audioUrl` / `artwork` / `chaptersUrl` while keeping IDs stable. The reducer-level draft used ID-only equality and would silently drop those updates.

Moving the check to the dispatch site (a) keeps the reducer pure, (b) preserves the suppress-flag mechanism, and (c) lets the focus-refetch caller use full-field equality without changing the contract for the other six `INIT_QUEUE` call sites (mount hydration, user-switch, server reconcile, rollback).

## Test plan

- [x] New test: focus refetch with content-equal server queue does NOT re-fire the persist effect. The mock returns a fresh array reference per call to mirror production deserialization (the previous version aliased a single array, which masked the regression — verified empirically).
- [x] New test: focus refetch with same-id-but-different-metadata MUST re-fire the persist effect — guards against ID-only-equality regressions.
- [x] Both tests verified to fail when the dispatch-site guard is removed (test 1) or weakened to ID-only equality (test 2).
- [x] All 70 existing tests in `audio-player-context.test.tsx` pass unchanged (provider behavior preserved).
- [x] `bun run format:check`, `bun run lint`, `bun run test` (2222 tests), `bun run build` all green.

## Out of scope

- Reorder-induced re-renders (the same `Set` rebuild affects `useIsEpisodeInQueue` consumers introduced in #371). Tracked separately — different optimization, different surface.
- Mount-time / user-switch / rollback dispatches. Those fire infrequently (once per mount, once per auth change, only on write failure) and aren't a measurable hot path. The same `queuesEqualByContent` helper could be applied there if needed.

## Context

Surfaced during pre-PR validation review of #371. Independent fix, can ship before or after that PR.