### PR TITLE
refactor: introduce PodcastIndexEpisodeId branded type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Audio player: narrow context selectors for affordance buttons (PlayEpisodeButton, AddToQueueButton) — eliminates re-renders on volume/scrub/buffering ticks. The provider also memoizes `QueueEpisodeIdsContext` against content equality so reorders (and any non-membership-changing queue refresh) preserve the Set reference and don't re-render queue-aware consumers. See ADR-039.
-- Internal: introduced `PodcastIndexEpisodeId` branded type to disambiguate the PodcastIndex episode id namespace from DB-internal and Clerk user ids at compile time. No runtime behaviour change. See ADR-039.
+- Internal: introduced `PodcastIndexEpisodeId` branded type to disambiguate the PodcastIndex episode id namespace from DB-internal and Clerk user ids at compile time. No runtime behaviour change. See ADR-040.
 - Topics query (`getTopicsByPodcastIndexId`) now caps per-episode results with a Postgres `row_number() OVER (PARTITION BY episode_id)` window function instead of a JS loop, so only `TOPICS_PER_EPISODE_LIMIT` rows are sent across the wire per episode (3a).
 - `PlayEpisodeButton` now uses `aria-disabled` + `aria-disabled:opacity-50 aria-disabled:cursor-not-allowed` Tailwind utilities instead of native `disabled`, keeping the button keyboard-focusable and screen-reader–accessible when an episode is actively playing (3b).
 - `TOPICS_PER_EPISODE_LIMIT` is now derived as `MAX_DISPLAYED_TOPICS + 1` from the shared `src/lib/episodes/topic-display.ts` module (consumed by both `EpisodeCard` and the topics server helper), linking the DB cap to the primitive's chip count without forcing the server to import a component (3c).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Audio player: narrow context selectors for affordance buttons (PlayEpisodeButton, AddToQueueButton) — eliminates re-renders on volume/scrub/buffering ticks. The provider also memoizes `QueueEpisodeIdsContext` against content equality so reorders (and any non-membership-changing queue refresh) preserve the Set reference and don't re-render queue-aware consumers. See ADR-039.
+- Internal: introduced `PodcastIndexEpisodeId` branded type to disambiguate the PodcastIndex episode id namespace from DB-internal and Clerk user ids at compile time. No runtime behaviour change. See ADR-039.
 - Topics query (`getTopicsByPodcastIndexId`) now caps per-episode results with a Postgres `row_number() OVER (PARTITION BY episode_id)` window function instead of a JS loop, so only `TOPICS_PER_EPISODE_LIMIT` rows are sent across the wire per episode (3a).
 - `PlayEpisodeButton` now uses `aria-disabled` + `aria-disabled:opacity-50 aria-disabled:cursor-not-allowed` Tailwind utilities instead of native `disabled`, keeping the button keyboard-focusable and screen-reader–accessible when an episode is actively playing (3b).
 - `TOPICS_PER_EPISODE_LIMIT` is now derived as `MAX_DISPLAYED_TOPICS + 1` from the shared `src/lib/episodes/topic-display.ts` module (consumed by both `EpisodeCard` and the topics server helper), linking the DB cap to the primitive's chip count without forcing the server to import a component (3c).

--- a/docs/adr/039-podcast-index-episode-id-branded-type.md
+++ b/docs/adr/039-podcast-index-episode-id-branded-type.md
@@ -1,0 +1,87 @@
+# ADR-039: PodcastIndexEpisodeId Branded Type for Compile-Time ID Disambiguation
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Issue:** [#352](https://github.com/Chalet-Labs/contentgenie/issues/352)
+
+---
+
+## Context
+
+ContentGenie carries three episode-id namespaces that are structurally indistinguishable at the TypeScript level:
+
+1. **DB internal id** — `episodes.id` (`serial` → `number`).
+2. **PodcastIndex episode id** — stringified numeric id from the PodcastIndex API, persisted as `text` in `episodes.podcastIndexId` and `listenHistory.podcastIndexEpisodeId`. Used everywhere a client needs to address an episode (URLs, server-action params, denormalized prop arrays).
+3. **Clerk user id** — `string`, unrelated but lives in the same plain-`string` type zoo.
+
+The PI-episode-id namespace crosses a stringification seam any time a `PodcastIndexEpisode` arrives from the PodcastIndex API (where `id: number | string`) and gets normalised with `String(episode.id)` before being passed to ROUTES, server actions, or component props. A separate stringification seam exists at `String(dbEpisode.id)`, where a DB internal id is coerced — these two `string` results are indistinguishable to the type system, so a refactor can silently swap one for the other. The failure mode is "empty result set" at runtime, not a compile error.
+
+PR #350 added two new surfaces that reinforce the problem with no compile-time guards:
+
+- `listenedIds?: string[]` (`NotificationPageList`)
+- `topicsByPodcastIndexId?: Record<string, string[]>` (`EpisodeList`, podcast page)
+
+## Decision
+
+Introduce a single branded type for the PodcastIndex _episode_ id namespace and apply it from the database column outward through every type-level boundary it crosses.
+
+```ts
+// src/types/ids.ts
+export type PodcastIndexEpisodeId = string & {
+  readonly __brand: "PodcastIndexEpisodeId";
+};
+
+// Compile-time tool only. Runtime validation (zod, route param parsing)
+// is a separate concern handled at external-input boundaries.
+export function asPodcastIndexEpisodeId(s: string): PodcastIndexEpisodeId {
+  return s as PodcastIndexEpisodeId;
+}
+```
+
+The brand is applied at the type origin via Drizzle's column-type hint (`text(...).$type<PodcastIndexEpisodeId>()`) on `episodes.podcastIndexId` and `listenHistory.podcastIndexEpisodeId`. From there, every consumer that selects the column inherits the branded type automatically — server actions, API responses, server components, denormalized rows, and (transitively) client component props.
+
+`asPodcastIndexEpisodeId(...)` is inserted exactly once per external-input seam: where a raw `string` (from `String(numericId)`, JSON body, URL param, or zod schema output) crosses into the branded zone. Each insertion is paired with a one-line comment naming the source namespace.
+
+### Scope
+
+**In scope (gets the brand):**
+
+- `episodes.podcastIndexId`, `listenHistory.podcastIndexEpisodeId` columns.
+- `ROUTES.episode(id)` parameter.
+- `AudioEpisode.id` and `EpisodeDenormRow.episodeId`.
+- Server-action signatures that take or return PI episode ids (`recordListenEvent`, `isEpisodeSaved`, `saveEpisode`, `removeFromLibrary`, `getQueueEpisodeScores`, `getTopicsByPodcastIndexId`, etc.).
+- Component prop types: `listenedIds`, `knownIds`, `topicsByPodcastIndexId`, `initialListenedIds`.
+
+**Out of scope (deferred until pain surfaces):**
+
+- Separate brands for `DbEpisodeId` (`number`), `ClerkUserId` (`string`), or `PodcastIndexPodcastId` (`podcasts.podcastIndexId` is a distinct namespace from episode ids; it is _not_ mixed with PI-episode-ids in current code).
+- Adding zod runtime validation at external-input boundaries (separate concern; brand is compile-time only).
+- Refactoring `episode.id` consumers that use the PI-episode-id where a DB internal id might be more appropriate (semantic change, not a type cleanup).
+
+### Why a single namespace, not three
+
+Two of the three id types in the introduction (DB internal id, Clerk user id) are not currently mixed up with PI episode ids in any reachable code path that a senior reviewer would call a real risk. Branding only the namespace that demonstrably leaks (`String(dbEpisode.id)` flowing into a `listenedIds: PodcastIndexEpisodeId[]` slot) gives the compile-time safety we need with the minimum surface change. The pattern in `src/types/ids.ts` is a template — adding `DbEpisodeId` or `ClerkUserId` later is a 5-line follow-up if a real bug surfaces.
+
+### Why an `as`-cast constructor, not a runtime check
+
+The brand exists to disambiguate already-validated strings at the type level. Validation (length, character set, server-side existence check) happens elsewhere — at zod schemas for server-action inputs and at the DB lookup that resolves `eq(episodes.podcastIndexId, value)` to either a row or a 404. Forcing a runtime check inside `asPodcastIndexEpisodeId` would either duplicate validation already done at the boundary or introduce a half-measure that gives false confidence. The constructor is a typed `as`-cast, consistent with the issue's blueprint.
+
+## Consequences
+
+### Positive
+
+- Passing `String(dbEpisode.id)` to a slot expecting `PodcastIndexEpisodeId[]` (or `Record<PodcastIndexEpisodeId, ...>`, or `ROUTES.episode(...)`, etc.) becomes a TypeScript error.
+- Drizzle column results carry the brand transitively — most consumers don't need explicit casts; the brand "just appears" in row types.
+- Future id-namespace brands (Clerk user id, podcast id, etc.) follow the exact same template.
+- Zero runtime cost: branded strings erase to plain strings in emitted JS.
+
+### Negative
+
+- Every external-input boundary that produces a PI episode id now needs an explicit `asPodcastIndexEpisodeId(...)` cast at exactly one site. Roughly 30–40 such seams across the repo (DB-internal-id → PI-id stringifications, JSON body parses, route-param parses, Trigger.dev numeric-payload-to-string casts, test fixtures).
+- Test fixtures that hand-construct mock data with PI episode id literals need a single `as PodcastIndexEpisodeId` cast (or call to the constructor) per literal. This is cosmetic and mechanical.
+- The brand can be circumvented by an `as PodcastIndexEpisodeId` cast or by the constructor itself. This is by design — the brand is a hint to the compiler, not a fortress.
+
+### Risks
+
+- **Drift.** New code that constructs PI episode ids from external sources may forget to cast and instead widen surface types back to `string`. Mitigation: prop types are tightened at the closest point to the consumer (component props, server-action signatures), so the TS error surfaces at the call site, not deep inside a helper.
+- **Drizzle `$type` regressions.** If a future schema migration drops `$type<PodcastIndexEpisodeId>()` from a column, downstream consumers silently fall back to plain `string` and the brand evaporates for that path. Mitigation: column-level `$type` lives in one file (`src/db/schema.ts`); a code-review checklist entry covers this when touching the schema.

--- a/docs/adr/040-podcast-index-episode-id-branded-type.md
+++ b/docs/adr/040-podcast-index-episode-id-branded-type.md
@@ -1,4 +1,4 @@
-# ADR-039: PodcastIndexEpisodeId Branded Type for Compile-Time ID Disambiguation
+# ADR-040: PodcastIndexEpisodeId Branded Type for Compile-Time ID Disambiguation
 
 **Status:** Accepted
 **Date:** 2026-04-25

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -8,7 +8,6 @@ import {
 import { getListenedEpisodeIds } from "@/app/actions/listen-history";
 import { NotificationPageList } from "@/components/notifications/notification-page-list";
 import { NOTIFICATIONS_PAGE_SIZE } from "@/lib/notifications-constants";
-import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 export const metadata: Metadata = {
   title: "Notifications",

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -8,6 +8,7 @@ import {
 import { getListenedEpisodeIds } from "@/app/actions/listen-history";
 import { NotificationPageList } from "@/components/notifications/notification-page-list";
 import { NOTIFICATIONS_PAGE_SIZE } from "@/lib/notifications-constants";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 export const metadata: Metadata = {
   title: "Notifications",
@@ -102,14 +103,16 @@ export default async function NotificationsPage({
   ]);
 
   const listenedDbIdSet = new Set(listenedDbIds);
-  const initialListenedIds = notifications
-    .filter(
-      (n) =>
-        n.episodeDbId !== null &&
-        listenedDbIdSet.has(n.episodeDbId) &&
-        n.episodePodcastIndexId,
-    )
-    .map((n) => n.episodePodcastIndexId as string);
+  const initialListenedIds = notifications.flatMap((n) => {
+    if (
+      n.episodeDbId !== null &&
+      listenedDbIdSet.has(n.episodeDbId) &&
+      n.episodePodcastIndexId !== null
+    ) {
+      return [n.episodePodcastIndexId]; // narrowed to PodcastIndexEpisodeId
+    }
+    return [];
+  });
 
   return (
     <div className="py-8">

--- a/src/app/(app)/podcast/[id]/__tests__/topics.test.ts
+++ b/src/app/(app)/podcast/[id]/__tests__/topics.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Inner chain: select → from → where → as (stand-in for the subquery object).
 const mockInnerAs = vi.fn(() => ({}));
@@ -65,7 +66,7 @@ describe("getTopicsByPodcastIndexId", () => {
   it("returns {} when no topic rows exist for the requested episodes", async () => {
     mockOuterOrderBy.mockResolvedValue([]);
     const result = await getTopicsByPodcastIndexId([
-      { id: 1, podcastIndexId: "PI-1" },
+      { id: 1, podcastIndexId: asPodcastIndexEpisodeId("PI-1") },
     ]);
     expect(result).toEqual({});
   });
@@ -78,9 +79,14 @@ describe("getTopicsByPodcastIndexId", () => {
       { episodeId: 1, topic: "D" },
     ]);
     const result = await getTopicsByPodcastIndexId([
-      { id: 1, podcastIndexId: "PI-1" },
+      { id: 1, podcastIndexId: asPodcastIndexEpisodeId("PI-1") },
     ]);
-    expect(result["PI-1"]).toEqual(["A", "B", "C", "D"]);
+    expect(result[asPodcastIndexEpisodeId("PI-1")]).toEqual([
+      "A",
+      "B",
+      "C",
+      "D",
+    ]);
   });
 
   it("trusts the DB cap — does not re-cap in JS if extra rows slip through", async () => {
@@ -93,9 +99,11 @@ describe("getTopicsByPodcastIndexId", () => {
     }));
     mockOuterOrderBy.mockResolvedValue(oversized);
     const result = await getTopicsByPodcastIndexId([
-      { id: 1, podcastIndexId: "PI-1" },
+      { id: 1, podcastIndexId: asPodcastIndexEpisodeId("PI-1") },
     ]);
-    expect(result["PI-1"]).toHaveLength(oversized.length);
+    expect(result[asPodcastIndexEpisodeId("PI-1")]).toHaveLength(
+      oversized.length,
+    );
   });
 
   it("remaps DB ids to PodcastIndex ids in the output keys", async () => {
@@ -104,8 +112,8 @@ describe("getTopicsByPodcastIndexId", () => {
       { episodeId: 20, topic: "Y" },
     ]);
     const result = await getTopicsByPodcastIndexId([
-      { id: 10, podcastIndexId: "PI-A" },
-      { id: 20, podcastIndexId: "PI-B" },
+      { id: 10, podcastIndexId: asPodcastIndexEpisodeId("PI-A") },
+      { id: 20, podcastIndexId: asPodcastIndexEpisodeId("PI-B") },
     ]);
     expect(result).toEqual({ "PI-A": ["X"], "PI-B": ["Y"] });
   });
@@ -114,7 +122,7 @@ describe("getTopicsByPodcastIndexId", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockOuterOrderBy.mockRejectedValue(new Error("neon unreachable"));
     const result = await getTopicsByPodcastIndexId([
-      { id: 1, podcastIndexId: "PI-1" },
+      { id: 1, podcastIndexId: asPodcastIndexEpisodeId("PI-1") },
     ]);
     expect(result).toEqual({});
     expect(errSpy).toHaveBeenCalledWith(

--- a/src/app/(app)/podcast/[id]/page.tsx
+++ b/src/app/(app)/podcast/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/podcastindex";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import { isSubscribedToPodcast } from "@/app/actions/subscriptions";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import { getListenedEpisodeIds } from "@/app/actions/listen-history";
 import { db } from "@/db";
 import { podcasts, episodes as episodesTable } from "@/db/schema";
@@ -316,7 +317,10 @@ export default async function PodcastPage({
     const episodes = episodesResponse.items || [];
 
     // Batch-query DB for summary data
-    const episodeStringIds = episodes.map((e) => String(e.id));
+    // PodcastIndex API id (number|string) → branded string.
+    const episodeStringIds = episodes.map((e) =>
+      asPodcastIndexEpisodeId(String(e.id)),
+    );
     const dbEpisodeData =
       episodeStringIds.length > 0
         ? await db.query.episodes.findMany({

--- a/src/app/(app)/podcast/[id]/topics.ts
+++ b/src/app/(app)/podcast/[id]/topics.ts
@@ -45,10 +45,7 @@ export async function getTopicsByPodcastIndexId(
       .where(lte(sub.rn, TOPICS_PER_EPISODE_LIMIT))
       .orderBy(sub.episodeId, sub.rn);
 
-    const out: Record<PodcastIndexEpisodeId, string[]> = {} as Record<
-      PodcastIndexEpisodeId,
-      string[]
-    >;
+    const out = {} as Record<PodcastIndexEpisodeId, string[]>;
     for (const row of rows) {
       const pi = idToPodcastIndexId.get(row.episodeId);
       if (!pi) continue;

--- a/src/app/(app)/podcast/[id]/topics.ts
+++ b/src/app/(app)/podcast/[id]/topics.ts
@@ -2,6 +2,7 @@ import { inArray, lte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { episodeTopics } from "@/db/schema";
 import { TOPICS_PER_EPISODE_LIMIT } from "@/lib/episodes/topic-display";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 export { TOPICS_PER_EPISODE_LIMIT };
 
@@ -12,8 +13,8 @@ export { TOPICS_PER_EPISODE_LIMIT };
  * page for a decorative chip row.
  */
 export async function getTopicsByPodcastIndexId(
-  dbEpisodes: { id: number; podcastIndexId: string }[],
-): Promise<Record<string, string[]>> {
+  dbEpisodes: { id: number; podcastIndexId: PodcastIndexEpisodeId }[],
+): Promise<Record<PodcastIndexEpisodeId, string[]>> {
   if (dbEpisodes.length === 0) return {};
   try {
     const episodeIds = dbEpisodes.map((e) => e.id);
@@ -44,7 +45,10 @@ export async function getTopicsByPodcastIndexId(
       .where(lte(sub.rn, TOPICS_PER_EPISODE_LIMIT))
       .orderBy(sub.episodeId, sub.rn);
 
-    const out: Record<string, string[]> = {};
+    const out: Record<PodcastIndexEpisodeId, string[]> = {} as Record<
+      PodcastIndexEpisodeId,
+      string[]
+    >;
     for (const row of rows) {
       const pi = idToPodcastIndexId.get(row.episodeId);
       if (!pi) continue;

--- a/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
+++ b/src/app/(app)/trending/[slug]/__tests__/trending-detail-content.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { TrendingTopic } from "@/db/schema";
 import type { RecommendedEpisodeDTO } from "@/db/library-columns";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const mockGetTrendingTopicBySlug = vi.fn();
 vi.mock("@/app/actions/dashboard", () => ({
@@ -35,7 +36,7 @@ const climateTopic: TrendingTopic = {
 
 const mockEpisode: RecommendedEpisodeDTO = {
   id: 10,
-  podcastIndexId: "pod-10",
+  podcastIndexId: asPodcastIndexEpisodeId("pod-10"),
   title: "AI Episode",
   description: "About AI",
   audioUrl: "https://example.com/ai.mp3",

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makeClerkAuthMock } from "@/test/mocks/clerk-server";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock Clerk auth
 const mockAuth = vi.fn();
@@ -850,7 +851,9 @@ describe("getEpisodeTopicOverlap", () => {
     mockAuth.mockResolvedValue({ userId: null });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
-    const result = await getEpisodeTopicOverlap("ep-123");
+    const result = await getEpisodeTopicOverlap(
+      asPodcastIndexEpisodeId("ep-123"),
+    );
 
     expect(result.label).toBeNull();
     expect(result.overlapCount).toBe(0);
@@ -861,7 +864,9 @@ describe("getEpisodeTopicOverlap", () => {
     mockLimit.mockResolvedValue([]);
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
-    const result = await getEpisodeTopicOverlap("ep-999");
+    const result = await getEpisodeTopicOverlap(
+      asPodcastIndexEpisodeId("ep-999"),
+    );
 
     expect(result.label).toBeNull();
   });
@@ -891,7 +896,9 @@ describe("getEpisodeTopicOverlap", () => {
     });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
-    const result = await getEpisodeTopicOverlap("ep-42");
+    const result = await getEpisodeTopicOverlap(
+      asPodcastIndexEpisodeId("ep-42"),
+    );
 
     expect(result.label).toBe("You've heard 4 similar episodes");
     expect(result.overlapCount).toBe(4);
@@ -917,7 +924,9 @@ describe("getEpisodeTopicOverlap", () => {
     });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
-    const result = await getEpisodeTopicOverlap("ep-42");
+    const result = await getEpisodeTopicOverlap(
+      asPodcastIndexEpisodeId("ep-42"),
+    );
 
     expect(result.label).toBeNull();
   });
@@ -926,7 +935,9 @@ describe("getEpisodeTopicOverlap", () => {
     mockLimit.mockRejectedValue(new Error("DB failure"));
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
-    const result = await getEpisodeTopicOverlap("ep-42");
+    const result = await getEpisodeTopicOverlap(
+      asPodcastIndexEpisodeId("ep-42"),
+    );
 
     expect(result.label).toBeNull();
     expect(result.overlapCount).toBe(0);

--- a/src/app/actions/__tests__/library-rating.test.ts
+++ b/src/app/actions/__tests__/library-rating.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock database
 const mockSelect = vi.fn();
@@ -40,7 +41,9 @@ describe("getEpisodeAverageRating", () => {
     mockQueryChain([{ averageRating: "4.0", ratingCount: 3 }]);
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
-    const result = await getEpisodeAverageRating("ep123");
+    const result = await getEpisodeAverageRating(
+      "ep123" as PodcastIndexEpisodeId,
+    );
 
     expect(result.averageRating).toBe(4.0);
     expect(result.ratingCount).toBe(3);
@@ -51,7 +54,9 @@ describe("getEpisodeAverageRating", () => {
     mockQueryChain([]);
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
-    const result = await getEpisodeAverageRating("ep123");
+    const result = await getEpisodeAverageRating(
+      "ep123" as PodcastIndexEpisodeId,
+    );
 
     expect(result.averageRating).toBeNull();
     expect(result.ratingCount).toBe(0);
@@ -62,7 +67,9 @@ describe("getEpisodeAverageRating", () => {
     mockQueryChain([]);
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
-    const result = await getEpisodeAverageRating("nonexistent");
+    const result = await getEpisodeAverageRating(
+      "nonexistent" as PodcastIndexEpisodeId,
+    );
 
     expect(result.averageRating).toBeNull();
     expect(result.ratingCount).toBe(0);

--- a/src/app/actions/__tests__/library-rating.test.ts
+++ b/src/app/actions/__tests__/library-rating.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { PodcastIndexEpisodeId } from "@/types/ids";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock database
 const mockSelect = vi.fn();
@@ -42,7 +42,7 @@ describe("getEpisodeAverageRating", () => {
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
     const result = await getEpisodeAverageRating(
-      "ep123" as PodcastIndexEpisodeId,
+      asPodcastIndexEpisodeId("ep123"),
     );
 
     expect(result.averageRating).toBe(4.0);
@@ -55,7 +55,7 @@ describe("getEpisodeAverageRating", () => {
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
     const result = await getEpisodeAverageRating(
-      "ep123" as PodcastIndexEpisodeId,
+      asPodcastIndexEpisodeId("ep123"),
     );
 
     expect(result.averageRating).toBeNull();
@@ -68,7 +68,7 @@ describe("getEpisodeAverageRating", () => {
 
     const { getEpisodeAverageRating } = await import("@/app/actions/library");
     const result = await getEpisodeAverageRating(
-      "nonexistent" as PodcastIndexEpisodeId,
+      asPodcastIndexEpisodeId("nonexistent"),
     );
 
     expect(result.averageRating).toBeNull();

--- a/src/app/actions/__tests__/library-save.test.ts
+++ b/src/app/actions/__tests__/library-save.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makeClerkAuthMock } from "@/test/mocks/clerk-server";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock Clerk auth
 const mockAuth = vi.fn();
@@ -92,7 +93,7 @@ describe("saveEpisodeToLibrary", () => {
 
     const { saveEpisodeToLibrary } = await import("@/app/actions/library");
     const result = await saveEpisodeToLibrary({
-      podcastIndexId: "ep1",
+      podcastIndexId: asPodcastIndexEpisodeId("ep1"),
       title: "Episode 1",
       podcast: {
         podcastIndexId: "pod1",
@@ -117,7 +118,7 @@ describe("saveEpisodeToLibrary", () => {
 
     const { saveEpisodeToLibrary } = await import("@/app/actions/library");
     const result = await saveEpisodeToLibrary({
-      podcastIndexId: "ep1",
+      podcastIndexId: asPodcastIndexEpisodeId("ep1"),
       title: "Episode 1",
       podcast: {
         podcastIndexId: "pod1",

--- a/src/app/actions/__tests__/library.test.ts
+++ b/src/app/actions/__tests__/library.test.ts
@@ -5,6 +5,9 @@ import {
   makeClerkAuthMock,
   testDbError,
 } from "@/app/actions/__tests__/__fixtures";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
+
+const epId = asPodcastIndexEpisodeId("ep1");
 
 // ── Mocks ─────────────────────────────────────────────────────────────────
 
@@ -209,7 +212,7 @@ beforeEach(() => {
 });
 
 const validEpisodeData = {
-  podcastIndexId: "ep1",
+  podcastIndexId: epId,
   title: "Episode 1",
   description: "An episode",
   audioUrl: "https://example.com/a.mp3",
@@ -349,7 +352,7 @@ describe("removeEpisodeFromLibrary", () => {
   it("removes episode and revalidates paths", async () => {
     mockEpisodesFindFirst.mockResolvedValue({ id: 42 });
     const { removeEpisodeFromLibrary } = await importLibrary();
-    const result = await removeEpisodeFromLibrary("ep1");
+    const result = await removeEpisodeFromLibrary(epId);
     expect(result).toEqual({
       success: true,
       message: "Episode removed from library",
@@ -374,7 +377,7 @@ describe("removeEpisodeFromLibrary", () => {
   it("returns error when unauthenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { removeEpisodeFromLibrary } = await importLibrary();
-    const result = await removeEpisodeFromLibrary("ep1");
+    const result = await removeEpisodeFromLibrary(epId);
     expect(result.success).toBe(false);
     expect(mockEpisodesFindFirst).not.toHaveBeenCalled();
   });
@@ -382,7 +385,7 @@ describe("removeEpisodeFromLibrary", () => {
   it("returns 'Episode not found' when episode missing", async () => {
     mockEpisodesFindFirst.mockResolvedValue(undefined);
     const { removeEpisodeFromLibrary } = await importLibrary();
-    const result = await removeEpisodeFromLibrary("ep1");
+    const result = await removeEpisodeFromLibrary(epId);
     expect(result).toEqual({ success: false, error: "Episode not found" });
     expect(mockDelete).not.toHaveBeenCalled();
   });
@@ -391,7 +394,7 @@ describe("removeEpisodeFromLibrary", () => {
     "returns generic error when DB throws",
     testDbError(mockEpisodesFindFirst, async () => {
       const { removeEpisodeFromLibrary } = await importLibrary();
-      return removeEpisodeFromLibrary("ep1");
+      return removeEpisodeFromLibrary(epId);
     }),
   );
 });
@@ -404,19 +407,19 @@ describe("isEpisodeSaved", () => {
   it("returns true when query returns a row", async () => {
     mockLimit.mockResolvedValue([{ id: 1 }]);
     const { isEpisodeSaved } = await importLibrary();
-    expect(await isEpisodeSaved("ep1")).toBe(true);
+    expect(await isEpisodeSaved(epId)).toBe(true);
   });
 
   it("returns false when query returns empty", async () => {
     mockLimit.mockResolvedValue([]);
     const { isEpisodeSaved } = await importLibrary();
-    expect(await isEpisodeSaved("ep1")).toBe(false);
+    expect(await isEpisodeSaved(epId)).toBe(false);
   });
 
   it("returns false when unauthenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { isEpisodeSaved } = await importLibrary();
-    expect(await isEpisodeSaved("ep1")).toBe(false);
+    expect(await isEpisodeSaved(epId)).toBe(false);
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
@@ -424,7 +427,7 @@ describe("isEpisodeSaved", () => {
     mockLimit.mockRejectedValue(new Error("DB failure"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { isEpisodeSaved } = await importLibrary();
-    expect(await isEpisodeSaved("ep1")).toBe(false);
+    expect(await isEpisodeSaved(epId)).toBe(false);
     expect(consoleSpy).toHaveBeenCalled();
   });
 });
@@ -608,7 +611,7 @@ describe("updateLibraryNotes", () => {
     mockEpisodesFindFirst.mockResolvedValue({ id: 42 });
     mockUserLibraryFindFirst.mockResolvedValue({ id: 1 });
     const { updateLibraryNotes } = await importLibrary();
-    const result = await updateLibraryNotes("ep1", "my note");
+    const result = await updateLibraryNotes(epId, "my note");
     expect(result).toEqual({ success: true, message: "Notes updated" });
     expect(mockUpdateSet).toHaveBeenCalledWith({ notes: "my note" });
     expect(mockRevalidatePath).toHaveBeenCalledWith("/library");
@@ -617,7 +620,7 @@ describe("updateLibraryNotes", () => {
   it("returns error when unauthenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { updateLibraryNotes } = await importLibrary();
-    const result = await updateLibraryNotes("ep1", "x");
+    const result = await updateLibraryNotes(epId, "x");
     expect(result.success).toBe(false);
     expect(mockEpisodesFindFirst).not.toHaveBeenCalled();
   });
@@ -625,7 +628,7 @@ describe("updateLibraryNotes", () => {
   it("returns 'Episode not found' when episode missing", async () => {
     mockEpisodesFindFirst.mockResolvedValue(undefined);
     const { updateLibraryNotes } = await importLibrary();
-    const result = await updateLibraryNotes("ep1", "x");
+    const result = await updateLibraryNotes(epId, "x");
     expect(result).toEqual({ success: false, error: "Episode not found" });
   });
 
@@ -633,7 +636,7 @@ describe("updateLibraryNotes", () => {
     mockEpisodesFindFirst.mockResolvedValue({ id: 42 });
     mockUserLibraryFindFirst.mockResolvedValue(undefined);
     const { updateLibraryNotes } = await importLibrary();
-    const result = await updateLibraryNotes("ep1", "x");
+    const result = await updateLibraryNotes(epId, "x");
     expect(result).toEqual({ success: false, error: "Episode not in library" });
   });
 
@@ -641,7 +644,7 @@ describe("updateLibraryNotes", () => {
     "returns generic error when DB throws",
     testDbError(mockEpisodesFindFirst, async () => {
       const { updateLibraryNotes } = await importLibrary();
-      return updateLibraryNotes("ep1", "x");
+      return updateLibraryNotes(epId, "x");
     }),
   );
 });
@@ -831,7 +834,7 @@ describe("updateLibraryRating", () => {
     mockEpisodesFindFirst.mockResolvedValue({ id: 42 });
     mockUserLibraryFindFirst.mockResolvedValue({ id: 1 });
     const { updateLibraryRating } = await importLibrary();
-    const result = await updateLibraryRating("ep1", 4);
+    const result = await updateLibraryRating(epId, 4);
     expect(result).toEqual({ success: true, message: "Rating updated" });
     expect(mockUpdateSet).toHaveBeenCalledWith({ rating: 4 });
     expect(mockRevalidatePath).toHaveBeenCalledWith("/library");
@@ -840,13 +843,13 @@ describe("updateLibraryRating", () => {
   it("returns error when unauthenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { updateLibraryRating } = await importLibrary();
-    const result = await updateLibraryRating("ep1", 4);
+    const result = await updateLibraryRating(epId, 4);
     expect(result.success).toBe(false);
   });
 
   it.each([0, 6, -1, 10])("rejects out-of-range rating %i", async (rating) => {
     const { updateLibraryRating } = await importLibrary();
-    const result = await updateLibraryRating("ep1", rating);
+    const result = await updateLibraryRating(epId, rating);
     expect(result).toEqual({
       success: false,
       error: "Rating must be between 1 and 5",
@@ -857,7 +860,7 @@ describe("updateLibraryRating", () => {
   it("returns 'Episode not found' when missing", async () => {
     mockEpisodesFindFirst.mockResolvedValue(undefined);
     const { updateLibraryRating } = await importLibrary();
-    const result = await updateLibraryRating("ep1", 4);
+    const result = await updateLibraryRating(epId, 4);
     expect(result).toEqual({ success: false, error: "Episode not found" });
   });
 
@@ -865,7 +868,7 @@ describe("updateLibraryRating", () => {
     mockEpisodesFindFirst.mockResolvedValue({ id: 42 });
     mockUserLibraryFindFirst.mockResolvedValue(undefined);
     const { updateLibraryRating } = await importLibrary();
-    const result = await updateLibraryRating("ep1", 4);
+    const result = await updateLibraryRating(epId, 4);
     expect(result).toEqual({ success: false, error: "Episode not in library" });
   });
 
@@ -873,7 +876,7 @@ describe("updateLibraryRating", () => {
     "returns generic error when DB throws",
     testDbError(mockEpisodesFindFirst, async () => {
       const { updateLibraryRating } = await importLibrary();
-      return updateLibraryRating("ep1", 4);
+      return updateLibraryRating(epId, 4);
     }),
   );
 });
@@ -890,7 +893,7 @@ describe("getEpisodeAverageRating", () => {
       { averageRating: "4.27", ratingCount: 7 },
     ]);
     const { getEpisodeAverageRating } = await importLibrary();
-    const result = await getEpisodeAverageRating("ep1");
+    const result = await getEpisodeAverageRating(epId);
     expect(result).toEqual({
       averageRating: 4.3,
       ratingCount: 7,
@@ -901,7 +904,7 @@ describe("getEpisodeAverageRating", () => {
   it("returns null average when no ratings exist", async () => {
     mockSelectWhere.mockReturnValue([{ averageRating: null, ratingCount: 0 }]);
     const { getEpisodeAverageRating } = await importLibrary();
-    const result = await getEpisodeAverageRating("ep1");
+    const result = await getEpisodeAverageRating(epId);
     expect(result).toEqual({
       averageRating: null,
       ratingCount: 0,
@@ -915,7 +918,7 @@ describe("getEpisodeAverageRating", () => {
     });
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { getEpisodeAverageRating } = await importLibrary();
-    const result = await getEpisodeAverageRating("ep1");
+    const result = await getEpisodeAverageRating(epId);
     expect(result).toEqual({
       averageRating: null,
       ratingCount: 0,
@@ -933,20 +936,20 @@ describe("getLibraryEntryByEpisodeId", () => {
   it("returns the first row when found", async () => {
     mockLimit.mockResolvedValue([{ libraryEntryId: 1, episodeId: 42 }]);
     const { getLibraryEntryByEpisodeId } = await importLibrary();
-    const result = await getLibraryEntryByEpisodeId("ep1");
+    const result = await getLibraryEntryByEpisodeId(epId);
     expect(result).toEqual({ libraryEntryId: 1, episodeId: 42 });
   });
 
   it("returns null when query is empty", async () => {
     mockLimit.mockResolvedValue([]);
     const { getLibraryEntryByEpisodeId } = await importLibrary();
-    expect(await getLibraryEntryByEpisodeId("ep1")).toBeNull();
+    expect(await getLibraryEntryByEpisodeId(epId)).toBeNull();
   });
 
   it("returns null when unauthenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { getLibraryEntryByEpisodeId } = await importLibrary();
-    expect(await getLibraryEntryByEpisodeId("ep1")).toBeNull();
+    expect(await getLibraryEntryByEpisodeId(epId)).toBeNull();
     expect(mockSelect).not.toHaveBeenCalled();
   });
 
@@ -954,7 +957,7 @@ describe("getLibraryEntryByEpisodeId", () => {
     mockLimit.mockRejectedValue(new Error("DB failure"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { getLibraryEntryByEpisodeId } = await importLibrary();
-    expect(await getLibraryEntryByEpisodeId("ep1")).toBeNull();
+    expect(await getLibraryEntryByEpisodeId(epId)).toBeNull();
     expect(consoleSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/actions/__tests__/listen-history.test.ts
+++ b/src/app/actions/__tests__/listen-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makeClerkAuthMock } from "@/test/mocks/clerk-server";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock Clerk auth
 const mockAuth = vi.fn();
@@ -93,7 +94,7 @@ describe("recordListenEvent", () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "12345",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("12345"),
     });
     expect(result).toEqual({ success: false, error: "Unauthorized" });
     expect(mockInsert).not.toHaveBeenCalled();
@@ -103,7 +104,7 @@ describe("recordListenEvent", () => {
     mockFindFirst.mockResolvedValue(undefined);
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "99999",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("99999"),
     });
     expect(result).toEqual({ success: false, error: "Episode not found" });
     expect(mockFindFirst).toHaveBeenCalledTimes(1);
@@ -114,7 +115,7 @@ describe("recordListenEvent", () => {
   it("calls db.insert with correct values for a started event", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "99999",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("99999"),
     });
     expect(result).toEqual({ success: true });
     expect(mockFindFirst).toHaveBeenCalledTimes(1);
@@ -124,7 +125,7 @@ describe("recordListenEvent", () => {
     expect(insertedValues).toMatchObject({
       userId: "user_123",
       episodeId: 42,
-      podcastIndexEpisodeId: "99999",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("99999"),
     });
     expect(insertedValues.startedAt).toBeInstanceOf(Date);
   });
@@ -132,7 +133,7 @@ describe("recordListenEvent", () => {
   it("calls db.insert with correct values for a completed event", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "777",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("777"),
       completed: true,
       durationSeconds: 1800,
     });
@@ -142,7 +143,7 @@ describe("recordListenEvent", () => {
     expect(insertedValues).toMatchObject({
       userId: "user_123",
       episodeId: 42,
-      podcastIndexEpisodeId: "777",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("777"),
       listenDurationSeconds: 1800,
     });
     expect(insertedValues.startedAt).toBeInstanceOf(Date);
@@ -152,7 +153,7 @@ describe("recordListenEvent", () => {
   it("uses onConflictDoUpdate with COALESCE for startedAt (preserves first listen)", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     await recordListenEvent({
-      podcastIndexEpisodeId: "111",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("111"),
     });
     expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1);
     const upsertOpts = mockOnConflictDoUpdate.mock.calls[0][0];
@@ -175,7 +176,7 @@ describe("recordListenEvent", () => {
   it("uses GREATEST for listenDurationSeconds on completed events", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     await recordListenEvent({
-      podcastIndexEpisodeId: "111",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("111"),
       completed: true,
       durationSeconds: 1800,
     });
@@ -191,7 +192,7 @@ describe("recordListenEvent", () => {
   it("calls ensureUserExists before inserting", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     await recordListenEvent({
-      podcastIndexEpisodeId: "12345",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("12345"),
     });
     expect(mockEnsureUserExists).toHaveBeenCalledWith("user_123");
     expect(mockEnsureUserExists).toHaveBeenCalledTimes(1);
@@ -204,7 +205,7 @@ describe("recordListenEvent", () => {
   it("returns { success: false } when durationSeconds is negative", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "12345",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("12345"),
       durationSeconds: -10,
     });
     expect(result).toEqual({
@@ -217,7 +218,7 @@ describe("recordListenEvent", () => {
   it("returns { success: false } when durationSeconds is not an integer", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "12345",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("12345"),
       durationSeconds: 3.14,
     });
     expect(result).toEqual({
@@ -230,7 +231,7 @@ describe("recordListenEvent", () => {
   it("returns { success: false } when podcastIndexEpisodeId is empty", async () => {
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId(""),
     });
     expect(result).toEqual({ success: false, error: "Invalid input" });
     expect(mockFindFirst).not.toHaveBeenCalled();
@@ -244,7 +245,7 @@ describe("recordListenEvent", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { recordListenEvent } = await import("@/app/actions/listen-history");
     const result = await recordListenEvent({
-      podcastIndexEpisodeId: "12345",
+      podcastIndexEpisodeId: asPodcastIndexEpisodeId("12345"),
     });
     expect(result).toEqual({
       success: false,

--- a/src/app/actions/__tests__/queue-scores.test.ts
+++ b/src/app/actions/__tests__/queue-scores.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makeClerkAuthMock } from "@/test/mocks/clerk-server";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock Clerk auth
 const mockAuth = vi.fn();
@@ -52,7 +53,10 @@ describe("getQueueEpisodeScores", () => {
     mockAuth.mockResolvedValue({ userId: null });
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["123", "456"]);
+    const result = await getQueueEpisodeScores([
+      "123",
+      "456",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({});
     expect(mockSelect).not.toHaveBeenCalled();
   });
@@ -60,7 +64,7 @@ describe("getQueueEpisodeScores", () => {
   it("returns empty object for empty input", async () => {
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores([]);
+    const result = await getQueueEpisodeScores([] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({});
     expect(mockSelect).not.toHaveBeenCalled();
   });
@@ -68,7 +72,11 @@ describe("getQueueEpisodeScores", () => {
   it("returns empty object when all IDs are empty strings", async () => {
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["", "  ", ""]);
+    const result = await getQueueEpisodeScores([
+      "",
+      "  ",
+      "",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({});
     expect(mockSelect).not.toHaveBeenCalled();
   });
@@ -81,7 +89,10 @@ describe("getQueueEpisodeScores", () => {
     mockWhere.mockReturnValue(Promise.resolve(dbRows));
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["111", "222"]);
+    const result = await getQueueEpisodeScores([
+      "111",
+      "222",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({
       "111": parseFloat(dbRows[0].worthItScore),
       "222": parseFloat(dbRows[1].worthItScore),
@@ -94,7 +105,9 @@ describe("getQueueEpisodeScores", () => {
     );
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["333"]);
+    const result = await getQueueEpisodeScores([
+      "333",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({ "333": null });
   });
 
@@ -107,14 +120,20 @@ describe("getQueueEpisodeScores", () => {
     );
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["111", "999"]);
+    const result = await getQueueEpisodeScores([
+      "111",
+      "999",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({ "111": 7.0 });
     expect(Object.hasOwn(result, "999")).toBe(false);
   });
 
   it("caps input at 50 IDs", async () => {
     const { inArray } = await import("drizzle-orm");
-    const ids = Array.from({ length: 60 }, (_, i) => String(i + 1));
+    const ids = Array.from(
+      { length: 60 },
+      (_, i) => String(i + 1) as PodcastIndexEpisodeId,
+    );
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
     await getQueueEpisodeScores(ids);
@@ -127,7 +146,9 @@ describe("getQueueEpisodeScores", () => {
     mockWhere.mockReturnValue(Promise.reject(new Error("db failure")));
     const { getQueueEpisodeScores } =
       await import("@/app/actions/queue-scores");
-    const result = await getQueueEpisodeScores(["111"]);
+    const result = await getQueueEpisodeScores([
+      "111",
+    ] as PodcastIndexEpisodeId[]);
     expect(result).toEqual({});
   });
 });

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -3,6 +3,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
+import {
   eq,
   desc,
   and,
@@ -193,7 +197,10 @@ export async function getRecentEpisodesFromSubscriptions({
     const allEpisodes = Array.from(episodesByFeed.values()).flat();
 
     // Batch-query DB for worth-it scores (keyed by podcastIndexId = String(ep.id))
-    const podcastIndexIds = allEpisodes.map((ep) => String(ep.id));
+    // PodcastIndex API id (number|string) → branded string.
+    const podcastIndexIds = allEpisodes.map((ep) =>
+      asPodcastIndexEpisodeId(String(ep.id)),
+    );
     const scoreRows =
       podcastIndexIds.length > 0
         ? await db
@@ -426,7 +433,9 @@ export async function getRecommendedEpisodes(
 }
 
 // Get topic overlap for a single episode — used by the episode detail page.
-export async function getEpisodeTopicOverlap(podcastIndexEpisodeId: string) {
+export async function getEpisodeTopicOverlap(
+  podcastIndexEpisodeId: PodcastIndexEpisodeId,
+) {
   if (!podcastIndexEpisodeId) return EMPTY_OVERLAP_RESULT;
 
   const { userId } = await auth();

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -212,7 +212,7 @@ export async function getRecentEpisodesFromSubscriptions({
             .where(inArray(episodes.podcastIndexId, podcastIndexIds))
         : [];
 
-    const scoreMap = new Map<string, number | null>();
+    const scoreMap = new Map<PodcastIndexEpisodeId, number | null>();
     for (const row of scoreRows) {
       const parsed =
         row.worthItScore !== null ? parseFloat(row.worthItScore) : null;
@@ -225,7 +225,9 @@ export async function getRecentEpisodesFromSubscriptions({
     // Merge scores onto episodes
     const enrichedEpisodes: RecentEpisode[] = allEpisodes.map((ep) => ({
       ...ep,
-      worthItScore: scoreMap.get(String(ep.id)) ?? null,
+      // PodcastIndex API id (number|string) → branded string for keyed lookup.
+      worthItScore:
+        scoreMap.get(asPodcastIndexEpisodeId(String(ep.id))) ?? null,
     }));
 
     // Sort: scored episodes by score DESC, then unscored by datePublished DESC

--- a/src/app/actions/library.ts
+++ b/src/app/actions/library.ts
@@ -14,9 +14,10 @@ import {
   type SavedItemDTO,
 } from "@/db/library-columns";
 import { saveEpisodeSchema, safeParseDate } from "@/lib/schemas/library";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 type EpisodeData = {
-  podcastIndexId: string;
+  podcastIndexId: PodcastIndexEpisodeId;
   title: string;
   description?: string;
   audioUrl?: string;
@@ -123,7 +124,9 @@ export async function saveEpisodeToLibrary(episodeData: EpisodeData) {
 }
 
 // Remove an episode from the user's library
-export async function removeEpisodeFromLibrary(episodePodcastIndexId: string) {
+export async function removeEpisodeFromLibrary(
+  episodePodcastIndexId: PodcastIndexEpisodeId,
+) {
   const { userId } = await auth();
 
   if (!userId) {
@@ -169,7 +172,7 @@ export async function removeEpisodeFromLibrary(episodePodcastIndexId: string) {
 
 // Check if an episode is saved to the user's library
 export async function isEpisodeSaved(
-  episodePodcastIndexId: string,
+  episodePodcastIndexId: PodcastIndexEpisodeId,
 ): Promise<boolean> {
   const { userId } = await auth();
 
@@ -276,7 +279,7 @@ export async function getUserLibrary(
 
 // Update notes for a library entry
 export async function updateLibraryNotes(
-  episodePodcastIndexId: string,
+  episodePodcastIndexId: PodcastIndexEpisodeId,
   notes: string,
 ) {
   const { userId } = await auth();
@@ -451,7 +454,7 @@ export async function deleteBookmark(bookmarkId: number) {
 
 // Update rating for a library entry
 export async function updateLibraryRating(
-  episodePodcastIndexId: string,
+  episodePodcastIndexId: PodcastIndexEpisodeId,
   rating: number,
 ) {
   const { userId } = await auth();
@@ -504,7 +507,9 @@ export async function updateLibraryRating(
 }
 
 // Get average rating for an episode across all users
-export async function getEpisodeAverageRating(episodePodcastIndexId: string) {
+export async function getEpisodeAverageRating(
+  episodePodcastIndexId: PodcastIndexEpisodeId,
+) {
   try {
     const [result] = await db
       .select({
@@ -542,7 +547,7 @@ export async function getEpisodeAverageRating(episodePodcastIndexId: string) {
 
 // Resolve a PodcastIndex episode ID to the user's library entry ID
 export async function getLibraryEntryByEpisodeId(
-  episodePodcastIndexId: string,
+  episodePodcastIndexId: PodcastIndexEpisodeId,
 ): Promise<{ libraryEntryId: number; episodeId: number } | null> {
   const { userId } = await auth();
 

--- a/src/app/actions/listen-history.ts
+++ b/src/app/actions/listen-history.ts
@@ -7,9 +7,13 @@ import { episodes, listenHistory } from "@/db/schema";
 import { auth } from "@clerk/nextjs/server";
 import { withAuthAction } from "@/lib/auth-wrapper";
 import type { ActionResult } from "@/types/action-result";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 export async function recordListenEvent(input: {
-  podcastIndexEpisodeId: string;
+  podcastIndexEpisodeId: PodcastIndexEpisodeId;
   completed?: boolean;
   durationSeconds?: number;
 }): Promise<ActionResult> {
@@ -34,11 +38,16 @@ export async function recordListenEvent(input: {
     return { success: false, error: "Invalid durationSeconds" };
   }
 
+  // Post-validation cast — input already trimmed and length-checked.
+  const brandedEpisodeId = asPodcastIndexEpisodeId(
+    trimmedPodcastIndexEpisodeId,
+  );
+
   return withAuthAction(async (userId) => {
     try {
       const episode = await db.query.episodes.findFirst({
         columns: { id: true },
-        where: eq(episodes.podcastIndexId, trimmedPodcastIndexEpisodeId),
+        where: eq(episodes.podcastIndexId, brandedEpisodeId),
       });
 
       if (!episode) {
@@ -55,7 +64,7 @@ export async function recordListenEvent(input: {
         .values({
           userId,
           episodeId,
-          podcastIndexEpisodeId: trimmedPodcastIndexEpisodeId,
+          podcastIndexEpisodeId: brandedEpisodeId,
           startedAt: now,
           completedAt: completed ? now : null,
           listenDurationSeconds: durationSeconds ?? null,

--- a/src/app/actions/queue-scores.ts
+++ b/src/app/actions/queue-scores.ts
@@ -5,6 +5,10 @@ import { inArray } from "drizzle-orm";
 import { db } from "@/db";
 import { episodes } from "@/db/schema";
 import { parseScoreOrNull } from "@/lib/score-utils";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 const MAX_IDS = 50;
 
@@ -15,22 +19,24 @@ const MAX_IDS = 50;
  * Returns an empty object when unauthenticated or on error.
  */
 export async function getQueueEpisodeScores(
-  podcastIndexIds: string[],
-): Promise<Record<string, number | null>> {
+  podcastIndexIds: PodcastIndexEpisodeId[],
+): Promise<Record<PodcastIndexEpisodeId, number | null>> {
   try {
     const { userId } = await auth();
-    if (!userId) return {};
+    if (!userId) return {} as Record<PodcastIndexEpisodeId, number | null>;
 
     const ids = Array.from(
       new Set(
         podcastIndexIds
           .filter((id) => typeof id === "string")
-          .map((id) => id.trim())
+          // Re-brand after trim: PodcastIndexEpisodeId.trim() returns string.
+          .map((id) => asPodcastIndexEpisodeId(id.trim()))
           .filter((id) => id.length > 0),
       ),
     ).slice(0, MAX_IDS);
 
-    if (ids.length === 0) return {};
+    if (ids.length === 0)
+      return {} as Record<PodcastIndexEpisodeId, number | null>;
 
     const rows = await db
       .select({
@@ -40,7 +46,10 @@ export async function getQueueEpisodeScores(
       .from(episodes)
       .where(inArray(episodes.podcastIndexId, ids));
 
-    const result = Object.create(null) as Record<string, number | null>;
+    const result = Object.create(null) as Record<
+      PodcastIndexEpisodeId,
+      number | null
+    >;
     for (const row of rows) {
       result[row.podcastIndexId] = parseScoreOrNull(row.worthItScore);
     }

--- a/src/app/actions/queue-scores.ts
+++ b/src/app/actions/queue-scores.ts
@@ -22,8 +22,11 @@ export async function getQueueEpisodeScores(
   podcastIndexIds: PodcastIndexEpisodeId[],
 ): Promise<Record<PodcastIndexEpisodeId, number | null>> {
   try {
+    const emptyResult = (): Record<PodcastIndexEpisodeId, number | null> =>
+      Object.create(null);
+
     const { userId } = await auth();
-    if (!userId) return {} as Record<PodcastIndexEpisodeId, number | null>;
+    if (!userId) return emptyResult();
 
     const ids = Array.from(
       new Set(
@@ -35,8 +38,7 @@ export async function getQueueEpisodeScores(
       ),
     ).slice(0, MAX_IDS);
 
-    if (ids.length === 0)
-      return {} as Record<PodcastIndexEpisodeId, number | null>;
+    if (ids.length === 0) return emptyResult();
 
     const rows = await db
       .select({
@@ -46,16 +48,13 @@ export async function getQueueEpisodeScores(
       .from(episodes)
       .where(inArray(episodes.podcastIndexId, ids));
 
-    const result = Object.create(null) as Record<
-      PodcastIndexEpisodeId,
-      number | null
-    >;
+    const result = emptyResult();
     for (const row of rows) {
       result[row.podcastIndexId] = parseScoreOrNull(row.worthItScore);
     }
     return result;
   } catch (err) {
     console.error("getQueueEpisodeScores failed:", err);
-    return {};
+    return Object.create(null);
   }
 }

--- a/src/app/actions/subscriptions.ts
+++ b/src/app/actions/subscriptions.ts
@@ -28,6 +28,7 @@ import {
   toggleSubscriptionSchema,
 } from "@/lib/schemas/library";
 import type { ActionResult } from "@/types/action-result";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const MAX_EPISODES_PER_IMPORT = 50;
 
@@ -158,7 +159,10 @@ export async function addPodcastByRssUrl(
     if (episodesToInsert.length > 0) {
       const episodeValues = episodesToInsert.map((ep) => ({
         podcastId,
-        podcastIndexId: generateEpisodeSyntheticId(trimmedUrl, ep.guid),
+        // RSS-sourced synthetic episode id → branded string.
+        podcastIndexId: asPodcastIndexEpisodeId(
+          generateEpisodeSyntheticId(trimmedUrl, ep.guid),
+        ),
         title: ep.title,
         description: ep.description,
         audioUrl: ep.audioUrl,
@@ -405,7 +409,10 @@ export async function refreshPodcastFeed(podcastId: number) {
     let newEpisodes: typeof fetchedEpisodes = [];
     if (fetchedEpisodes.length > 0) {
       // Deduplicate: find which episodes already exist in DB
-      const fetchedIds = fetchedEpisodes.map((ep) => String(ep.id));
+      // PodcastIndex API id (number|string) → branded string for DB lookup.
+      const fetchedIds = fetchedEpisodes.map((ep) =>
+        asPodcastIndexEpisodeId(String(ep.id)),
+      );
       const existingEpisodes = await db
         .select({ podcastIndexId: episodes.podcastIndexId })
         .from(episodes)
@@ -414,8 +421,9 @@ export async function refreshPodcastFeed(podcastId: number) {
       const existingIds = new Set(
         existingEpisodes.map((e) => e.podcastIndexId),
       );
+      // Reuse fetchedIds (already computed above) to avoid re-branding.
       newEpisodes = fetchedEpisodes.filter(
-        (ep) => !existingIds.has(String(ep.id)),
+        (_, i) => !existingIds.has(fetchedIds[i]),
       );
 
       // Trigger summarization for new episodes (fire-and-forget from server context)

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -6,6 +6,7 @@ import { episodes } from "@/db/schema";
 import { getEpisodeById, getPodcastById } from "@/lib/podcastindex";
 import { createRateLimitChecker } from "@/lib/rate-limit";
 import { parseScoreOrNull } from "@/lib/score-utils";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const PUBLIC_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600";
 const checkPublicEpisodeRateLimit = createRateLimitChecker({
@@ -80,6 +81,12 @@ export async function GET(
     }
 
     const id = params.id;
+    // URL param: RSS ids carry "rss-" prefix; PI numeric ids are validated below.
+    // Note: piId uses the raw URL string directly rather than re-stringifying
+    // Number(id) — this is intentional. PI episode ids don't carry leading zeros
+    // in practice, and the DB stores exactly what PodcastIndex returns (e.g. "123",
+    // not "0123"), so skipping the Number round-trip is semantically equivalent.
+    const piId = asPodcastIndexEpisodeId(id);
 
     // RSS-sourced episode: load from database
     if (isRssSourced(id)) {
@@ -89,7 +96,7 @@ export async function GET(
       // Note: Uses column exclusion (vs. whitelist in the PodcastIndex path below)
       // because this query needs nearly all episode fields for response mapping.
       const dbEpisode = await db.query.episodes.findFirst({
-        where: eq(episodes.podcastIndexId, id),
+        where: eq(episodes.podcastIndexId, piId),
         columns: {
           transcription: false,
         },
@@ -220,7 +227,7 @@ export async function GET(
       // when only checking for cached summary data.
       // Expected impact: Significant reduction in DB I/O and memory usage per episode view.
       const cachedEpisode = await db.query.episodes.findFirst({
-        where: eq(episodes.podcastIndexId, episodeId.toString()),
+        where: eq(episodes.podcastIndexId, piId),
         columns: {
           id: true,
           summary: true,

--- a/src/app/api/episodes/[id]/route.ts
+++ b/src/app/api/episodes/[id]/route.ts
@@ -81,15 +81,11 @@ export async function GET(
     }
 
     const id = params.id;
-    // URL param: RSS ids carry "rss-" prefix; PI numeric ids are validated below.
-    // Note: piId uses the raw URL string directly rather than re-stringifying
-    // Number(id) — this is intentional. PI episode ids don't carry leading zeros
-    // in practice, and the DB stores exactly what PodcastIndex returns (e.g. "123",
-    // not "0123"), so skipping the Number round-trip is semantically equivalent.
-    const piId = asPodcastIndexEpisodeId(id);
 
     // RSS-sourced episode: load from database
     if (isRssSourced(id)) {
+      // URL param (canonical "rss-..." form) → branded string for DB lookup.
+      const piId = asPodcastIndexEpisodeId(id);
       // BOLT OPTIMIZATION: Exclude the high-volume transcription field
       // which is not used in the response.
       // Expected impact: ~90% reduction in data transfer when transcripts are present.
@@ -185,6 +181,9 @@ export async function GET(
         { status: 400 },
       );
     }
+    // Round-trip through Number() so "00123" lookups normalise to "123" — DB
+    // stores the canonical PodcastIndex form. Then brand for DB lookup.
+    const piId = asPodcastIndexEpisodeId(episodeId.toString());
 
     // Fetch episode from PodcastIndex
     let episodeResponse;

--- a/src/app/api/episodes/batch-summarize/route.ts
+++ b/src/app/api/episodes/batch-summarize/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: NextRequest) {
     }
 
     // Query DB for already-processed episodes
-    // episodeIds are PI episode numeric ids from the request body.
     const existingEpisodes = await db.query.episodes.findMany({
+      // JSON body numeric episode ids → branded strings for DB lookup.
       where: inArray(
         episodes.podcastIndexId,
         episodeIds.map((id) => asPodcastIndexEpisodeId(String(id))),

--- a/src/app/api/episodes/batch-summarize/route.ts
+++ b/src/app/api/episodes/batch-summarize/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/rate-limit";
 import { BATCH_SUMMARIZE_LIMIT } from "@/lib/batch-summarize";
 import type { batchSummarizeEpisodes } from "@/trigger/batch-summarize-episodes";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 export async function POST(request: NextRequest) {
   try {
@@ -51,8 +52,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Query DB for already-processed episodes
+    // episodeIds are PI episode numeric ids from the request body.
     const existingEpisodes = await db.query.episodes.findMany({
-      where: inArray(episodes.podcastIndexId, episodeIds.map(String)),
+      where: inArray(
+        episodes.podcastIndexId,
+        episodeIds.map((id) => asPodcastIndexEpisodeId(String(id))),
+      ),
       columns: { podcastIndexId: true, processedAt: true },
     });
 

--- a/src/app/api/episodes/fetch-transcript/route.ts
+++ b/src/app/api/episodes/fetch-transcript/route.ts
@@ -8,6 +8,7 @@ import { upsertPodcast } from "@/db/helpers";
 import { ADMIN_ROLE } from "@/lib/auth-roles";
 import { getEpisodeById, getPodcastById } from "@/lib/podcastindex";
 import type { fetchTranscriptTask } from "@/trigger/fetch-transcript";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 export async function POST(request: NextRequest) {
   try {
@@ -130,7 +131,10 @@ export async function POST(request: NextRequest) {
       }
 
       numericPodcastIndexId = parsedPodcastIndexId;
-      const podcastIndexIdStr = numericPodcastIndexId.toString();
+      // PI episode id numeric form → branded string for DB lookup.
+      const podcastIndexIdStr = asPodcastIndexEpisodeId(
+        numericPodcastIndexId.toString(),
+      );
 
       // Look for an existing DB row
       const existingEpisode = await db.query.episodes.findFirst({

--- a/src/app/api/episodes/summarize/route.ts
+++ b/src/app/api/episodes/summarize/route.ts
@@ -40,6 +40,7 @@ export async function POST(request: NextRequest) {
 
     // Check if we already have a cached summary in the database
     const existingEpisode = await db.query.episodes.findFirst({
+      // JSON body numeric episode id → branded string for DB lookup.
       where: eq(
         episodes.podcastIndexId,
         asPodcastIndexEpisodeId(episodeId.toString()),
@@ -199,10 +200,8 @@ export async function GET(request: NextRequest) {
 
     // Check if we have a cached summary
     const existingEpisode = await db.query.episodes.findFirst({
-      where: eq(
-        episodes.podcastIndexId,
-        asPodcastIndexEpisodeId(episodeId), // URL search param — PI episode id
-      ),
+      // URL search param (raw string) → branded string for DB lookup.
+      where: eq(episodes.podcastIndexId, asPodcastIndexEpisodeId(episodeId)),
     });
 
     if (existingEpisode?.summary && existingEpisode?.processedAt) {

--- a/src/app/api/episodes/summarize/route.ts
+++ b/src/app/api/episodes/summarize/route.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { tasks, auth } from "@trigger.dev/sdk";
 import { db } from "@/db";
 import { episodes, IN_PROGRESS_STATUSES } from "@/db/schema";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import {
   checkRateLimit,
   checkDailyLimit,
@@ -39,7 +40,10 @@ export async function POST(request: NextRequest) {
 
     // Check if we already have a cached summary in the database
     const existingEpisode = await db.query.episodes.findFirst({
-      where: eq(episodes.podcastIndexId, episodeId.toString()),
+      where: eq(
+        episodes.podcastIndexId,
+        asPodcastIndexEpisodeId(episodeId.toString()),
+      ),
     });
 
     // Admin force re-summarize: reject non-admins trying to force
@@ -195,7 +199,10 @@ export async function GET(request: NextRequest) {
 
     // Check if we have a cached summary
     const existingEpisode = await db.query.episodes.findFirst({
-      where: eq(episodes.podcastIndexId, episodeId),
+      where: eq(
+        episodes.podcastIndexId,
+        asPodcastIndexEpisodeId(episodeId), // URL search param — PI episode id
+      ),
     });
 
     if (existingEpisode?.summary && existingEpisode?.processedAt) {

--- a/src/components/__tests__/save-button.test.tsx
+++ b/src/components/__tests__/save-button.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SaveButton } from "@/components/episodes/save-button";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 vi.mock("@/lib/offline-actions", () => ({
   offlineSaveEpisode: vi.fn(),
@@ -23,7 +24,7 @@ vi.mock("@/hooks/use-online-status", () => ({
 }));
 
 const mockEpisodeData = {
-  podcastIndexId: "123",
+  podcastIndexId: asPodcastIndexEpisodeId("123"),
   title: "Test Episode",
   description: "A test episode",
   podcast: {

--- a/src/components/admin/episodes/__tests__/episodes-table.test.tsx
+++ b/src/components/admin/episodes/__tests__/episodes-table.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/components/admin/episodes/episode-action-buttons", () => ({
 import { EpisodesTable } from "@/components/admin/episodes/episodes-table";
 import { ROUTES } from "@/lib/routes";
 import type { EpisodeRow } from "@/lib/admin/episode-queries";
-import type { PodcastIndexEpisodeId } from "@/types/ids";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const makeEpisode = (id: number): EpisodeRow => ({
   id,
@@ -22,7 +22,7 @@ const makeEpisode = (id: number): EpisodeRow => ({
   podcastId: 1,
   podcastTitle: "Test Podcast",
   podcastImageUrl: null,
-  podcastIndexId: `idx_${id}` as PodcastIndexEpisodeId,
+  podcastIndexId: asPodcastIndexEpisodeId(`idx_${id}`),
   publishDate: new Date("2026-01-15"),
   transcriptStatus: "available",
   transcriptSource: "assemblyai",

--- a/src/components/admin/episodes/__tests__/episodes-table.test.tsx
+++ b/src/components/admin/episodes/__tests__/episodes-table.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/components/admin/episodes/episode-action-buttons", () => ({
 import { EpisodesTable } from "@/components/admin/episodes/episodes-table";
 import { ROUTES } from "@/lib/routes";
 import type { EpisodeRow } from "@/lib/admin/episode-queries";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 const makeEpisode = (id: number): EpisodeRow => ({
   id,
@@ -21,7 +22,7 @@ const makeEpisode = (id: number): EpisodeRow => ({
   podcastId: 1,
   podcastTitle: "Test Podcast",
   podcastImageUrl: null,
-  podcastIndexId: `idx_${id}`,
+  podcastIndexId: `idx_${id}` as PodcastIndexEpisodeId,
   publishDate: new Date("2026-01-15"),
   transcriptStatus: "available",
   transcriptSource: "assemblyai",

--- a/src/components/audio-player/__tests__/add-to-queue-button.render-count.test.tsx
+++ b/src/components/audio-player/__tests__/add-to-queue-button.render-count.test.tsx
@@ -5,6 +5,7 @@ import {
   AudioPlayerProvider,
   type AudioEpisode,
 } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import { AddToQueueButton } from "@/components/audio-player/add-to-queue-button";
 import {
   createRenderCountHarness,
@@ -57,7 +58,7 @@ vi.mock("@/app/actions/player-session", () => ({
 }));
 
 const testEpisode: AudioEpisode = {
-  id: "ep-queue-test",
+  id: asPodcastIndexEpisodeId("ep-queue-test"),
   title: "Queue Test Episode",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/audio.mp3",
@@ -65,7 +66,7 @@ const testEpisode: AudioEpisode = {
 };
 
 const unrelatedEpisode: AudioEpisode = {
-  id: "ep-unrelated",
+  id: asPodcastIndexEpisodeId("ep-unrelated"),
   title: "Unrelated Episode",
   podcastTitle: "Other Podcast",
   audioUrl: "https://example.com/other.mp3",
@@ -73,7 +74,7 @@ const unrelatedEpisode: AudioEpisode = {
 };
 
 const secondQueueEpisode: AudioEpisode = {
-  id: "ep-second-in-queue",
+  id: asPodcastIndexEpisodeId("ep-second-in-queue"),
   title: "Second Queue Episode",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/second.mp3",

--- a/src/components/audio-player/__tests__/bookmark-button.test.tsx
+++ b/src/components/audio-player/__tests__/bookmark-button.test.tsx
@@ -4,10 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { BookmarkButton } from "@/components/audio-player/bookmark-button";
 import type { AudioPlayerState } from "@/contexts/audio-player-context";
 import { BOOKMARK_CHANGED_EVENT } from "@/lib/events";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const mockState: AudioPlayerState = {
   currentEpisode: {
-    id: "ep-123",
+    id: asPodcastIndexEpisodeId("ep-123"),
     title: "Test Episode",
     podcastTitle: "Test Pod",
     audioUrl: "http://example.com/a.mp3",
@@ -59,7 +60,7 @@ describe("BookmarkButton", () => {
     vi.clearAllMocks();
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockState.currentEpisode = {
-      id: "ep-123",
+      id: asPodcastIndexEpisodeId("ep-123"),
       title: "Test Episode",
       podcastTitle: "Test Pod",
       audioUrl: "http://example.com/a.mp3",

--- a/src/components/audio-player/__tests__/play-episode-button.render-count.test.tsx
+++ b/src/components/audio-player/__tests__/play-episode-button.render-count.test.tsx
@@ -6,6 +6,7 @@ import {
   type AudioEpisode,
 } from "@/contexts/audio-player-context";
 import { PlayEpisodeButton } from "@/components/audio-player/play-episode-button";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import {
   createRenderCountHarness,
   stubHTMLMediaElement,
@@ -57,7 +58,7 @@ vi.mock("@/app/actions/player-session", () => ({
 }));
 
 const testEpisode: AudioEpisode = {
-  id: "ep-render-test",
+  id: asPodcastIndexEpisodeId("ep-render-test"),
   title: "Render Count Test Episode",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/audio.mp3",
@@ -65,7 +66,7 @@ const testEpisode: AudioEpisode = {
 };
 
 const unrelatedEpisode: AudioEpisode = {
-  id: "ep-unrelated",
+  id: asPodcastIndexEpisodeId("ep-unrelated"),
   title: "Unrelated Episode",
   podcastTitle: "Other Podcast",
   audioUrl: "https://example.com/other.mp3",

--- a/src/components/audio-player/__tests__/play-episode-button.test.tsx
+++ b/src/components/audio-player/__tests__/play-episode-button.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { AudioEpisode } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const mockPlayEpisode = vi.fn();
 const mockTogglePlay = vi.fn();
@@ -23,7 +24,7 @@ vi.mock("@/contexts/audio-player-context", () => ({
 import { PlayEpisodeButton } from "@/components/audio-player/play-episode-button";
 
 const episode: AudioEpisode = {
-  id: "ep-42",
+  id: asPodcastIndexEpisodeId("ep-42"),
   title: "Episode Title",
   podcastTitle: "Podcast",
   audioUrl: "https://example.com/a.mp3",

--- a/src/components/audio-player/add-to-queue-button.stories.tsx
+++ b/src/components/audio-player/add-to-queue-button.stories.tsx
@@ -1,10 +1,11 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { type AudioEpisode } from "@/contexts/audio-player-context";
 import { AddToQueueButton } from "@/components/audio-player/add-to-queue-button";
 import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const testEpisode: AudioEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "How to Build Better Products",
   podcastTitle: "Design Matters",
   audioUrl: "https://example.com/audio.mp3",
@@ -13,7 +14,7 @@ const testEpisode: AudioEpisode = {
 };
 
 const playingEpisode: AudioEpisode = {
-  id: "ep-playing",
+  id: asPodcastIndexEpisodeId("ep-playing"),
   title: "Currently Playing Episode",
   podcastTitle: "Some Podcast",
   audioUrl: "https://example.com/playing.mp3",

--- a/src/components/audio-player/bookmark-button.stories.tsx
+++ b/src/components/audio-player/bookmark-button.stories.tsx
@@ -1,10 +1,11 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Decorator, Meta, StoryObj } from "@storybook/nextjs-vite";
 import { BookmarkButton } from "@/components/audio-player/bookmark-button";
 import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const playingState = {
   currentEpisode: {
-    id: "ep-123",
+    id: asPodcastIndexEpisodeId("ep-123"),
     title: "Test Episode",
     podcastTitle: "Test Podcast",
     audioUrl: "http://example.com/audio.mp3",

--- a/src/components/audio-player/chapter-list.stories.tsx
+++ b/src/components/audio-player/chapter-list.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Decorator, Meta, StoryObj } from "@storybook/nextjs-vite";
 import { ChapterList } from "@/components/audio-player/chapter-list";
 import type { Chapter } from "@/lib/chapters";
@@ -5,7 +6,7 @@ import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const playingState = {
   currentEpisode: {
-    id: "1",
+    id: asPodcastIndexEpisodeId("1"),
     title: "Test Episode",
     podcastTitle: "Test Podcast",
     audioUrl: "https://example.com/audio.mp3",

--- a/src/components/audio-player/chapter-panel.stories.tsx
+++ b/src/components/audio-player/chapter-panel.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { BookMarked } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,7 @@ const sampleChapters: Chapter[] = [
 
 const playingState = {
   currentEpisode: {
-    id: "1",
+    id: asPodcastIndexEpisodeId("1"),
     title: "Test Episode",
     podcastTitle: "Test Podcast",
     audioUrl: "https://example.com/audio.mp3",

--- a/src/components/audio-player/play-episode-button.stories.tsx
+++ b/src/components/audio-player/play-episode-button.stories.tsx
@@ -1,10 +1,11 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { type AudioEpisode } from "@/contexts/audio-player-context";
 import { PlayEpisodeButton } from "@/components/audio-player/play-episode-button";
 import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const testEpisode: AudioEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "How to Build Better Products",
   podcastTitle: "Design Matters",
   audioUrl: "https://example.com/audio.mp3",
@@ -13,7 +14,7 @@ const testEpisode: AudioEpisode = {
 };
 
 const otherEpisode: AudioEpisode = {
-  id: "ep-2",
+  id: asPodcastIndexEpisodeId("ep-2"),
   title: "A Different Episode",
   podcastTitle: "Other Podcast",
   audioUrl: "https://example.com/other.mp3",

--- a/src/components/audio-player/player-bar.stories.tsx
+++ b/src/components/audio-player/player-bar.stories.tsx
@@ -1,9 +1,10 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { PlayerBar } from "./player-bar";
 import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const testEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "How to Build Better Products",
   podcastTitle: "Design Matters",
   audioUrl: "https://example.com/audio.mp3",
@@ -12,7 +13,7 @@ const testEpisode = {
 };
 
 const longTitleEpisode = {
-  id: "ep-2",
+  id: asPodcastIndexEpisodeId("ep-2"),
   title:
     "The Extremely Long Episode Title That Should Be Truncated Because It Exceeds The Available Width In The Player Bar Component",
   podcastTitle: "My Very Long Podcast Name That Also Needs Truncation",
@@ -109,7 +110,7 @@ export const WithQueue: Story = {
         duration: 2400,
         queue: [
           {
-            id: "ep-3",
+            id: asPodcastIndexEpisodeId("ep-3"),
             title: "The Future of Web Development",
             podcastTitle: "Frontend First",
             audioUrl: "https://example.com/audio3.mp3",
@@ -117,7 +118,7 @@ export const WithQueue: Story = {
             duration: 1800,
           },
           {
-            id: "ep-4",
+            id: asPodcastIndexEpisodeId("ep-4"),
             title: "Understanding TypeScript Generics",
             podcastTitle: "TypeScript Weekly",
             audioUrl: "https://example.com/audio4.mp3",

--- a/src/components/audio-player/queue-item.stories.tsx
+++ b/src/components/audio-player/queue-item.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { DndContext } from "@dnd-kit/core";
 import {
@@ -8,7 +9,7 @@ import type { AudioEpisode } from "@/contexts/audio-player-context";
 import { QueueItem } from "@/components/audio-player/queue-item";
 
 const testEpisode: AudioEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "How to Build Better Products",
   podcastTitle: "Design Matters",
   audioUrl: "https://example.com/audio.mp3",
@@ -17,7 +18,7 @@ const testEpisode: AudioEpisode = {
 };
 
 const longTitleEpisode: AudioEpisode = {
-  id: "ep-2",
+  id: asPodcastIndexEpisodeId("ep-2"),
   title:
     "The Extremely Long Episode Title That Should Be Truncated Because It Exceeds The Available Width",
   podcastTitle:

--- a/src/components/audio-player/queue-panel.stories.tsx
+++ b/src/components/audio-player/queue-panel.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { ListMusic } from "lucide-react";
 import { type AudioEpisode } from "@/contexts/audio-player-context";
@@ -10,7 +11,7 @@ import {
 } from "@/test/story-fixtures";
 
 const playingEpisode: AudioEpisode = {
-  id: "ep-playing",
+  id: asPodcastIndexEpisodeId("ep-playing"),
   title: "Currently Playing Episode",
   podcastTitle: "Some Podcast",
   audioUrl: "https://example.com/playing.mp3",
@@ -19,7 +20,7 @@ const playingEpisode: AudioEpisode = {
 
 const queueEpisodes: AudioEpisode[] = [
   {
-    id: "ep-1",
+    id: asPodcastIndexEpisodeId("ep-1"),
     title: "How to Build Better Products",
     podcastTitle: "Design Matters",
     audioUrl: "https://example.com/audio1.mp3",
@@ -27,7 +28,7 @@ const queueEpisodes: AudioEpisode[] = [
     duration: 2400,
   },
   {
-    id: "ep-2",
+    id: asPodcastIndexEpisodeId("ep-2"),
     title: "The Future of AI in Healthcare",
     podcastTitle: "Tech Talk Daily",
     audioUrl: "https://example.com/audio2.mp3",
@@ -35,7 +36,7 @@ const queueEpisodes: AudioEpisode[] = [
     duration: 3600,
   },
   {
-    id: "ep-3",
+    id: asPodcastIndexEpisodeId("ep-3"),
     title:
       "An Extremely Long Title That Should Be Truncated In The Queue Panel",
     podcastTitle: "Conversations With Very Long Podcast Names",
@@ -107,7 +108,7 @@ export const LongTitles: Story = {
         ...playingState,
         queue: [
           {
-            id: "ep-long-1",
+            id: asPodcastIndexEpisodeId("ep-long-1"),
             title:
               "An Episode With An Extremely Long Title That Will Definitely Overflow And Need Truncation In The Queue Panel List",
             podcastTitle:
@@ -116,7 +117,7 @@ export const LongTitles: Story = {
             duration: 4500,
           },
           {
-            id: "ep-long-2",
+            id: asPodcastIndexEpisodeId("ep-long-2"),
             title:
               "Another Very Long Episode Title: Deep Dive Into The Minutiae Of Something Extremely Complicated And Verbose",
             podcastTitle: "The Long-Winded Podcast",

--- a/src/components/dashboard/__tests__/episode-recommendations.test.tsx
+++ b/src/components/dashboard/__tests__/episode-recommendations.test.tsx
@@ -7,6 +7,7 @@ import {
   EPISODES_INITIAL,
 } from "@/components/dashboard/episode-recommendations";
 import type { RecommendedEpisodeDTO } from "@/db/library-columns";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -24,7 +25,7 @@ function makeEpisode(
   const id = _idCounter++;
   return {
     id,
-    podcastIndexId: String(id * 100),
+    podcastIndexId: asPodcastIndexEpisodeId(String(id * 100)),
     title: `Episode ${id}`,
     description: null,
     audioUrl: null,

--- a/src/components/dashboard/__tests__/queue-section.test.tsx
+++ b/src/components/dashboard/__tests__/queue-section.test.tsx
@@ -5,6 +5,7 @@ import type {
   AudioEpisode,
   AudioPlayerState,
 } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -51,13 +52,16 @@ const mockFetch = vi.fn();
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeEpisode(overrides: Partial<AudioEpisode> = {}): AudioEpisode {
+type MakeEpisodeOverrides = Partial<Omit<AudioEpisode, "id">> & { id?: string };
+
+function makeEpisode(overrides: MakeEpisodeOverrides = {}): AudioEpisode {
+  const { id = "1001", ...rest } = overrides;
   return {
-    id: "1001",
+    id: asPodcastIndexEpisodeId(id),
     title: "Test Episode",
     podcastTitle: "Test Podcast",
     audioUrl: "https://example.com/audio.mp3",
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/src/components/dashboard/episode-recommendations.stories.tsx
+++ b/src/components/dashboard/episode-recommendations.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import {
   EpisodeRecommendations,
   EpisodeRecommendationsLoading,
@@ -18,7 +19,7 @@ function makeEpisode(
 ): RecommendedEpisodeDTO {
   return {
     id,
-    podcastIndexId: String(id * 100),
+    podcastIndexId: asPodcastIndexEpisodeId(String(id * 100)),
     title,
     description: null,
     audioUrl: null,

--- a/src/components/dashboard/queue-section.stories.tsx
+++ b/src/components/dashboard/queue-section.stories.tsx
@@ -1,10 +1,11 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { type AudioEpisode } from "@/contexts/audio-player-context";
 import { QueueSection } from "@/components/dashboard/queue-section";
 import { audioPlayerContextDecorator } from "@/test/story-fixtures";
 
 const nowPlayingEpisode: AudioEpisode = {
-  id: "2001",
+  id: asPodcastIndexEpisodeId("2001"),
   title: "The Future of AI in Healthcare",
   podcastTitle: "Tech Talk Daily",
   audioUrl: "https://example.com/playing.mp3",
@@ -14,7 +15,7 @@ const nowPlayingEpisode: AudioEpisode = {
 
 const queueEpisodes: AudioEpisode[] = [
   {
-    id: "1001",
+    id: asPodcastIndexEpisodeId("1001"),
     title: "How to Build Better Products",
     podcastTitle: "Design Matters",
     audioUrl: "https://example.com/audio1.mp3",
@@ -22,7 +23,7 @@ const queueEpisodes: AudioEpisode[] = [
     duration: 2400,
   },
   {
-    id: "1002",
+    id: asPodcastIndexEpisodeId("1002"),
     title: "Leadership in the Age of Remote Work",
     podcastTitle: "The Management Lab",
     audioUrl: "https://example.com/audio2.mp3",
@@ -30,7 +31,7 @@ const queueEpisodes: AudioEpisode[] = [
     duration: 1800,
   },
   {
-    id: "1003",
+    id: asPodcastIndexEpisodeId("1003"),
     title:
       "An Extremely Long Episode Title That Should Be Truncated When Displayed Inside the Queue Section Card Component",
     podcastTitle: "The Very Verbose and Long-Winded Podcast About Everything",
@@ -98,7 +99,7 @@ export const LongTitles: Story = {
     audioPlayerContextDecorator({
       state: {
         currentEpisode: {
-          id: "long-0",
+          id: asPodcastIndexEpisodeId("long-0"),
           title:
             "An Episode With An Extremely Long Title That Will Definitely Overflow And Need Truncation In The Queue Section On The Dashboard Page",
           podcastTitle:
@@ -116,14 +117,14 @@ export const NoArtwork: Story = {
     audioPlayerContextDecorator({
       state: {
         currentEpisode: {
-          id: "2001",
+          id: asPodcastIndexEpisodeId("2001"),
           title: "Episode Without Artwork",
           podcastTitle: "Text-only Podcast",
           audioUrl: "https://example.com/audio.mp3",
         },
         queue: [
           {
-            id: "1001",
+            id: asPodcastIndexEpisodeId("1001"),
             title: "Another Episode Without Artwork",
             podcastTitle: "Also No Artwork",
             audioUrl: "https://example.com/audio2.mp3",

--- a/src/components/episodes/__tests__/episode-chapters-list.test.tsx
+++ b/src/components/episodes/__tests__/episode-chapters-list.test.tsx
@@ -4,13 +4,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EpisodeChaptersList } from "@/components/episodes/episode-chapters-list";
 import type { UseChaptersState } from "@/hooks/use-chapters";
 import type { AudioEpisode } from "@/contexts/audio-player-context";
-import { asPodcastIndexEpisodeId } from "@/types/ids";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 const mocks = vi.hoisted(() => ({
-  useAudioPlayerState:
-    vi.fn<
-      () => { currentEpisode: { id: string } | null; isPlaying: boolean }
-    >(),
+  useAudioPlayerState: vi.fn<
+    () => {
+      currentEpisode: { id: PodcastIndexEpisodeId } | null;
+      isPlaying: boolean;
+    }
+  >(),
   useAudioPlayerProgress: vi.fn(),
   useAudioPlayerAPI: vi.fn(),
 }));

--- a/src/components/episodes/__tests__/episode-chapters-list.test.tsx
+++ b/src/components/episodes/__tests__/episode-chapters-list.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EpisodeChaptersList } from "@/components/episodes/episode-chapters-list";
 import type { UseChaptersState } from "@/hooks/use-chapters";
 import type { AudioEpisode } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const mocks = vi.hoisted(() => ({
   useAudioPlayerState:
@@ -21,7 +22,7 @@ vi.mock("@/contexts/audio-player-context", () => ({
 }));
 
 const sampleEpisode: AudioEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "Sample Episode",
   podcastTitle: "Sample Podcast",
   audioUrl: "https://example.com/audio.mp3",

--- a/src/components/episodes/__tests__/listened-button.test.tsx
+++ b/src/components/episodes/__tests__/listened-button.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LISTEN_STATE_CHANGED_EVENT } from "@/lib/events";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
+
+const TEST_PI_EPISODE_ID = asPodcastIndexEpisodeId("ep-1");
 
 const mockRecordListenEvent = vi.fn();
 vi.mock("@/app/actions/listen-history", () => ({
@@ -22,7 +25,12 @@ describe("ListenedButton", () => {
   it("renders a button with aria-label 'Mark as listened' when isListened is false", async () => {
     const { ListenedButton } =
       await import("@/components/episodes/listened-button");
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
     expect(
       screen.getByRole("button", { name: "Mark as listened" }),
     ).toBeInTheDocument();
@@ -31,7 +39,12 @@ describe("ListenedButton", () => {
   it("renders non-button indicator with aria-label 'Already listened' when isListened is true", async () => {
     const { ListenedButton } =
       await import("@/components/episodes/listened-button");
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={true} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={true}
+      />,
+    );
     expect(
       screen.queryByRole("button", { name: "Mark as listened" }),
     ).toBeNull();
@@ -42,13 +55,21 @@ describe("ListenedButton", () => {
     const { ListenedButton } =
       await import("@/components/episodes/listened-button");
     const { rerender } = render(
-      <ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />,
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
     );
     expect(
       screen.getByRole("button", { name: "Mark as listened" }),
     ).toBeInTheDocument();
 
-    rerender(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={true} />);
+    rerender(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={true}
+      />,
+    );
     expect(
       screen.queryByRole("button", { name: "Mark as listened" }),
     ).toBeNull();
@@ -66,7 +87,12 @@ describe("ListenedButton", () => {
     const { ListenedButton } =
       await import("@/components/episodes/listened-button");
     const user = userEvent.setup();
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
 
     const btn = screen.getByRole("button", { name: "Mark as listened" });
     await user.click(btn);
@@ -88,7 +114,12 @@ describe("ListenedButton", () => {
       await import("@/components/episodes/listened-button");
     const { toast } = await import("sonner");
     const user = userEvent.setup();
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Mark as listened" }));
 
@@ -107,7 +138,12 @@ describe("ListenedButton", () => {
       await import("@/components/episodes/listened-button");
     const { toast } = await import("sonner");
     const user = userEvent.setup();
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Mark as listened" }));
 
@@ -128,7 +164,12 @@ describe("ListenedButton", () => {
     const { toast } = await import("sonner");
     const user = userEvent.setup();
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Mark as listened" }));
 
@@ -158,7 +199,12 @@ describe("ListenedButton", () => {
     const { toast } = await import("sonner");
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     const user = userEvent.setup();
-    render(<ListenedButton podcastIndexEpisodeId="ep-1" isListened={false} />);
+    render(
+      <ListenedButton
+        podcastIndexEpisodeId={TEST_PI_EPISODE_ID}
+        isListened={false}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Mark as listened" }));
 

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -70,6 +70,7 @@ import {
   getSafeEpisodeLink,
   supportsEpisodeProcessing,
 } from "@/components/episodes/episode-detail-shared";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 interface AuthenticatedEpisodeDetailProps {
   episodeId: string;
@@ -239,7 +240,10 @@ export function AuthenticatedEpisodeDetail({
       }
 
       // Check if episode is saved to library
-      const saved = await isEpisodeSaved(String(data.episode.id));
+      // PodcastIndex API id (number|string) → branded string.
+      const saved = await isEpisodeSaved(
+        asPodcastIndexEpisodeId(String(data.episode.id)),
+      );
       setIsSaved(saved);
     } catch (error) {
       console.error("Error fetching episode:", error);
@@ -293,7 +297,7 @@ export function AuthenticatedEpisodeDetail({
   useEffect(() => {
     if (!isOnline || !episodeLoaded) return;
     let ignore = false;
-    getEpisodeTopicOverlap(episodeId)
+    getEpisodeTopicOverlap(asPodcastIndexEpisodeId(episodeId))
       .then((result) => {
         if (!ignore)
           setOverlapResult({
@@ -462,8 +466,10 @@ export function AuthenticatedEpisodeDetail({
       ? chaptersState.chapters.length
       : undefined;
 
-  const isCurrentEpisode =
-    playerState.currentEpisode?.id === String(episode.id);
+  // PodcastIndex API id (number|string) → branded string.
+  const piId = asPodcastIndexEpisodeId(String(episode.id));
+
+  const isCurrentEpisode = playerState.currentEpisode?.id === piId;
   const isPlayingThis = isCurrentEpisode && playerState.isPlaying;
   const isPausedThis = isCurrentEpisode && !playerState.isPlaying;
 
@@ -472,7 +478,7 @@ export function AuthenticatedEpisodeDetail({
       playerAPI.togglePlay();
     } else {
       playerAPI.playEpisode({
-        id: String(episode.id),
+        id: piId,
         title: episode.title,
         podcastTitle: podcast?.title || "",
         audioUrl: episode.enclosureUrl,
@@ -617,7 +623,7 @@ export function AuthenticatedEpisodeDetail({
                 Community Rating:
               </span>
               <CommunityRating
-                episodePodcastIndexId={episodeId}
+                episodePodcastIndexId={asPodcastIndexEpisodeId(episodeId)}
                 size="md"
                 showCount={true}
               />
@@ -649,7 +655,7 @@ export function AuthenticatedEpisodeDetail({
             {isOnline && episode.enclosureUrl && (
               <AddToQueueButton
                 episode={{
-                  id: String(episode.id),
+                  id: piId,
                   title: episode.title,
                   podcastTitle: podcast?.title || "",
                   audioUrl: episode.enclosureUrl,
@@ -666,7 +672,7 @@ export function AuthenticatedEpisodeDetail({
             {isOnline && (
               <SaveButton
                 episodeData={{
-                  podcastIndexId: String(episode.id),
+                  podcastIndexId: piId,
                   title: episode.title,
                   description: episode.description,
                   audioUrl: episode.enclosureUrl,
@@ -753,7 +759,7 @@ export function AuthenticatedEpisodeDetail({
                   state={chaptersState}
                   canPlay={canPlayEpisode}
                   audioEpisode={{
-                    id: String(episode.id),
+                    id: piId,
                     title: episode.title,
                     podcastTitle: podcast?.title || "",
                     audioUrl: episode.enclosureUrl,

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -108,6 +108,9 @@ export function AuthenticatedEpisodeDetail({
     labelKind: OverlapLabelKind | null;
   }>({ label: null, labelKind: null });
   const canRunEpisodeProcessing = supportsEpisodeProcessing(episodeId);
+  // Route param (URL segment) → branded string. Reused for downstream calls
+  // that key off the PodcastIndex episode-id namespace.
+  const episodeIdBranded = asPodcastIndexEpisodeId(episodeId);
 
   // Realtime subscription to the Trigger.dev run
   const { run } = useRealtimeRun<typeof summarizeEpisode>(runId ?? "", {
@@ -297,7 +300,7 @@ export function AuthenticatedEpisodeDetail({
   useEffect(() => {
     if (!isOnline || !episodeLoaded) return;
     let ignore = false;
-    getEpisodeTopicOverlap(asPodcastIndexEpisodeId(episodeId))
+    getEpisodeTopicOverlap(episodeIdBranded)
       .then((result) => {
         if (!ignore)
           setOverlapResult({
@@ -311,7 +314,7 @@ export function AuthenticatedEpisodeDetail({
     return () => {
       ignore = true;
     };
-  }, [isOnline, episodeLoaded, episodeId]);
+  }, [isOnline, episodeLoaded, episodeIdBranded]);
 
   // Generate summary — triggers a background task and subscribes to realtime updates
   const generateSummary = useCallback(async () => {
@@ -623,7 +626,7 @@ export function AuthenticatedEpisodeDetail({
                 Community Rating:
               </span>
               <CommunityRating
-                episodePodcastIndexId={asPodcastIndexEpisodeId(episodeId)}
+                episodePodcastIndexId={episodeIdBranded}
                 size="md"
                 showCount={true}
               />

--- a/src/components/episodes/community-rating.tsx
+++ b/src/components/episodes/community-rating.tsx
@@ -5,9 +5,10 @@ import { Star, Users } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getEpisodeAverageRating } from "@/app/actions/library";
 import { cn } from "@/lib/utils";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 interface CommunityRatingProps {
-  episodePodcastIndexId: string;
+  episodePodcastIndexId: PodcastIndexEpisodeId;
   size?: "sm" | "md" | "lg";
   showCount?: boolean;
 }

--- a/src/components/episodes/episode-card.stories.tsx
+++ b/src/components/episodes/episode-card.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 // Left-accent bar is driven by isListened: unlistened → bar; listened → no bar (see ADR-038). VRT baselines must be regenerated after any change here.
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { X } from "lucide-react";
@@ -12,7 +13,7 @@ import {
 import { formatRelativeTime } from "@/lib/utils";
 
 const baseAudioEpisode = {
-  id: "PI-42",
+  id: asPodcastIndexEpisodeId("PI-42"),
   title: "How AI is Transforming Podcast Discovery",
   podcastTitle: "Tech Talk Daily",
   audioUrl: "https://example.com/audio.mp3",
@@ -106,7 +107,10 @@ export const Unlistened: Story = {
   args: {
     isListened: false,
     secondaryActions: (
-      <ListenedButton podcastIndexEpisodeId="PI-42" isListened={false} />
+      <ListenedButton
+        podcastIndexEpisodeId={asPodcastIndexEpisodeId("PI-42")}
+        isListened={false}
+      />
     ),
   },
 };
@@ -116,7 +120,10 @@ export const Listened: Story = {
   args: {
     isListened: true,
     secondaryActions: (
-      <ListenedButton podcastIndexEpisodeId="PI-42" isListened={true} />
+      <ListenedButton
+        podcastIndexEpisodeId={asPodcastIndexEpisodeId("PI-42")}
+        isListened={true}
+      />
     ),
   },
 };

--- a/src/components/episodes/episode-tabs.stories.tsx
+++ b/src/components/episodes/episode-tabs.stories.tsx
@@ -17,6 +17,7 @@ import {
   type AudioPlayerState,
 } from "@/contexts/audio-player-context";
 import type { Chapter } from "@/lib/chapters";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const meta: Meta<typeof EpisodeTabs> = {
   title: "Episodes/EpisodeTabs",
@@ -77,7 +78,7 @@ function InsightsPanel() {
 }
 
 const sampleAudioEpisode: AudioEpisode = {
-  id: "story-ep",
+  id: asPodcastIndexEpisodeId("story-ep"),
   title: "Why Senior Designers Stop Using Frameworks",
   podcastTitle: "Design Decisions",
   audioUrl: "https://example.com/audio.mp3",

--- a/src/components/episodes/listened-button.stories.tsx
+++ b/src/components/episodes/listened-button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { ListenedButton } from "@/components/episodes/listened-button";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const meta: Meta<typeof ListenedButton> = {
   title: "Episodes/ListenedButton",
@@ -11,14 +12,14 @@ type Story = StoryObj<typeof ListenedButton>;
 
 export const Unlistened: Story = {
   args: {
-    podcastIndexEpisodeId: "ep-1",
+    podcastIndexEpisodeId: asPodcastIndexEpisodeId("ep-1"),
     isListened: false,
   },
 };
 
 export const Listened: Story = {
   args: {
-    podcastIndexEpisodeId: "ep-1",
+    podcastIndexEpisodeId: asPodcastIndexEpisodeId("ep-1"),
     isListened: true,
   },
 };

--- a/src/components/episodes/listened-button.tsx
+++ b/src/components/episodes/listened-button.tsx
@@ -12,9 +12,10 @@ import {
 } from "@/components/ui/tooltip";
 import { recordListenEvent } from "@/app/actions/listen-history";
 import { LISTEN_STATE_CHANGED_EVENT } from "@/lib/events";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 interface ListenedButtonProps {
-  podcastIndexEpisodeId: string;
+  podcastIndexEpisodeId: PodcastIndexEpisodeId;
   isListened: boolean;
 }
 

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -235,6 +235,7 @@ export function PublicEpisodeDetail({ episodeId }: PublicEpisodeDetailProps) {
               Community Rating:
             </span>
             <CommunityRating
+              // PodcastIndex API id (number|string) → branded string.
               episodePodcastIndexId={asPodcastIndexEpisodeId(
                 String(episode.id),
               )}

--- a/src/components/episodes/public-episode-detail.tsx
+++ b/src/components/episodes/public-episode-detail.tsx
@@ -28,6 +28,7 @@ import {
   getEpisodeArtworkUrl,
   getSafeEpisodeLink,
 } from "@/components/episodes/episode-detail-shared";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 interface PublicEpisodeDetailProps {
   episodeId: string;
@@ -234,7 +235,9 @@ export function PublicEpisodeDetail({ episodeId }: PublicEpisodeDetailProps) {
               Community Rating:
             </span>
             <CommunityRating
-              episodePodcastIndexId={String(episode.id)}
+              episodePodcastIndexId={asPodcastIndexEpisodeId(
+                String(episode.id),
+              )}
               size="md"
               showCount={true}
             />

--- a/src/components/episodes/save-button.stories.tsx
+++ b/src/components/episodes/save-button.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { SaveButton } from "./save-button";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const mockEpisodeData = {
-  podcastIndexId: "123",
+  podcastIndexId: asPodcastIndexEpisodeId("123"),
   title: "Test Episode",
   description: "A test episode description",
   podcast: {

--- a/src/components/episodes/save-button.tsx
+++ b/src/components/episodes/save-button.tsx
@@ -17,9 +17,10 @@ import {
   offlineUnsaveEpisode,
 } from "@/lib/offline-actions";
 import { useSidebarCountsOptional } from "@/contexts/sidebar-counts-context";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 interface EpisodeData {
-  podcastIndexId: string;
+  podcastIndexId: PodcastIndexEpisodeId;
   title: string;
   description?: string;
   audioUrl?: string;

--- a/src/components/library/bookmarks-list.tsx
+++ b/src/components/library/bookmarks-list.tsx
@@ -39,12 +39,13 @@ import {
 } from "@/contexts/audio-player-context";
 import type { Bookmark as BookmarkType } from "@/db/schema";
 import { BOOKMARK_CHANGED_EVENT } from "@/lib/events";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 interface BookmarksListProps {
   libraryEntryId: number;
   episodeDuration?: number | null;
   episodeAudioData?: {
-    podcastIndexId: string;
+    podcastIndexId: PodcastIndexEpisodeId;
     title: string;
     podcastTitle: string;
     audioUrl: string;

--- a/src/components/library/notes-editor.stories.tsx
+++ b/src/components/library/notes-editor.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { NotesEditor } from "./notes-editor";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const meta: Meta<typeof NotesEditor> = {
   title: "Library/NotesEditor",
@@ -11,14 +12,14 @@ type Story = StoryObj<typeof NotesEditor>;
 
 export const Empty: Story = {
   args: {
-    episodePodcastIndexId: "123",
+    episodePodcastIndexId: asPodcastIndexEpisodeId("123"),
     initialNotes: "",
   },
 };
 
 export const WithContent: Story = {
   args: {
-    episodePodcastIndexId: "123",
+    episodePodcastIndexId: asPodcastIndexEpisodeId("123"),
     initialNotes:
       "Great episode about AI in podcasting.\n\nKey points:\n- AI can help with editing\n- Transcription is getting better\n- Important to maintain authenticity",
   },

--- a/src/components/library/notes-editor.tsx
+++ b/src/components/library/notes-editor.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Loader2, Check, StickyNote } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
 import { updateLibraryNotes } from "@/app/actions/library";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 interface NotesEditorProps {
-  episodePodcastIndexId: string;
+  episodePodcastIndexId: PodcastIndexEpisodeId;
   initialNotes: string;
   onNotesChange?: (notes: string) => void;
 }

--- a/src/components/notifications/__tests__/notification-page-list.test.tsx
+++ b/src/components/notifications/__tests__/notification-page-list.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NOTIFICATIONS_PAGE_SIZE } from "@/lib/notifications-constants";
-import {
-  asPodcastIndexEpisodeId,
-  type PodcastIndexEpisodeId,
-} from "@/types/ids";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // --- Mocks ---
 
@@ -400,7 +397,7 @@ describe("NotificationPageList", () => {
         ]}
         initialHasMore={false}
         initialTopicsByEpisode={{}}
-        initialListenedIds={["PI-read"] as PodcastIndexEpisodeId[]}
+        initialListenedIds={[asPodcastIndexEpisodeId("PI-read")]}
       />,
     );
     // Row 1: unlistened → clickable Mark-as-listened button exists.
@@ -691,7 +688,7 @@ describe("NotificationPageList", () => {
         initialItems={[makeItem({ id: 1, episodePodcastIndexId: "PI-42" })]}
         initialHasMore={false}
         initialTopicsByEpisode={{}}
-        initialListenedIds={["PI-42"] as PodcastIndexEpisodeId[]}
+        initialListenedIds={[asPodcastIndexEpisodeId("PI-42")]}
       />,
     );
     const card = screen.getByRole("article")

--- a/src/components/notifications/__tests__/notification-page-list.test.tsx
+++ b/src/components/notifications/__tests__/notification-page-list.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NOTIFICATIONS_PAGE_SIZE } from "@/lib/notifications-constants";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 // --- Mocks ---
 
@@ -75,7 +79,16 @@ type NotificationItem = React.ComponentProps<
   typeof NotificationPageList
 >["initialItems"][0];
 
-function makeItem(overrides: Partial<NotificationItem> = {}): NotificationItem {
+type MakeItemOverrides = Partial<
+  Omit<NotificationItem, "episodePodcastIndexId">
+> & {
+  episodePodcastIndexId?: string | null;
+};
+
+function makeItem(overrides: MakeItemOverrides = {}): NotificationItem {
+  const { episodePodcastIndexId, ...rest } = overrides;
+  const piId =
+    episodePodcastIndexId === undefined ? "PI-42" : episodePodcastIndexId;
   return {
     id: 1,
     type: "new_episode",
@@ -84,14 +97,14 @@ function makeItem(overrides: Partial<NotificationItem> = {}): NotificationItem {
     isRead: false,
     createdAt: new Date("2026-01-15T10:00:00Z"),
     episodeDbId: 10,
-    episodePodcastIndexId: "PI-42",
+    episodePodcastIndexId: piId === null ? null : asPodcastIndexEpisodeId(piId),
     episodeTitle: "Test Episode",
     podcastTitle: "Test Podcast",
     worthItScore: "7.50",
     audioUrl: "https://example.com/audio.mp3",
     artwork: "https://example.com/art.jpg",
     duration: 3600,
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -387,7 +400,7 @@ describe("NotificationPageList", () => {
         ]}
         initialHasMore={false}
         initialTopicsByEpisode={{}}
-        initialListenedIds={["PI-read"]}
+        initialListenedIds={["PI-read"] as PodcastIndexEpisodeId[]}
       />,
     );
     // Row 1: unlistened → clickable Mark-as-listened button exists.
@@ -678,7 +691,7 @@ describe("NotificationPageList", () => {
         initialItems={[makeItem({ id: 1, episodePodcastIndexId: "PI-42" })]}
         initialHasMore={false}
         initialTopicsByEpisode={{}}
-        initialListenedIds={["PI-42"]}
+        initialListenedIds={["PI-42"] as PodcastIndexEpisodeId[]}
       />,
     );
     const card = screen.getByRole("article")

--- a/src/components/notifications/notification-page-list.stories.tsx
+++ b/src/components/notifications/notification-page-list.stories.tsx
@@ -1,3 +1,4 @@
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { NotificationPageList } from "@/components/notifications/notification-page-list";
 import {
@@ -38,7 +39,7 @@ function makeItem(
     isRead: false,
     createdAt: STORY_NOW,
     episodeDbId: id * 10,
-    episodePodcastIndexId: `pi-${id}`,
+    episodePodcastIndexId: asPodcastIndexEpisodeId(`pi-${id}`),
     episodeTitle: `Episode ${id}`,
     podcastTitle: `Podcast ${id}`,
     worthItScore: null,

--- a/src/components/notifications/notification-page-list.tsx
+++ b/src/components/notifications/notification-page-list.tsx
@@ -29,6 +29,7 @@ import { formatRelativeTime } from "@/lib/utils";
 import { ROUTES } from "@/lib/routes";
 import { LISTEN_STATE_CHANGED_EVENT } from "@/lib/events";
 import { NOTIFICATIONS_PAGE_SIZE } from "@/lib/notifications-constants";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 type NotificationItem = Awaited<
   ReturnType<typeof getNotifications>
@@ -53,7 +54,7 @@ interface NotificationPageListProps {
    * Passed as an array because RSC Flight can't serialize Sets; we build the
    * Set client-side. Matches the pattern in `src/components/podcasts/episode-list.tsx`.
    */
-  initialListenedIds?: string[];
+  initialListenedIds?: PodcastIndexEpisodeId[];
   filter?: { podcastId?: number; since?: Date };
 }
 
@@ -67,7 +68,7 @@ export function NotificationPageList({
   const router = useRouter();
   const [items, setItems] = useState<LocalNotification[]>(initialItems);
   const [hasMore, setHasMore] = useState(initialHasMore);
-  const [listenedIds, setListenedIds] = useState<string[]>(
+  const [listenedIds, setListenedIds] = useState<PodcastIndexEpisodeId[]>(
     initialListenedIds ?? [],
   );
   const listenedSet = useMemo(() => new Set(listenedIds), [listenedIds]);
@@ -101,14 +102,16 @@ export function NotificationPageList({
         const listenedDbIds = new Set(await getListenedEpisodeIds(dbIds));
         // Drop stale responses when a newer refresh is already in flight.
         if (seq !== refreshSeqRef.current) return;
-        const piIds = current
-          .filter(
-            (n) =>
-              n.episodeDbId !== null &&
-              listenedDbIds.has(n.episodeDbId) &&
-              n.episodePodcastIndexId,
-          )
-          .map((n) => n.episodePodcastIndexId as string);
+        const piIds = current.flatMap((n) => {
+          if (
+            n.episodeDbId !== null &&
+            listenedDbIds.has(n.episodeDbId) &&
+            n.episodePodcastIndexId !== null
+          ) {
+            return [n.episodePodcastIndexId]; // narrowed to PodcastIndexEpisodeId
+          }
+          return [];
+        });
         setListenedIds((prev) => {
           // getListenedEpisodeIds returns [] on failure and on "no listens"
           // alike. Treat empty-while-prev-non-empty as a likely failure and
@@ -241,7 +244,7 @@ export function NotificationPageList({
           .map((n) => n.episodeDbId)
           .filter((id): id is number => id !== null);
         let newTopics: Record<number, string[]> = {};
-        let newListenedPiIds: string[] = [];
+        let newListenedPiIds: PodcastIndexEpisodeId[] = [];
         if (newEpisodeIds.length > 0) {
           const [topicsResult, listenedResult] = await Promise.allSettled([
             getEpisodeTopics(newEpisodeIds),
@@ -258,14 +261,16 @@ export function NotificationPageList({
           }
           if (listenedResult.status === "fulfilled") {
             const listenedDbIds = new Set(listenedResult.value);
-            newListenedPiIds = newItems
-              .filter(
-                (n) =>
-                  n.episodeDbId !== null &&
-                  listenedDbIds.has(n.episodeDbId) &&
-                  n.episodePodcastIndexId,
-              )
-              .map((n) => n.episodePodcastIndexId as string);
+            newListenedPiIds = newItems.flatMap((n) => {
+              if (
+                n.episodeDbId !== null &&
+                listenedDbIds.has(n.episodeDbId) &&
+                n.episodePodcastIndexId !== null
+              ) {
+                return [n.episodePodcastIndexId]; // narrowed to PodcastIndexEpisodeId
+              }
+              return [];
+            });
           } else {
             // Degrade gracefully — rows stay "unlistened" on failure; the
             // user can re-mark if needed.

--- a/src/components/podcasts/episode-card.tsx
+++ b/src/components/podcasts/episode-card.tsx
@@ -4,6 +4,7 @@ import { Calendar, Clock, Mic } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import { formatDuration, formatPublishDate } from "@/lib/podcastindex";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import { stripHtml } from "@/lib/utils";
 import type { SummaryStatus } from "@/db/schema";
 import { AddToQueueButton } from "@/components/audio-player/add-to-queue-button";
@@ -31,9 +32,12 @@ export function EpisodeCard({
   canMarkListened = true,
   topics,
 }: EpisodeCardProps) {
+  // PodcastIndex API id (number|string) → branded string.
+  const piId = asPodcastIndexEpisodeId(String(episode.id));
+
   const audioEpisode = episode.enclosureUrl
     ? {
-        id: String(episode.id),
+        id: piId,
         title: episode.title,
         podcastTitle: episode.feedTitle ?? "Podcast",
         audioUrl: episode.enclosureUrl,
@@ -86,10 +90,7 @@ export function EpisodeCard({
         <AddToQueueButton episode={audioEpisode} variant="icon" />
       )}
       {canMarkListened && (
-        <ListenedButton
-          podcastIndexEpisodeId={String(episode.id)}
-          isListened={isListened}
-        />
+        <ListenedButton podcastIndexEpisodeId={piId} isListened={isListened} />
       )}
     </>
   );

--- a/src/components/podcasts/episode-list.tsx
+++ b/src/components/podcasts/episode-list.tsx
@@ -7,6 +7,10 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import type { SummaryStatus } from "@/db/schema";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 interface EpisodeListProps {
   episodes: PodcastIndexEpisode[];
@@ -17,15 +21,15 @@ interface EpisodeListProps {
   // String arrays (not Set) because props cross the RSC Flight boundary from
   // Server Components to this Client Component; Set is not serializable on
   // Next.js 14 / React 18 and becomes {} on the client.
-  listenedIds?: string[];
+  listenedIds?: PodcastIndexEpisodeId[];
   // Podcast-index-episode-ids (stringified) that exist in our DB and can be targeted by recordListenEvent.
   // Omit to allow marking on all episodes (library/trending surfaces where every episode is in-DB by construction).
-  knownIds?: string[];
+  knownIds?: PodcastIndexEpisodeId[];
   /**
-   * Top topics per episode, keyed by PodcastIndex id (string). Absent keys render
-   * no chips — episodes without summaries simply show nothing here.
+   * Top topics per episode, keyed by PodcastIndex id. Absent keys render no
+   * chips — episodes without summaries simply show nothing here.
    */
-  topicsByPodcastIndexId?: Record<string, string[]>;
+  topicsByPodcastIndexId?: Record<PodcastIndexEpisodeId, string[]>;
 }
 
 export function EpisodeList({
@@ -105,17 +109,21 @@ export function EpisodeList({
           </p>
         </div>
       ) : (
-        filteredEpisodes.map((episode) => (
-          <EpisodeCard
-            key={episode.id}
-            episode={episode}
-            summaryStatus={statusMap?.[String(episode.id)]}
-            worthItScore={scoreMap?.[String(episode.id)]}
-            isListened={listenedSet.has(String(episode.id))}
-            canMarkListened={knownSet ? knownSet.has(String(episode.id)) : true}
-            topics={topicsByPodcastIndexId?.[String(episode.id)]}
-          />
-        ))
+        filteredEpisodes.map((episode) => {
+          // PodcastIndex API id (number|string) → branded string.
+          const piId = asPodcastIndexEpisodeId(String(episode.id));
+          return (
+            <EpisodeCard
+              key={episode.id}
+              episode={episode}
+              summaryStatus={statusMap?.[piId]}
+              worthItScore={scoreMap?.[piId]}
+              isListened={listenedSet.has(piId)}
+              canMarkListened={knownSet ? knownSet.has(piId) : true}
+              topics={topicsByPodcastIndexId?.[piId]}
+            />
+          );
+        })
       )}
     </div>
   );

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -2087,7 +2087,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("focus refetch with mutated server metadata still applies the update", async () => {
     const localQueue: AudioEpisode[] = [
       {
-        id: "shared-id",
+        id: asPodcastIndexEpisodeId("shared-id"),
         title: "Old Title",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/old.mp3",
@@ -2095,7 +2095,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
     ];
     const serverQueue: AudioEpisode[] = [
       {
-        id: "shared-id",
+        id: asPodcastIndexEpisodeId("shared-id"),
         title: "New Title",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/new.mp3",

--- a/src/contexts/__tests__/audio-player-context.test.tsx
+++ b/src/contexts/__tests__/audio-player-context.test.tsx
@@ -11,6 +11,7 @@ import {
   useIsEpisodeInQueue,
   type AudioEpisode,
 } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock media-session helpers
 vi.mock("@/lib/media-session", () => ({
@@ -91,7 +92,7 @@ beforeEach(() => {
 });
 
 const mockEpisode: AudioEpisode = {
-  id: "ep-123",
+  id: asPodcastIndexEpisodeId("ep-123"),
   title: "Test Episode",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/audio.mp3",
@@ -100,7 +101,7 @@ const mockEpisode: AudioEpisode = {
 };
 
 const queueEpisode1: AudioEpisode = {
-  id: "q-1",
+  id: asPodcastIndexEpisodeId("q-1"),
   title: "Queue Episode 1",
   podcastTitle: "Queue Podcast",
   audioUrl: "https://example.com/q1.mp3",
@@ -108,7 +109,7 @@ const queueEpisode1: AudioEpisode = {
 };
 
 const queueEpisode2: AudioEpisode = {
-  id: "q-2",
+  id: asPodcastIndexEpisodeId("q-2"),
   title: "Queue Episode 2",
   podcastTitle: "Queue Podcast",
   audioUrl: "https://example.com/q2.mp3",
@@ -116,7 +117,7 @@ const queueEpisode2: AudioEpisode = {
 };
 
 const queueEpisode3: AudioEpisode = {
-  id: "q-3",
+  id: asPodcastIndexEpisodeId("q-3"),
   title: "Queue Episode 3",
   podcastTitle: "Queue Podcast",
   audioUrl: "https://example.com/q3.mp3",
@@ -1083,7 +1084,7 @@ function ChapterConsumer() {
         onClick={() =>
           api.playEpisode({
             ...mockEpisode,
-            id: "ep-with-chapters",
+            id: asPodcastIndexEpisodeId("ep-with-chapters"),
             chaptersUrl: "https://example.com/chapters.json",
           })
         }
@@ -1521,7 +1522,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("replaces queue with server state when server returns a non-empty queue different from local", async () => {
     const serverQueue: AudioEpisode[] = [
       {
-        id: "server-1",
+        id: asPodcastIndexEpisodeId("server-1"),
         title: "Server Ep 1",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/s1.mp3",
@@ -1550,7 +1551,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("calls setQueue(localQueue) exactly once when server is empty and local cache is non-empty (migration)", async () => {
     const localQueue: AudioEpisode[] = [
       {
-        id: "local-1",
+        id: asPodcastIndexEpisodeId("local-1"),
         title: "Local Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/l1.mp3",
@@ -1656,7 +1657,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("loads server session episode when a different episode is on device (cross-device sync)", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const serverEpisode: AudioEpisode = {
-      id: "server-ep-x",
+      id: asPodcastIndexEpisodeId("server-ep-x"),
       title: "Server Episode",
       podcastTitle: "Podcast",
       audioUrl: "https://example.com/server.mp3",
@@ -1691,7 +1692,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const serverQueue: AudioEpisode[] = [
       {
-        id: "server-1",
+        id: asPodcastIndexEpisodeId("server-1"),
         title: "Server Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/s1.mp3",
@@ -1728,7 +1729,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("migration race: in-flight setQueue suppresses concurrent focus INIT_QUEUE dispatch", async () => {
     const localQueue: AudioEpisode[] = [
       {
-        id: "local-1",
+        id: asPodcastIndexEpisodeId("local-1"),
         title: "Local Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/l1.mp3",
@@ -1780,7 +1781,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
     // Start with server returning an initial queue (lastAcked = this)
     const initialServerQueue: AudioEpisode[] = [
       {
-        id: "acked-1",
+        id: asPodcastIndexEpisodeId("acked-1"),
         title: "Acked Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/a1.mp3",
@@ -1865,7 +1866,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("does not write local queue back to server on cold boot when server has a different queue (local-wins regression)", async () => {
     const localQueue: AudioEpisode[] = [
       {
-        id: "local-1",
+        id: asPodcastIndexEpisodeId("local-1"),
         title: "Local Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/l1.mp3",
@@ -1873,7 +1874,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
     ];
     const serverQueue: AudioEpisode[] = [
       {
-        id: "server-1",
+        id: asPodcastIndexEpisodeId("server-1"),
         title: "Server Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/s1.mp3",
@@ -2013,7 +2014,7 @@ describe("Cross-device sync: hydration and reconcile", () => {
   it("fires a toast when the migration upload fails", async () => {
     const localQueue: AudioEpisode[] = [
       {
-        id: "local-1",
+        id: asPodcastIndexEpisodeId("local-1"),
         title: "Local Ep",
         podcastTitle: "Podcast",
         audioUrl: "https://example.com/l1.mp3",

--- a/src/db/library-columns.ts
+++ b/src/db/library-columns.ts
@@ -1,5 +1,6 @@
 /** Shared column selections and DTO types for library/episode/podcast queries. */
 
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 import { type OverlapLabelKind } from "@/lib/topic-overlap";
 
 // -- Column selection constants (Drizzle `columns` allowlist) --
@@ -41,7 +42,7 @@ export const COLLECTION_LIST_COLUMNS = {
 
 export interface EpisodeListDTO {
   id: number;
-  podcastIndexId: string;
+  podcastIndexId: PodcastIndexEpisodeId;
   title: string;
   description: string | null;
   audioUrl: string | null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -676,6 +676,9 @@ type _SessionDenormKeys = keyof Omit<
 
 type _Assert<T extends true> = T;
 type _KeysMatch<A, B> = [A, B] extends [B, A] ? true : false;
+// Same shape as _KeysMatch, named for readability when comparing field types
+// (rather than key unions) — see the `_Pi*Branded` invariants below.
+type _TypesMatch<A, B> = [A, B] extends [B, A] ? true : false;
 
 // If either of these fails to compile, the denormalized columns and
 // AudioEpisode have drifted. Fix by adding/removing a column on
@@ -692,14 +695,17 @@ export type _SessionDenormInvariant = _Assert<
 // these columns, the matching assertion fails and the build breaks at the
 // source — see ADR-040 (Drizzle `$type` regression risk).
 export type _EpisodesPiIdBranded = _Assert<
-  _KeysMatch<Episode["podcastIndexId"], PodcastIndexEpisodeId>
+  _TypesMatch<Episode["podcastIndexId"], PodcastIndexEpisodeId>
 >;
 export type _ListenHistoryPiIdBranded = _Assert<
-  _KeysMatch<ListenHistoryEntry["podcastIndexEpisodeId"], PodcastIndexEpisodeId>
+  _TypesMatch<
+    ListenHistoryEntry["podcastIndexEpisodeId"],
+    PodcastIndexEpisodeId
+  >
 >;
 export type _QueueItemsPiIdBranded = _Assert<
-  _KeysMatch<UserQueueItem["episodeId"], PodcastIndexEpisodeId>
+  _TypesMatch<UserQueueItem["episodeId"], PodcastIndexEpisodeId>
 >;
 export type _PlayerSessionPiIdBranded = _Assert<
-  _KeysMatch<UserPlayerSession["episodeId"], PodcastIndexEpisodeId>
+  _TypesMatch<UserPlayerSession["episodeId"], PodcastIndexEpisodeId>
 >;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,6 +15,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { relations, sql } from "drizzle-orm";
 import type { WorthItSignals } from "@/lib/openrouter";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 import {
   DEFAULT_SUBSCRIPTION_SORT,
   SUBSCRIPTION_SORTS,
@@ -86,7 +87,10 @@ export const episodes = pgTable(
     podcastId: integer("podcast_id")
       .references(() => podcasts.id, { onDelete: "cascade" })
       .notNull(),
-    podcastIndexId: text("podcast_index_id").notNull().unique(),
+    podcastIndexId: text("podcast_index_id")
+      .$type<PodcastIndexEpisodeId>()
+      .notNull()
+      .unique(),
     title: text("title").notNull(),
     description: text("description"),
     audioUrl: text("audio_url"),
@@ -370,7 +374,9 @@ export const listenHistory = pgTable(
     episodeId: integer("episode_id")
       .references(() => episodes.id, { onDelete: "cascade" })
       .notNull(),
-    podcastIndexEpisodeId: text("podcast_index_episode_id").notNull(),
+    podcastIndexEpisodeId: text("podcast_index_episode_id")
+      .$type<PodcastIndexEpisodeId>()
+      .notNull(),
     startedAt: timestamp("started_at").notNull(),
     completedAt: timestamp("completed_at"),
     listenDurationSeconds: integer("listen_duration_seconds"),
@@ -398,7 +404,7 @@ export const userQueueItems = pgTable(
       .references(() => users.id, { onDelete: "cascade" })
       .notNull(),
     position: integer("position").notNull(),
-    episodeId: text("episode_id").notNull(),
+    episodeId: text("episode_id").$type<PodcastIndexEpisodeId>().notNull(),
     title: text("title").notNull(),
     podcastTitle: text("podcast_title").notNull(),
     audioUrl: text("audio_url").notNull(),
@@ -424,7 +430,7 @@ export const userPlayerSession = pgTable("user_player_session", {
   userId: text("user_id")
     .primaryKey()
     .references(() => users.id, { onDelete: "cascade" }),
-  episodeId: text("episode_id").notNull(),
+  episodeId: text("episode_id").$type<PodcastIndexEpisodeId>().notNull(),
   title: text("title").notNull(),
   podcastTitle: text("podcast_title").notNull(),
   audioUrl: text("audio_url").notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -686,3 +686,20 @@ export type _QueueDenormInvariant = _Assert<
 export type _SessionDenormInvariant = _Assert<
   _KeysMatch<_SessionDenormKeys, _AudioEpisodeNonIdKeys>
 >;
+
+// Pin the PodcastIndexEpisodeId brand on every column that stores a PI episode
+// id. If a future migration drops `$type<PodcastIndexEpisodeId>()` from any of
+// these columns, the matching assertion fails and the build breaks at the
+// source — see ADR-040 (Drizzle `$type` regression risk).
+export type _EpisodesPiIdBranded = _Assert<
+  _KeysMatch<Episode["podcastIndexId"], PodcastIndexEpisodeId>
+>;
+export type _ListenHistoryPiIdBranded = _Assert<
+  _KeysMatch<ListenHistoryEntry["podcastIndexEpisodeId"], PodcastIndexEpisodeId>
+>;
+export type _QueueItemsPiIdBranded = _Assert<
+  _KeysMatch<UserQueueItem["episodeId"], PodcastIndexEpisodeId>
+>;
+export type _PlayerSessionPiIdBranded = _Assert<
+  _KeysMatch<UserPlayerSession["episodeId"], PodcastIndexEpisodeId>
+>;

--- a/src/lib/__tests__/offline-actions.test.ts
+++ b/src/lib/__tests__/offline-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock sync-queue before importing offline-actions
 const mockEnqueue = vi.fn();
@@ -28,7 +29,7 @@ vi.mock("@/app/actions/subscriptions", () => ({
 }));
 
 const sampleEpisodeData = {
-  podcastIndexId: "ep-123",
+  podcastIndexId: asPodcastIndexEpisodeId("ep-123"),
   title: "Test Episode",
   description: "A test",
   audioUrl: "https://example.com/audio.mp3",
@@ -174,7 +175,10 @@ describe("offlineUnsaveEpisode", () => {
     mockRemoveEpisodeFromLibrary.mockResolvedValue({ success: true });
 
     const { offlineUnsaveEpisode } = await import("@/lib/offline-actions");
-    const result = await offlineUnsaveEpisode("ep-123", true);
+    const result = await offlineUnsaveEpisode(
+      asPodcastIndexEpisodeId("ep-123"),
+      true,
+    );
 
     expect(mockRemoveEpisodeFromLibrary).toHaveBeenCalledWith("ep-123");
     expect(result.success).toBe(true);
@@ -182,7 +186,7 @@ describe("offlineUnsaveEpisode", () => {
 
   it("enqueues unsave-episode action when offline", async () => {
     const { offlineUnsaveEpisode } = await import("@/lib/offline-actions");
-    await offlineUnsaveEpisode("ep-123", false);
+    await offlineUnsaveEpisode(asPodcastIndexEpisodeId("ep-123"), false);
 
     expect(mockEnqueue).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -194,7 +198,10 @@ describe("offlineUnsaveEpisode", () => {
 
   it("returns queued:true when offline", async () => {
     const { offlineUnsaveEpisode } = await import("@/lib/offline-actions");
-    const result = await offlineUnsaveEpisode("ep-123", false);
+    const result = await offlineUnsaveEpisode(
+      asPodcastIndexEpisodeId("ep-123"),
+      false,
+    );
 
     expect(result.success).toBe(true);
     expect(result.queued).toBe(true);

--- a/src/lib/__tests__/player-session.test.ts
+++ b/src/lib/__tests__/player-session.test.ts
@@ -11,6 +11,7 @@ import {
   withoutWindow,
 } from "@/test/mocks/local-storage";
 import { validEpisode } from "@/test/fixtures/audio-episode";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const STORAGE_KEY = "contentgenie-player-session";
 
@@ -256,7 +257,7 @@ describe("loadPlayerSession", () => {
 
   it("accepts episode without optional fields", () => {
     const minimalEpisode: AudioEpisode = {
-      id: "ep-min",
+      id: asPodcastIndexEpisodeId("ep-min"),
       title: "Minimal",
       podcastTitle: "Pod",
       audioUrl: "https://example.com/a.mp3",

--- a/src/lib/admin/episode-queries.ts
+++ b/src/lib/admin/episode-queries.ts
@@ -1,6 +1,7 @@
 import { db } from "@/db";
 import { episodes, podcasts } from "@/db/schema";
 import { count, eq, sql } from "drizzle-orm";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 import {
   buildEpisodeWhereConditions,
   PAGE_SIZE,
@@ -13,7 +14,7 @@ export interface EpisodeRow {
   podcastId: number;
   podcastTitle: string;
   podcastImageUrl: string | null;
-  podcastIndexId: string;
+  podcastIndexId: PodcastIndexEpisodeId;
   publishDate: Date | null;
   transcriptStatus: string | null;
   transcriptSource: string | null;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -8,6 +8,7 @@ import {
 import { eq, inArray } from "drizzle-orm";
 import { sendPushToUser, consolePushLogger } from "@/lib/push";
 import { ROUTES } from "@/lib/routes";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 
 async function getNotificationPrefs(userId: string): Promise<{
   digestFrequency: "realtime" | "daily" | "weekly";
@@ -146,7 +147,7 @@ export async function createBulkNotifications(
         .filter((id): id is number => id != null),
     ),
   );
-  const episodePodcastIndexMap = new Map<number, string>();
+  const episodePodcastIndexMap = new Map<number, PodcastIndexEpisodeId>();
   if (episodeDbIds.length > 0) {
     try {
       const episodeRows = await db.query.episodes.findMany({

--- a/src/lib/offline-actions.ts
+++ b/src/lib/offline-actions.ts
@@ -3,6 +3,7 @@ import {
   saveEpisodeToLibrary,
   removeEpisodeFromLibrary,
 } from "@/app/actions/library";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 import {
   subscribeToPodcast,
   unsubscribeFromPodcast,
@@ -18,7 +19,7 @@ export interface ActionResult {
 }
 
 interface EpisodeData {
-  podcastIndexId: string;
+  podcastIndexId: PodcastIndexEpisodeId;
   title: string;
   description?: string;
   audioUrl?: string;
@@ -99,7 +100,7 @@ export async function offlineSaveEpisode(
 }
 
 export async function offlineUnsaveEpisode(
-  podcastIndexId: string,
+  podcastIndexId: PodcastIndexEpisodeId,
   isOnline: boolean,
 ): Promise<ActionResult> {
   // Online path

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,3 +1,5 @@
+import type { PodcastIndexEpisodeId } from "@/types/ids";
+
 /**
  * Centralized route path constants.
  * Kept in sync with the Next.js App Router file-system routes under app/(app)/.
@@ -8,7 +10,8 @@ export const ROUTES = {
   SUBSCRIPTIONS: "/subscriptions",
   LIBRARY: "/library",
   SETTINGS: "/settings",
-  episode: (podcastIndexId: string) => `/episode/${podcastIndexId}` as const,
+  episode: (podcastIndexId: PodcastIndexEpisodeId) =>
+    `/episode/${podcastIndexId}` as const,
 } as const;
 
 export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];

--- a/src/lib/schemas/library.ts
+++ b/src/lib/schemas/library.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 
 import { SUBSCRIPTION_SORTS } from "@/db/subscription-sorts";
-import {
-  asPodcastIndexEpisodeId,
-  type PodcastIndexEpisodeId,
-} from "@/types/ids";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 /** Shared max-length for short user text (notes, descriptions, etc.). */
 export const MAX_SHORT_TEXT = 500;

--- a/src/lib/schemas/library.ts
+++ b/src/lib/schemas/library.ts
@@ -32,6 +32,7 @@ const podcastSchema = z
 
 export const saveEpisodeSchema = z
   .object({
+    // Post-validation cast — JSON body string, trimmed and length-checked.
     podcastIndexId: trimmedNonEmpty.transform((v) =>
       asPodcastIndexEpisodeId(v),
     ),
@@ -46,6 +47,7 @@ export const saveEpisodeSchema = z
 
 export const unsaveEpisodeSchema = z
   .object({
+    // Post-validation cast — JSON body string, trimmed and length-checked.
     podcastIndexId: trimmedNonEmpty.transform((v) =>
       asPodcastIndexEpisodeId(v),
     ),

--- a/src/lib/schemas/library.ts
+++ b/src/lib/schemas/library.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
+
 import { SUBSCRIPTION_SORTS } from "@/db/subscription-sorts";
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
 
 /** Shared max-length for short user text (notes, descriptions, etc.). */
 export const MAX_SHORT_TEXT = 500;
@@ -27,7 +32,9 @@ const podcastSchema = z
 
 export const saveEpisodeSchema = z
   .object({
-    podcastIndexId: trimmedNonEmpty,
+    podcastIndexId: trimmedNonEmpty.transform((v) =>
+      asPodcastIndexEpisodeId(v),
+    ),
     title: trimmedNonEmpty,
     description: optionalText,
     audioUrl: optionalUrl,
@@ -39,7 +46,9 @@ export const saveEpisodeSchema = z
 
 export const unsaveEpisodeSchema = z
   .object({
-    podcastIndexId: trimmedNonEmpty,
+    podcastIndexId: trimmedNonEmpty.transform((v) =>
+      asPodcastIndexEpisodeId(v),
+    ),
   })
   .strip();
 

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -25,6 +25,7 @@ export const MAX_QUEUE_ITEMS = 200;
 
 export const audioEpisodeSchema = z
   .object({
+    // Post-validation cast — client/RSC payload string, trimmed and length-checked.
     id: trimmedNonEmpty.transform((v) => asPodcastIndexEpisodeId(v)),
     title: trimmedNonEmpty,
     podcastTitle: trimmedNonEmpty,

--- a/src/lib/schemas/listening-queue.ts
+++ b/src/lib/schemas/listening-queue.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
+
 const trimmedNonEmpty = z.string().trim().min(1).max(500);
 
 // Restrict URL schemes to http/https so user-supplied payloads can't land
@@ -20,7 +25,7 @@ export const MAX_QUEUE_ITEMS = 200;
 
 export const audioEpisodeSchema = z
   .object({
-    id: trimmedNonEmpty,
+    id: trimmedNonEmpty.transform((v) => asPodcastIndexEpisodeId(v)),
     title: trimmedNonEmpty,
     podcastTitle: trimmedNonEmpty,
     audioUrl: httpOrHttpsUrl,
@@ -60,7 +65,7 @@ export type AudioEpisode = z.infer<typeof audioEpisodeSchema>;
  * assertions in `@/db/schema` guarantee these field sets stay aligned.
  */
 export interface EpisodeDenormRow {
-  episodeId: string;
+  episodeId: PodcastIndexEpisodeId;
   title: string;
   podcastTitle: string;
   audioUrl: string;

--- a/src/test/fixtures/audio-episode.ts
+++ b/src/test/fixtures/audio-episode.ts
@@ -1,7 +1,8 @@
 import type { AudioEpisode } from "@/contexts/audio-player-context";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 export const validEpisode: AudioEpisode = {
-  id: "ep-1",
+  id: asPodcastIndexEpisodeId("ep-1"),
   title: "Test Episode",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/audio.mp3",
@@ -10,7 +11,7 @@ export const validEpisode: AudioEpisode = {
 };
 
 export const validEpisode2: AudioEpisode = {
-  id: "ep-2",
+  id: asPodcastIndexEpisodeId("ep-2"),
   title: "Test Episode 2",
   podcastTitle: "Test Podcast",
   audioUrl: "https://example.com/audio2.mp3",

--- a/src/trigger/fetch-transcript.ts
+++ b/src/trigger/fetch-transcript.ts
@@ -2,6 +2,7 @@ import { task, retry, logger, metadata, wait } from "@trigger.dev/sdk";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { episodes } from "@/db/schema";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import {
   fetchTranscript,
   extractTranscriptUrl,
@@ -50,6 +51,8 @@ export const fetchTranscriptTask = task({
       force = false,
       triggerSummarize = false,
     } = payload;
+    // Trigger payload uses numeric form; brand for DB lookup.
+    const piId = asPodcastIndexEpisodeId(String(episodeId));
 
     metadata.set("step", "fetching-transcript");
     logger.info("Checking for cached transcription");
@@ -66,7 +69,7 @@ export const fetchTranscriptTask = task({
     if (!force) {
       try {
         const existing = await db.query.episodes.findFirst({
-          where: eq(episodes.podcastIndexId, String(episodeId)),
+          where: eq(episodes.podcastIndexId, piId),
           columns: { transcription: true },
         });
         if (existing?.transcription?.trim()) {
@@ -275,7 +278,7 @@ export const fetchTranscriptTask = task({
           ...(!transcript && { transcriptStatus: "missing" }),
           updatedAt: new Date(),
         })
-        .where(eq(episodes.podcastIndexId, String(episodeId)));
+        .where(eq(episodes.podcastIndexId, piId));
     } catch (err) {
       logger.warn("Failed to clear transcriptRunId", {
         episodeId,
@@ -301,6 +304,8 @@ export const fetchTranscriptTask = task({
     return { transcript, source: dbSource };
   },
   onFailure: async ({ payload }) => {
+    // Trigger payload uses numeric form; brand for DB lookup.
+    const piId = asPodcastIndexEpisodeId(String(payload.episodeId));
     logger.error("Transcript fetch task failed permanently", {
       episodeId: payload.episodeId,
     });
@@ -312,7 +317,7 @@ export const fetchTranscriptTask = task({
           transcriptStatus: "failed",
           updatedAt: new Date(),
         })
-        .where(eq(episodes.podcastIndexId, String(payload.episodeId)));
+        .where(eq(episodes.podcastIndexId, piId));
     } catch (error) {
       logger.error("Failed to update episode status in onFailure", {
         episodeId: payload.episodeId,

--- a/src/trigger/helpers/__tests__/notifications.test.ts
+++ b/src/trigger/helpers/__tests__/notifications.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 // Mock Trigger.dev SDK
 vi.mock("@trigger.dev/sdk", () => ({
@@ -108,7 +109,7 @@ describe("trigger/helpers/notifications", () => {
     const singleEpisode = [
       {
         episodeId: 100,
-        podcastIndexEpisodeId: "PI-100",
+        podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-100"),
         title: "Test Podcast",
         body: "New episode: Test Episode",
       },
@@ -138,13 +139,13 @@ describe("trigger/helpers/notifications", () => {
       await createEpisodeNotifications(1, [
         {
           episodeId: 100,
-          podcastIndexEpisodeId: "PI-100",
+          podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-100"),
           title: "Test Podcast",
           body: "New episode: Ep X",
         },
         {
           episodeId: 101,
-          podcastIndexEpisodeId: "PI-101",
+          podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-101"),
           title: "Test Podcast",
           body: "New episode: Ep Y",
         },
@@ -246,7 +247,7 @@ describe("trigger/helpers/notifications", () => {
       await createEpisodeNotifications(1, [
         {
           episodeId: 100,
-          podcastIndexEpisodeId: "PI-999",
+          podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-999"),
           title: "Test Podcast",
           body: "New episode: Test",
         },
@@ -319,13 +320,13 @@ describe("trigger/helpers/notifications", () => {
       await createEpisodeNotifications(1, [
         {
           episodeId: 100,
-          podcastIndexEpisodeId: "PI-100",
+          podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-100"),
           title: "Show",
           body: "New episode: A",
         },
         {
           episodeId: 101,
-          podcastIndexEpisodeId: "PI-101",
+          podcastIndexEpisodeId: asPodcastIndexEpisodeId("PI-101"),
           title: "Show",
           body: "New episode: B",
         },
@@ -446,7 +447,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -475,7 +476,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -502,7 +503,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -536,7 +537,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -567,7 +568,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -603,7 +604,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -624,7 +625,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-100",
+        asPodcastIndexEpisodeId("PI-100"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );
@@ -654,7 +655,7 @@ describe("trigger/helpers/notifications", () => {
       await markSummaryReady(
         1,
         100,
-        "PI-456",
+        asPodcastIndexEpisodeId("PI-456"),
         "Test Podcast",
         "Summary ready: Test Episode",
       );

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -104,6 +104,8 @@ export async function updateEpisodeStatus(
   episodeId: number | string,
   status: "summarizing",
 ): Promise<void> {
+  // PodcastIndex API id (number|string from caller) → branded string for DB lookup.
+  const piId = asPodcastIndexEpisodeId(String(episodeId));
   await db
     .update(episodes)
     .set({
@@ -111,9 +113,7 @@ export async function updateEpisodeStatus(
       processingError: null,
       updatedAt: new Date(),
     })
-    .where(
-      eq(episodes.podcastIndexId, asPodcastIndexEpisodeId(String(episodeId))),
-    );
+    .where(eq(episodes.podcastIndexId, piId));
 }
 
 // persistTranscript is the sole writer of transcript columns — summarize-episode
@@ -127,6 +127,8 @@ export async function persistTranscript(
   source: "podcastindex" | "assemblyai" | "description-url",
 ): Promise<void> {
   const now = new Date();
+  // Trigger payload uses numeric form; brand for DB lookup.
+  const piId = asPodcastIndexEpisodeId(String(episodeId));
   const updated = await db
     .update(episodes)
     .set({
@@ -138,9 +140,7 @@ export async function persistTranscript(
       transcriptRunId: null,
       updatedAt: now,
     })
-    .where(
-      eq(episodes.podcastIndexId, asPodcastIndexEpisodeId(String(episodeId))),
-    )
+    .where(eq(episodes.podcastIndexId, piId))
     .returning({ id: episodes.id });
 
   if (updated.length === 0) {

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { episodes, episodeTopics, podcasts } from "@/db/schema";
 import { upsertPodcast } from "@/db/helpers";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import type { SummaryResult } from "@/lib/openrouter";
 import type {
   PodcastIndexPodcast,
@@ -58,8 +59,11 @@ export async function trackEpisodeRun(
   const podcastId = await ensurePodcast(episode.feedId, podcast);
   if (!podcastId) return;
 
+  // PodcastIndex API id (number|string) → branded string.
+  const piId = asPodcastIndexEpisodeId(episode.id.toString());
+
   const existingEp = await db.query.episodes.findFirst({
-    where: eq(episodes.podcastIndexId, episode.id.toString()),
+    where: eq(episodes.podcastIndexId, piId),
   });
 
   if (existingEp) {
@@ -77,7 +81,7 @@ export async function trackEpisodeRun(
       .insert(episodes)
       .values({
         podcastId,
-        podcastIndexId: episode.id.toString(),
+        podcastIndexId: piId,
         title: episode.title,
         description: episode.description,
         audioUrl: episode.enclosureUrl,
@@ -107,7 +111,9 @@ export async function updateEpisodeStatus(
       processingError: null,
       updatedAt: new Date(),
     })
-    .where(eq(episodes.podcastIndexId, String(episodeId)));
+    .where(
+      eq(episodes.podcastIndexId, asPodcastIndexEpisodeId(String(episodeId))),
+    );
 }
 
 // persistTranscript is the sole writer of transcript columns — summarize-episode
@@ -132,7 +138,9 @@ export async function persistTranscript(
       transcriptRunId: null,
       updatedAt: now,
     })
-    .where(eq(episodes.podcastIndexId, String(episodeId)))
+    .where(
+      eq(episodes.podcastIndexId, asPodcastIndexEpisodeId(String(episodeId))),
+    )
     .returning({ id: episodes.id });
 
   if (updated.length === 0) {
@@ -170,9 +178,12 @@ export async function persistEpisodeSummary(
     throw new Error("Could not find or create podcast in database");
   }
 
+  // PodcastIndex API id (number|string) → branded string.
+  const piId = asPodcastIndexEpisodeId(episode.id.toString());
+
   // May have been created by trackEpisodeRun
   const existingEpisode = await db.query.episodes.findFirst({
-    where: eq(episodes.podcastIndexId, episode.id.toString()),
+    where: eq(episodes.podcastIndexId, piId),
   });
 
   if (existingEpisode) {
@@ -198,7 +209,7 @@ export async function persistEpisodeSummary(
       .insert(episodes)
       .values({
         podcastId,
-        podcastIndexId: episode.id.toString(),
+        podcastIndexId: piId,
         title: episode.title,
         description: episode.description,
         audioUrl: episode.enclosureUrl,

--- a/src/trigger/helpers/notifications.ts
+++ b/src/trigger/helpers/notifications.ts
@@ -3,6 +3,7 @@ import { eq, and, inArray, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { sendPushToUser } from "@/lib/push";
 import { ROUTES } from "@/lib/routes";
+import type { PodcastIndexEpisodeId } from "@/types/ids";
 import {
   notifications,
   userSubscriptions,
@@ -70,7 +71,7 @@ const episodeTag = (episodeId: number) => `episode-${episodeId}`;
 
 export type NewEpisodeInput = {
   episodeId: number;
-  podcastIndexEpisodeId: string;
+  podcastIndexEpisodeId: PodcastIndexEpisodeId;
   title: string;
   body: string;
 };
@@ -166,7 +167,7 @@ export async function createEpisodeNotifications(
 export async function markSummaryReady(
   podcastId: number,
   episodeId: number,
-  podcastIndexEpisodeId: string,
+  podcastIndexEpisodeId: PodcastIndexEpisodeId,
   title: string,
   body: string,
 ): Promise<void> {

--- a/src/trigger/import-opml.ts
+++ b/src/trigger/import-opml.ts
@@ -9,6 +9,7 @@ import {
   generateEpisodeSyntheticId,
 } from "@/lib/rss";
 import type { OpmlFeed } from "@/lib/opml";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 
 const MAX_EPISODES_PER_FEED = 50;
 
@@ -199,7 +200,10 @@ async function importSingleFeed(userId: string, feed: OpmlFeed): Promise<void> {
   if (episodesToInsert.length > 0) {
     const episodeValues = episodesToInsert.map((ep) => ({
       podcastId,
-      podcastIndexId: generateEpisodeSyntheticId(feedUrl, ep.guid),
+      // RSS-sourced synthetic episode id → branded string for insert.
+      podcastIndexId: asPodcastIndexEpisodeId(
+        generateEpisodeSyntheticId(feedUrl, ep.guid),
+      ),
       title: ep.title,
       description: ep.description,
       audioUrl: ep.audioUrl,

--- a/src/trigger/poll-new-episodes.ts
+++ b/src/trigger/poll-new-episodes.ts
@@ -2,6 +2,7 @@ import { schedules, logger, retry } from "@trigger.dev/sdk";
 import { eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { podcasts, episodes, userSubscriptions } from "@/db/schema";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import { getEpisodesByFeedId } from "@/trigger/helpers/podcastindex";
 import { fetchTranscriptTask } from "@/trigger/fetch-transcript";
 import { createEpisodeNotifications } from "@/trigger/helpers/notifications";
@@ -68,15 +69,19 @@ export async function pollSingleFeed(podcast: typeof podcasts.$inferSelect) {
     // Deduplicate for the transcript pipeline: only genuinely-new episodes
     // trigger fetch-transcript. Not used to gate the notification path — see
     // the `upserted` block below for the retry-safe notification flow.
-    const fetchedIds = fetchedEpisodes.map((ep) => String(ep.id));
+    // PodcastIndex API id (number|string) → branded string.
+    const fetchedIds = fetchedEpisodes.map((ep) =>
+      asPodcastIndexEpisodeId(String(ep.id)),
+    );
     const existingEpisodes = await db
       .select({ podcastIndexId: episodes.podcastIndexId })
       .from(episodes)
       .where(inArray(episodes.podcastIndexId, fetchedIds));
 
     const existingIds = new Set(existingEpisodes.map((e) => e.podcastIndexId));
+    // Reuse fetchedIds (already computed above) to avoid re-branding.
     newEpisodes = fetchedEpisodes.filter(
-      (ep) => !existingIds.has(String(ep.id)),
+      (_, i) => !existingIds.has(fetchedIds[i]),
     );
 
     logger.info("Deduplication complete", {
@@ -97,9 +102,9 @@ export async function pollSingleFeed(podcast: typeof podcasts.$inferSelect) {
     const upserted = await db
       .insert(episodes)
       .values(
-        fetchedEpisodes.map((ep) => ({
+        fetchedEpisodes.map((ep, i) => ({
           podcastId: podcast.id,
-          podcastIndexId: String(ep.id),
+          podcastIndexId: fetchedIds[i], // reuse pre-branded id
           title: ep.title,
           description: ep.description,
           audioUrl: ep.enclosureUrl,
@@ -121,7 +126,7 @@ export async function pollSingleFeed(podcast: typeof podcasts.$inferSelect) {
     // instead of N queries per-episode. Idempotent — only genuinely-new
     // (user, episode) pairs produce a row + push.
     const episodeByPiid = new Map(
-      fetchedEpisodes.map((e) => [String(e.id), e]),
+      fetchedEpisodes.map((e, i) => [fetchedIds[i], e]), // reuse pre-branded ids
     );
     const notificationBatch = upserted.map((row) => {
       const ep = episodeByPiid.get(row.podcastIndexId);

--- a/src/trigger/summarize-episode.ts
+++ b/src/trigger/summarize-episode.ts
@@ -6,6 +6,7 @@ import {
   AbortTaskRunError,
 } from "@trigger.dev/sdk";
 import { eq } from "drizzle-orm";
+import { asPodcastIndexEpisodeId } from "@/types/ids";
 import { getEpisodeById, getPodcastById } from "@/trigger/helpers/podcastindex";
 import {
   generateEpisodeSummary,
@@ -52,11 +53,13 @@ export const summarizeEpisode = task({
   maxDuration: 600, // 10 min — summarization itself is ~10-30s; generous buffer for retries
   onFailure: async (params: { payload: SummarizeEpisodePayload }) => {
     const { episodeId } = params.payload;
+    // Trigger payload uses numeric form; brand for DB lookup.
+    const piId = asPodcastIndexEpisodeId(String(episodeId));
     logger.error("Summarization task failed permanently", { episodeId });
     let existingProcessingError: string | null = null;
     try {
       const existing = await db.query.episodes.findFirst({
-        where: eq(episodes.podcastIndexId, String(episodeId)),
+        where: eq(episodes.podcastIndexId, piId),
         columns: { processingError: true },
       });
       existingProcessingError = existing?.processingError ?? null;
@@ -81,7 +84,7 @@ export const summarizeEpisode = task({
             "Summarization failed after maximum retry attempts",
           updatedAt: new Date(),
         })
-        .where(eq(episodes.podcastIndexId, String(episodeId)));
+        .where(eq(episodes.podcastIndexId, piId));
     } catch (error) {
       logger.error("Failed to update episode status to failed in database", {
         episodeId,
@@ -95,6 +98,8 @@ export const summarizeEpisode = task({
     { ctx },
   ): Promise<SummaryResult> => {
     const { episodeId } = payload;
+    // Trigger payload uses numeric form; brand for DB lookup.
+    const piId = asPodcastIndexEpisodeId(String(episodeId));
 
     // Step 1: Fetch episode from PodcastIndex
     setStep("fetching-episode");
@@ -116,7 +121,7 @@ export const summarizeEpisode = task({
             processingError: errorMsg,
             updatedAt: new Date(),
           })
-          .where(eq(episodes.podcastIndexId, String(episodeId)));
+          .where(eq(episodes.podcastIndexId, piId));
       } catch (dbErr) {
         logger.warn("Failed to write processingError before abort", {
           episodeId,
@@ -164,7 +169,7 @@ export const summarizeEpisode = task({
     const episodeRow = await retry.onThrow(
       async () =>
         db.query.episodes.findFirst({
-          where: eq(episodes.podcastIndexId, String(episodeId)),
+          where: eq(episodes.podcastIndexId, piId),
           columns: { transcription: true },
         }),
       { maxAttempts: 3 },
@@ -183,7 +188,7 @@ export const summarizeEpisode = task({
             processingError: errorMsg,
             updatedAt: new Date(),
           })
-          .where(eq(episodes.podcastIndexId, String(episodeId)));
+          .where(eq(episodes.podcastIndexId, piId));
       } catch (dbErr) {
         logger.warn("Failed to write processingError before abort", {
           episodeId,
@@ -242,7 +247,7 @@ export const summarizeEpisode = task({
       const podcastDbId = await resolvePodcastId(episode.feedId);
       if (podcastDbId) {
         const dbEpisode = await db.query.episodes.findFirst({
-          where: eq(episodes.podcastIndexId, String(episodeId)),
+          where: eq(episodes.podcastIndexId, piId),
           columns: { id: true },
         });
         const episodeDbId = dbEpisode?.id ?? null;
@@ -250,7 +255,7 @@ export const summarizeEpisode = task({
           await markSummaryReady(
             podcastDbId,
             episodeDbId,
-            String(episodeId),
+            piId,
             podcast?.title ?? episode.title,
             `Summary ready: ${episode.title}`,
           );

--- a/src/types/__tests__/ids.test.ts
+++ b/src/types/__tests__/ids.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Type-level tests for PodcastIndexEpisodeId brand.
+ *
+ * Note: vitest does not type-check source files — the TypeScript compiler
+ * (run as part of `bun run build` → `next build` → `tsc --noEmit`) is what
+ * enforces the `@ts-expect-error` directives below. If a brand constraint
+ * is removed or widened, the corresponding `@ts-expect-error` becomes unused
+ * and tsc flags the test file as a build error — that IS the assertion.
+ *
+ * The vitest `expect` body is minimal: just enough to exercise the module so
+ * the file is included in the test run (and coverage tooling) without dead code.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  asPodcastIndexEpisodeId,
+  type PodcastIndexEpisodeId,
+} from "@/types/ids";
+
+// A throwaway "other" brand to verify cross-brand non-interchangeability.
+type OtherBrandedId = string & { readonly __brand: "OtherBrandedId" };
+
+describe("PodcastIndexEpisodeId brand", () => {
+  it("constructor is a transparent cast at runtime", () => {
+    expect(asPodcastIndexEpisodeId("12345")).toBe("12345");
+    expect(asPodcastIndexEpisodeId("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level assertions (enforced by tsc, not vitest)
+// ---------------------------------------------------------------------------
+
+// 1. A plain string (e.g. String(dbEpisode.id)) is NOT assignable to
+//    PodcastIndexEpisodeId[].
+function _acceptsEpisodeIdArray(_ids: PodcastIndexEpisodeId[]): void {}
+
+const _plainString: string = "42";
+// @ts-expect-error — plain string not assignable to PodcastIndexEpisodeId[]
+_acceptsEpisodeIdArray([_plainString]);
+
+// 2. A numeric DB id coerced to string is NOT assignable.
+const _numericDbId: number = 99;
+// @ts-expect-error — String(dbEpisodeId) plain string not assignable to PodcastIndexEpisodeId[]
+_acceptsEpisodeIdArray([String(_numericDbId)]);
+
+// 3. Two different branded ids are not interchangeable.
+function _acceptsOtherBrand(_id: OtherBrandedId): void {}
+
+const _piId = asPodcastIndexEpisodeId("42");
+// @ts-expect-error — PodcastIndexEpisodeId not assignable to OtherBrandedId
+_acceptsOtherBrand(_piId);
+
+// 4. Positive: the constructor output IS assignable to PodcastIndexEpisodeId[].
+const _brandedArray: PodcastIndexEpisodeId[] = [asPodcastIndexEpisodeId("1")];
+_acceptsEpisodeIdArray(_brandedArray);

--- a/src/types/ids.ts
+++ b/src/types/ids.ts
@@ -1,0 +1,33 @@
+/**
+ * Branded id types for compile-time namespace disambiguation.
+ *
+ * Each namespace in the codebase that carries a structurally identical `string`
+ * but a distinct semantic identity gets its own brand. Runtime validation
+ * (zod, route-param parsing, DB lookups) is a separate concern handled at
+ * external-input boundaries — the constructors here are compile-time tools only.
+ */
+
+/**
+ * The stringified PodcastIndex episode id — the canonical identifier used in
+ * URLs, server-action params, and component props to address a specific episode.
+ *
+ * Sourced from `PodcastIndexEpisode.id` (number|string from the PI API) via
+ * `String(...)`, or read from `episodes.podcastIndexId` /
+ * `listenHistory.podcastIndexEpisodeId` columns (which carry this brand via
+ * Drizzle `$type<PodcastIndexEpisodeId>()`).
+ *
+ * Not to be confused with:
+ * - `episodes.id` — the DB-internal serial integer id (`number`).
+ * - `podcasts.podcastIndexId` — the PI *podcast* id namespace (different entity).
+ */
+export type PodcastIndexEpisodeId = string & {
+  readonly __brand: "PodcastIndexEpisodeId";
+};
+
+/**
+ * Compile-time constructor. Cast a validated/trusted string into the
+ * PodcastIndex episode id namespace. Not a runtime check.
+ */
+export function asPodcastIndexEpisodeId(s: string): PodcastIndexEpisodeId {
+  return s as PodcastIndexEpisodeId;
+}


### PR DESCRIPTION
## Summary

Introduces a TypeScript branded type `PodcastIndexEpisodeId` to disambiguate the PodcastIndex *episode* id namespace from the structurally identical `string`s of DB-internal episode ids and Clerk user ids. The brand is applied at the Drizzle column origin (`episodes.podcastIndexId`, `listenHistory.podcastIndexEpisodeId`, `userQueueItems.episodeId`, `userPlayerSession.episodeId`) and propagates outward through every type-level boundary it crosses — server actions, route helpers, component props, zod schemas, and Trigger.dev seams. Cast points use `asPodcastIndexEpisodeId(...)` with one-line comments naming the source namespace at each seam.

- Pure type-level change; **no runtime behaviour change**.
- Pinned by a type-level test (`src/types/__tests__/ids.test.ts`) with `@ts-expect-error` directives, plus four `_Pi*Branded` schema invariants in `src/db/schema.ts` that fail the build if any column ever drops `$type<PodcastIndexEpisodeId>()`.
- See [ADR-040](docs/adr/040-podcast-index-episode-id-branded-type.md) for the design decision and scope discipline (deferred siblings: `PodcastIndexPodcastId`, `DbEpisodeId`, `ClerkUserId`).

Out of scope (deferred until pain surfaces): brands for the *podcast* PI id, DB internal id, and Clerk user id; runtime zod validation of the brand.

## Test plan

- [x] `bun run format:check` exits 0
- [x] `bunx tsc --noEmit` exits 0 (full project, including tests)
- [x] `bun run lint` exits 0 (no warnings)
- [x] `bun run test` exits 0 — 2258/2258 tests pass (zero regressions)
- [x] `bun run build` exits 0
- [x] `bun run build-storybook` exits 0
- [x] No stray `as PodcastIndexEpisodeId` outside the constructor and test/story fixtures
- [x] Type-level test pins the brand contract via `@ts-expect-error`
- [x] Schema invariants pin `$type<PodcastIndexEpisodeId>()` on all four PI episode-id columns

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced compile-time type safety improvements for episode identifiers to prevent type-level ID namespace confusion. No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->