### PR TITLE
feat: canonical_topic_digests cache schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `canonical_topic_digests` cache table for per-canonical-topic synthesis digests (consensus + disagreement takeaways across episodes) with FK to `canonical_topics` (ON DELETE CASCADE), UNIQUE on `canonical_topic_id` (`ctd_canonical_topic_uidx`), and CHECK `episode_count_at_generation >= 0` (`ctd_episode_count_gte_0`). Migration `drizzle/0026_breezy_gabe_jones.sql` (#397).
 - `canonical_topics`, `canonical_topic_aliases`, and `episode_canonical_topics` schema with dual `vector(1024)` embeddings, HNSW indexes (`m=16, ef_construction=64`), partial unique index on `(lower(normalized_label), kind) WHERE status='active'`, seven CHECK constraints on `canonical_topics` (biconditional merged flag, self-merge ban, relevance/episode_count ranges, non-blank label/normalized_label/summary), and three on the junction table (match_method enum, coverage_score/similarity ranges). Migrations `drizzle/0024_vengeful_salo.sql` and `drizzle/0025_loose_matthew_murdock.sql`. Foundation for canonical-topics entity resolution (#383).
 - Auto-dismiss notifications for an episode when the user adds it to the queue or marks it as listened. ([#362](https://github.com/Chalet-Labs/contentgenie/issues/362))
 - pgvector extension migration (`drizzle/0023_enable_pgvector.sql`) and embedding helper (`generateEmbedding`, `generateEmbeddings` in `@/lib/ai`) targeting `perplexity/pplx-embed-v1-0.6b` via OpenRouter. Foundation for canonical-topics epic (#376).

--- a/drizzle/0026_breezy_gabe_jones.sql
+++ b/drizzle/0026_breezy_gabe_jones.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "canonical_topic_digests" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"canonical_topic_id" integer NOT NULL,
+	"digest_markdown" text NOT NULL,
+	"consensus_points" jsonb NOT NULL,
+	"disagreement_points" jsonb NOT NULL,
+	"episode_ids" integer[] NOT NULL,
+	"episode_count_at_generation" integer NOT NULL,
+	"model_used" text NOT NULL,
+	"generated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "ctd_episode_count_gte_0" CHECK ("canonical_topic_digests"."episode_count_at_generation" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "canonical_topic_digests" ADD CONSTRAINT "canonical_topic_digests_canonical_topic_id_canonical_topics_id_fk" FOREIGN KEY ("canonical_topic_id") REFERENCES "public"."canonical_topics"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "ctd_canonical_topic_uidx" ON "canonical_topic_digests" USING btree ("canonical_topic_id");

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,2438 @@
+{
+  "id": "eb279444-145d-479a-99a5-3de2b313f842",
+  "prevId": "b3bb90d8-ffdd-40fc-af30-6c4c7231f61e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_config": {
+      "name": "ai_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summarization_prompt": {
+          "name": "summarization_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_config_updated_by_users_id_fk": {
+          "name": "ai_config_updated_by_users_id_fk",
+          "tableFrom": "ai_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "provider_enum": {
+          "name": "provider_enum",
+          "value": "\"ai_config\".\"provider\" IN ('openrouter', 'zai')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_library_id": {
+          "name": "user_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_library_id_idx": {
+          "name": "bookmarks_user_library_id_idx",
+          "columns": [
+            {
+              "expression": "user_library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_library_id_user_library_id_fk": {
+          "name": "bookmarks_user_library_id_user_library_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "user_library",
+          "columnsFrom": [
+            "user_library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canonical_topic_aliases": {
+      "name": "canonical_topic_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canonical_topic_id": {
+          "name": "canonical_topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cta_topic_alias_lower_uidx": {
+          "name": "cta_topic_alias_lower_uidx",
+          "columns": [
+            {
+              "expression": "canonical_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"alias\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canonical_topic_aliases_canonical_topic_id_canonical_topics_id_fk": {
+          "name": "canonical_topic_aliases_canonical_topic_id_canonical_topics_id_fk",
+          "tableFrom": "canonical_topic_aliases",
+          "tableTo": "canonical_topics",
+          "columnsFrom": [
+            "canonical_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cta_alias_not_blank": {
+          "name": "cta_alias_not_blank",
+          "value": "length(btrim(\"canonical_topic_aliases\".\"alias\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.canonical_topic_digests": {
+      "name": "canonical_topic_digests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canonical_topic_id": {
+          "name": "canonical_topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digest_markdown": {
+          "name": "digest_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consensus_points": {
+          "name": "consensus_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disagreement_points": {
+          "name": "disagreement_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_ids": {
+          "name": "episode_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count_at_generation": {
+          "name": "episode_count_at_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_used": {
+          "name": "model_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ctd_canonical_topic_uidx": {
+          "name": "ctd_canonical_topic_uidx",
+          "columns": [
+            {
+              "expression": "canonical_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canonical_topic_digests_canonical_topic_id_canonical_topics_id_fk": {
+          "name": "canonical_topic_digests_canonical_topic_id_canonical_topics_id_fk",
+          "tableFrom": "canonical_topic_digests",
+          "tableTo": "canonical_topics",
+          "columnsFrom": [
+            "canonical_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ctd_episode_count_gte_0": {
+          "name": "ctd_episode_count_gte_0",
+          "value": "\"canonical_topic_digests\".\"episode_count_at_generation\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.canonical_topics": {
+      "name": "canonical_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_label": {
+          "name": "normalized_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "canonical_topic_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "canonical_topic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ongoing": {
+          "name": "ongoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "identity_embedding": {
+          "name": "identity_embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_embedding": {
+          "name": "context_embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_version": {
+          "name": "embedding_model_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'perplexity/pplx-embed-v1-0.6b'"
+        },
+        "merged_into_id": {
+          "name": "merged_into_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ct_identity_embedding_hnsw_idx": {
+          "name": "ct_identity_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "identity_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        },
+        "ct_context_embedding_hnsw_idx": {
+          "name": "ct_context_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "context_embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        },
+        "ct_normalized_label_kind_active_uidx": {
+          "name": "ct_normalized_label_kind_active_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"normalized_label\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"canonical_topics\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ct_merged_into_id_idx": {
+          "name": "ct_merged_into_id_idx",
+          "columns": [
+            {
+              "expression": "merged_into_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canonical_topics_merged_into_id_canonical_topics_id_fk": {
+          "name": "canonical_topics_merged_into_id_canonical_topics_id_fk",
+          "tableFrom": "canonical_topics",
+          "tableTo": "canonical_topics",
+          "columnsFrom": [
+            "merged_into_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ct_merged_biconditional": {
+          "name": "ct_merged_biconditional",
+          "value": "(\"canonical_topics\".\"status\" = 'merged' AND \"canonical_topics\".\"merged_into_id\" IS NOT NULL) OR (\"canonical_topics\".\"status\" <> 'merged' AND \"canonical_topics\".\"merged_into_id\" IS NULL)"
+        },
+        "ct_no_self_merge": {
+          "name": "ct_no_self_merge",
+          "value": "\"canonical_topics\".\"merged_into_id\" IS NULL OR \"canonical_topics\".\"merged_into_id\" <> \"canonical_topics\".\"id\""
+        },
+        "ct_relevance_range": {
+          "name": "ct_relevance_range",
+          "value": "\"canonical_topics\".\"relevance\" >= 0 AND \"canonical_topics\".\"relevance\" <= 1"
+        },
+        "ct_episode_count_gte_0": {
+          "name": "ct_episode_count_gte_0",
+          "value": "\"canonical_topics\".\"episode_count\" >= 0"
+        },
+        "ct_label_not_blank": {
+          "name": "ct_label_not_blank",
+          "value": "length(btrim(\"canonical_topics\".\"label\")) > 0"
+        },
+        "ct_normalized_label_not_blank": {
+          "name": "ct_normalized_label_not_blank",
+          "value": "length(btrim(\"canonical_topics\".\"normalized_label\")) > 0"
+        },
+        "ct_summary_not_blank": {
+          "name": "ct_summary_not_blank",
+          "value": "length(btrim(\"canonical_topics\".\"summary\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_id_idx": {
+          "name": "collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episode_canonical_topics": {
+      "name": "episode_canonical_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_topic_id": {
+          "name": "canonical_topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_to_top_match": {
+          "name": "similarity_to_top_match",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_score": {
+          "name": "coverage_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ect_episode_canonical_uidx": {
+          "name": "ect_episode_canonical_uidx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ect_canonical_id_idx": {
+          "name": "ect_canonical_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episode_canonical_topics_episode_id_episodes_id_fk": {
+          "name": "episode_canonical_topics_episode_id_episodes_id_fk",
+          "tableFrom": "episode_canonical_topics",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "episode_canonical_topics_canonical_topic_id_canonical_topics_id_fk": {
+          "name": "episode_canonical_topics_canonical_topic_id_canonical_topics_id_fk",
+          "tableFrom": "episode_canonical_topics",
+          "tableTo": "canonical_topics",
+          "columnsFrom": [
+            "canonical_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ect_match_method_enum": {
+          "name": "ect_match_method_enum",
+          "value": "\"episode_canonical_topics\".\"match_method\" IN ('auto', 'llm_disambig', 'new')"
+        },
+        "ect_coverage_score_range": {
+          "name": "ect_coverage_score_range",
+          "value": "\"episode_canonical_topics\".\"coverage_score\" >= 0 AND \"episode_canonical_topics\".\"coverage_score\" <= 1"
+        },
+        "ect_similarity_range": {
+          "name": "ect_similarity_range",
+          "value": "\"episode_canonical_topics\".\"similarity_to_top_match\" IS NULL OR (\"episode_canonical_topics\".\"similarity_to_top_match\" >= 0 AND \"episode_canonical_topics\".\"similarity_to_top_match\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.episode_topics": {
+      "name": "episode_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_rank": {
+          "name": "topic_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranked_at": {
+          "name": "ranked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episode_topics_episode_topic_idx": {
+          "name": "episode_topics_episode_topic_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_idx": {
+          "name": "episode_topics_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episode_topics_topic_rank_idx": {
+          "name": "episode_topics_topic_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episode_topics_episode_id_episodes_id_fk": {
+          "name": "episode_topics_episode_id_episodes_id_fk",
+          "tableFrom": "episode_topics",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relevance_range": {
+          "name": "relevance_range",
+          "value": "\"episode_topics\".\"relevance\" >= 0 AND \"episode_topics\".\"relevance\" <= 1"
+        },
+        "topic_not_blank": {
+          "name": "topic_not_blank",
+          "value": "length(btrim(\"episode_topics\".\"topic\")) > 0"
+        },
+        "topic_rank_positive": {
+          "name": "topic_rank_positive",
+          "value": "\"episode_topics\".\"topic_rank\" IS NULL OR \"episode_topics\".\"topic_rank\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription": {
+          "name": "transcription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_takeaways": {
+          "name": "key_takeaways",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_score": {
+          "name": "worth_it_score",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_reason": {
+          "name": "worth_it_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worth_it_dimensions": {
+          "name": "worth_it_dimensions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_run_id": {
+          "name": "summary_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_run_id": {
+          "name": "transcript_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_status": {
+          "name": "summary_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_source": {
+          "name": "transcript_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_status": {
+          "name": "transcript_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_fetched_at": {
+          "name": "transcript_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_error": {
+          "name": "transcript_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_guid": {
+          "name": "rss_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episodes_podcast_index_id_idx": {
+          "name": "episodes_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_podcast_id_idx": {
+          "name": "episodes_podcast_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_rss_guid_idx": {
+          "name": "episodes_rss_guid_idx",
+          "columns": [
+            {
+              "expression": "rss_guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_podcast_id_podcasts_id_fk": {
+          "name": "episodes_podcast_id_podcasts_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "episodes_podcast_index_id_unique": {
+          "name": "episodes_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "worth_it_score_range": {
+          "name": "worth_it_score_range",
+          "value": "\"episodes\".\"worth_it_score\" >= 0 AND \"episodes\".\"worth_it_score\" <= 10"
+        },
+        "summary_status_enum": {
+          "name": "summary_status_enum",
+          "value": "\"episodes\".\"summary_status\" IN ('queued', 'running', 'summarizing', 'completed', 'failed')"
+        },
+        "transcript_source_enum": {
+          "name": "transcript_source_enum",
+          "value": "\"episodes\".\"transcript_source\" IN ('podcastindex', 'assemblyai', 'description-url')"
+        },
+        "transcript_status_enum": {
+          "name": "transcript_status_enum",
+          "value": "\"episodes\".\"transcript_status\" IN ('missing', 'fetching', 'available', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listen_history": {
+      "name": "listen_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_index_episode_id": {
+          "name": "podcast_index_episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listen_duration_seconds": {
+          "name": "listen_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listen_history_user_episode_idx": {
+          "name": "listen_history_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_user_id_idx": {
+          "name": "listen_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listen_history_podcast_index_episode_id_idx": {
+          "name": "listen_history_podcast_index_episode_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listen_history_user_id_users_id_fk": {
+          "name": "listen_history_user_id_users_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listen_history_episode_id_episodes_id_fk": {
+          "name": "listen_history_episode_id_episodes_id_fk",
+          "tableFrom": "listen_history",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_dismissed": {
+          "name": "is_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_episode_unique_idx": {
+          "name": "notifications_user_episode_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "episode_id IS NOT NULL AND type = 'new_episode'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_episode_id_episodes_id_fk": {
+          "name": "notifications_episode_id_episodes_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_type_enum": {
+          "name": "notification_type_enum",
+          "value": "\"notifications\".\"type\" IN ('new_episode', 'summary_completed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.podcasts": {
+      "name": "podcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "podcast_index_id": {
+          "name": "podcast_index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rss_feed_url": {
+          "name": "rss_feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_episode_date": {
+          "name": "latest_episode_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'podcastindex'"
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "podcasts_podcast_index_id_idx": {
+          "name": "podcasts_podcast_index_id_idx",
+          "columns": [
+            {
+              "expression": "podcast_index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "podcasts_podcast_index_id_unique": {
+          "name": "podcasts_podcast_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "podcast_index_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "source_enum": {
+          "name": "source_enum",
+          "value": "\"podcasts\".\"source\" IN ('podcastindex', 'rss')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expire": {
+          "name": "expire",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trending_topics": {
+      "name": "trending_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trending_topics_generated_at_idx": {
+          "name": "trending_topics_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library": {
+      "name": "user_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_library_user_episode_idx": {
+          "name": "user_library_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_user_id_idx": {
+          "name": "user_library_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_episode_id_idx": {
+          "name": "user_library_episode_id_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_library_collection_id_idx": {
+          "name": "user_library_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_user_id_users_id_fk": {
+          "name": "user_library_user_id_users_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_episode_id_episodes_id_fk": {
+          "name": "user_library_episode_id_episodes_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_collection_id_collections_id_fk": {
+          "name": "user_library_collection_id_collections_id_fk",
+          "tableFrom": "user_library",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_player_session": {
+      "name": "user_player_session",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_title": {
+          "name": "podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters_url": {
+          "name": "chapters_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_time": {
+          "name": "current_time",
+          "type": "numeric(12, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_player_session_user_id_users_id_fk": {
+          "name": "user_player_session_user_id_users_id_fk",
+          "tableFrom": "user_player_session",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_queue_items": {
+      "name": "user_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_title": {
+          "name": "podcast_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artwork": {
+          "name": "artwork",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters_url": {
+          "name": "chapters_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_queue_items_user_episode_idx": {
+          "name": "user_queue_items_user_episode_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_queue_items_user_position_idx": {
+          "name": "user_queue_items_user_position_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_queue_items_user_id_users_id_fk": {
+          "name": "user_queue_items_user_id_users_id_fk",
+          "tableFrom": "user_queue_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_podcast_idx": {
+          "name": "user_subscriptions_user_podcast_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_id_idx": {
+          "name": "user_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_pinned_idx": {
+          "name": "user_subscriptions_pinned_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_subscriptions\".\"is_pinned\" = true",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_podcast_id_podcasts_id_fk": {
+          "name": "user_subscriptions_podcast_id_podcasts_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.canonical_topic_kind": {
+      "name": "canonical_topic_kind",
+      "schema": "public",
+      "values": [
+        "release",
+        "incident",
+        "regulation",
+        "announcement",
+        "deal",
+        "event",
+        "concept",
+        "work",
+        "other"
+      ]
+    },
+    "public.canonical_topic_status": {
+      "name": "canonical_topic_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "merged",
+        "dormant"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777362176522,
       "tag": "0025_loose_matthew_murdock",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777381388709,
+      "tag": "0026_breezy_gabe_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/__tests__/canonical-topic-digests.schema.test.ts
+++ b/src/db/__tests__/canonical-topic-digests.schema.test.ts
@@ -8,6 +8,7 @@ import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { canonicalTopics, canonicalTopicDigests } from "@/db/schema";
 import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
+import { expectInsertRejects } from "./schema-test-helpers";
 
 // Stable fixture embedding — content irrelevant for constraint tests.
 const EMBEDDING = Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
@@ -21,35 +22,6 @@ const validDigest = {
   episodeCountAtGeneration: 3,
   modelUsed: "claude-sonnet-4-6",
 };
-
-// Helper: look for a Postgres SQLSTATE code on the thrown error.
-// The Neon HTTP driver wraps the NeonDbError in `err.cause` rather than
-// surfacing it directly on the thrown object.
-function pgCode(err: unknown): string | undefined {
-  const e = err as { code?: string; cause?: { code?: string } };
-  return e?.cause?.code ?? e?.code;
-}
-
-// Helper: pull the violated constraint name out of a Postgres error so
-// individual constraint tests can pin to the specific check, not just the
-// SQLSTATE class.
-function pgConstraint(err: unknown): string | undefined {
-  const e = err as { constraint?: string; cause?: { constraint?: string } };
-  return e?.cause?.constraint ?? e?.constraint;
-}
-
-// Wrap an insert/update promise and assert it rejects with the given SQLSTATE
-// (and optional constraint name). Centralises the awkward `.catch((e) => e)`
-// pattern so each constraint test reads as a single expectation.
-async function expectInsertRejects(
-  insertPromise: Promise<unknown>,
-  sqlstate: "23514" | "23505",
-  constraint?: string,
-) {
-  const err = await insertPromise.catch((e: unknown) => e);
-  expect(pgCode(err)).toBe(sqlstate);
-  if (constraint) expect(pgConstraint(err)).toBe(constraint);
-}
 
 let fixtureTopicId: number;
 
@@ -77,9 +49,8 @@ describe.skipIf(!process.env.DATABASE_URL)(
     });
 
     afterAll(async () => {
-      await db.execute(
-        sql`DELETE FROM canonical_topic_digests WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, '__schema_test_'))`,
-      );
+      // Deleting the parent canonical_topics row cascades digest cleanup
+      // via the FK ON DELETE CASCADE.
       await db.execute(
         sql`DELETE FROM canonical_topics WHERE starts_with(label, '__schema_test_')`,
       );
@@ -91,17 +62,39 @@ describe.skipIf(!process.env.DATABASE_URL)(
       );
     });
 
-    // 1. Happy path — guard against silent column-drop / default drift.
-    it("inserts a fully-valid digest row with expected defaults", async () => {
+    // Round-trips every column to guard against silent column-drop, jsonb
+    // shape drift (e.g. an accidental double-stringify), or default drift.
+    it("inserts a fully-valid digest row and round-trips every column", async () => {
       const [row] = await db
         .insert(canonicalTopicDigests)
         .values({ ...validDigest, canonicalTopicId: fixtureTopicId })
         .returning();
       expect(row.id).toBeTypeOf("number");
-      expect(row.generatedAt).toBeTruthy();
+      expect(row.canonicalTopicId).toBe(fixtureTopicId);
+      expect(row.digestMarkdown).toBe(validDigest.digestMarkdown);
+      expect(row.consensusPoints).toEqual(validDigest.consensusPoints);
+      expect(row.disagreementPoints).toEqual(validDigest.disagreementPoints);
+      expect(row.episodeIds).toEqual(validDigest.episodeIds);
+      expect(row.episodeCountAtGeneration).toBe(
+        validDigest.episodeCountAtGeneration,
+      );
+      expect(row.modelUsed).toBe(validDigest.modelUsed);
+      expect(row.generatedAt).toBeInstanceOf(Date);
     });
 
-    // 2. UNIQUE constraint — one digest per canonical topic.
+    it("accepts episode_count_at_generation = 0 (inclusive lower bound)", async () => {
+      const [row] = await db
+        .insert(canonicalTopicDigests)
+        .values({
+          ...validDigest,
+          canonicalTopicId: fixtureTopicId,
+          episodeCountAtGeneration: 0,
+          episodeIds: [],
+        })
+        .returning();
+      expect(row.episodeCountAtGeneration).toBe(0);
+    });
+
     it("rejects a second digest for the same canonical_topic_id (ctd_canonical_topic_uidx)", async () => {
       await db
         .insert(canonicalTopicDigests)
@@ -116,7 +109,6 @@ describe.skipIf(!process.env.DATABASE_URL)(
       );
     });
 
-    // 3. CHECK constraint — episode_count_at_generation must be >= 0.
     it("rejects episode_count_at_generation = -1 (ctd_episode_count_gte_0)", async () => {
       await expectInsertRejects(
         db.insert(canonicalTopicDigests).values({
@@ -127,6 +119,34 @@ describe.skipIf(!process.env.DATABASE_URL)(
         "23514",
         "ctd_episode_count_gte_0",
       );
+    });
+
+    it("cascades digest deletion when the parent canonical_topic is deleted", async () => {
+      const [tmp] = await db
+        .insert(canonicalTopics)
+        .values({
+          label: "__schema_test_cascade",
+          normalizedLabel: "__schema_test_cascade",
+          kind: "concept",
+          status: "active",
+          summary: "__schema_test_summary",
+          ongoing: false,
+          relevance: 0.5,
+          episodeCount: 1,
+          identityEmbedding: EMBEDDING,
+          contextEmbedding: EMBEDDING,
+        })
+        .returning({ id: canonicalTopics.id });
+      await db
+        .insert(canonicalTopicDigests)
+        .values({ ...validDigest, canonicalTopicId: tmp.id });
+
+      await db.execute(sql`DELETE FROM canonical_topics WHERE id = ${tmp.id}`);
+
+      const remaining = await db.execute<{ count: number }>(
+        sql`SELECT COUNT(*)::int AS count FROM canonical_topic_digests WHERE canonical_topic_id = ${tmp.id}`,
+      );
+      expect(remaining.rows[0].count).toBe(0);
     });
   },
 );

--- a/src/db/__tests__/canonical-topic-digests.schema.test.ts
+++ b/src/db/__tests__/canonical-topic-digests.schema.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+// Integration smoke tests for canonical-topic-digests schema constraints.
+// Requires a live DATABASE_URL — skipped in CI (no DATABASE_URL set).
+// Run locally: doppler run -- bun run test src/db/__tests__/canonical-topic-digests.schema.test.ts
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+import { canonicalTopics, canonicalTopicDigests } from "@/db/schema";
+import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
+
+// Stable fixture embedding — content irrelevant for constraint tests.
+const EMBEDDING = Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
+
+// Base row that satisfies every constraint (happy path).
+const validDigest = {
+  digestMarkdown: "__schema_test_digest_markdown",
+  consensusPoints: ["point one", "point two"],
+  disagreementPoints: ["disagree one"],
+  episodeIds: [1, 2, 3],
+  episodeCountAtGeneration: 3,
+  modelUsed: "claude-sonnet-4-6",
+};
+
+// Helper: look for a Postgres SQLSTATE code on the thrown error.
+// The Neon HTTP driver wraps the NeonDbError in `err.cause` rather than
+// surfacing it directly on the thrown object.
+function pgCode(err: unknown): string | undefined {
+  const e = err as { code?: string; cause?: { code?: string } };
+  return e?.cause?.code ?? e?.code;
+}
+
+// Helper: pull the violated constraint name out of a Postgres error so
+// individual constraint tests can pin to the specific check, not just the
+// SQLSTATE class.
+function pgConstraint(err: unknown): string | undefined {
+  const e = err as { constraint?: string; cause?: { constraint?: string } };
+  return e?.cause?.constraint ?? e?.constraint;
+}
+
+// Wrap an insert/update promise and assert it rejects with the given SQLSTATE
+// (and optional constraint name). Centralises the awkward `.catch((e) => e)`
+// pattern so each constraint test reads as a single expectation.
+async function expectInsertRejects(
+  insertPromise: Promise<unknown>,
+  sqlstate: "23514" | "23505",
+  constraint?: string,
+) {
+  const err = await insertPromise.catch((e: unknown) => e);
+  expect(pgCode(err)).toBe(sqlstate);
+  if (constraint) expect(pgConstraint(err)).toBe(constraint);
+}
+
+let fixtureTopicId: number;
+
+describe.skipIf(!process.env.DATABASE_URL)(
+  "canonical-topic-digests schema constraints",
+  () => {
+    beforeAll(async () => {
+      // Insert a stable canonical_topic fixture to FK against.
+      const [topic] = await db
+        .insert(canonicalTopics)
+        .values({
+          label: "__schema_test_digest_fixture",
+          normalizedLabel: "__schema_test_digest_fixture",
+          kind: "concept",
+          status: "active",
+          summary: "__schema_test_summary",
+          ongoing: false,
+          relevance: 0.5,
+          episodeCount: 3,
+          identityEmbedding: EMBEDDING,
+          contextEmbedding: EMBEDDING,
+        })
+        .returning({ id: canonicalTopics.id });
+      fixtureTopicId = topic.id;
+    });
+
+    afterAll(async () => {
+      await db.execute(
+        sql`DELETE FROM canonical_topic_digests WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, '__schema_test_'))`,
+      );
+      await db.execute(
+        sql`DELETE FROM canonical_topics WHERE starts_with(label, '__schema_test_')`,
+      );
+    });
+
+    afterEach(async () => {
+      await db.execute(
+        sql`DELETE FROM canonical_topic_digests WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, '__schema_test_'))`,
+      );
+    });
+
+    // 1. Happy path — guard against silent column-drop / default drift.
+    it("inserts a fully-valid digest row with expected defaults", async () => {
+      const [row] = await db
+        .insert(canonicalTopicDigests)
+        .values({ ...validDigest, canonicalTopicId: fixtureTopicId })
+        .returning();
+      expect(row.id).toBeTypeOf("number");
+      expect(row.generatedAt).toBeTruthy();
+    });
+
+    // 2. UNIQUE constraint — one digest per canonical topic.
+    it("rejects a second digest for the same canonical_topic_id (ctd_canonical_topic_uidx)", async () => {
+      await db
+        .insert(canonicalTopicDigests)
+        .values({ ...validDigest, canonicalTopicId: fixtureTopicId });
+
+      await expectInsertRejects(
+        db
+          .insert(canonicalTopicDigests)
+          .values({ ...validDigest, canonicalTopicId: fixtureTopicId }),
+        "23505",
+        "ctd_canonical_topic_uidx",
+      );
+    });
+
+    // 3. CHECK constraint — episode_count_at_generation must be >= 0.
+    it("rejects episode_count_at_generation = -1 (ctd_episode_count_gte_0)", async () => {
+      await expectInsertRejects(
+        db.insert(canonicalTopicDigests).values({
+          ...validDigest,
+          canonicalTopicId: fixtureTopicId,
+          episodeCountAtGeneration: -1,
+        }),
+        "23514",
+        "ctd_episode_count_gte_0",
+      );
+    });
+  },
+);

--- a/src/db/__tests__/canonical-topic-digests.schema.test.ts
+++ b/src/db/__tests__/canonical-topic-digests.schema.test.ts
@@ -8,7 +8,7 @@ import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { canonicalTopics, canonicalTopicDigests } from "@/db/schema";
 import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
-import { expectInsertRejects } from "./schema-test-helpers";
+import { expectInsertRejects } from "@/db/__tests__/schema-test-helpers";
 
 // Stable fixture embedding — content irrelevant for constraint tests.
 const EMBEDDING = Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
@@ -52,13 +52,13 @@ describe.skipIf(!process.env.DATABASE_URL)(
       // Deleting the parent canonical_topics row cascades digest cleanup
       // via the FK ON DELETE CASCADE.
       await db.execute(
-        sql`DELETE FROM canonical_topics WHERE starts_with(label, '__schema_test_')`,
+        sql`DELETE FROM canonical_topics WHERE starts_with(label, '__schema_test_digest_')`,
       );
     });
 
     afterEach(async () => {
       await db.execute(
-        sql`DELETE FROM canonical_topic_digests WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, '__schema_test_'))`,
+        sql`DELETE FROM canonical_topic_digests WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, '__schema_test_digest_'))`,
       );
     });
 
@@ -125,8 +125,8 @@ describe.skipIf(!process.env.DATABASE_URL)(
       const [tmp] = await db
         .insert(canonicalTopics)
         .values({
-          label: "__schema_test_cascade",
-          normalizedLabel: "__schema_test_cascade",
+          label: "__schema_test_digest_cascade",
+          normalizedLabel: "__schema_test_digest_cascade",
           kind: "concept",
           status: "active",
           summary: "__schema_test_summary",

--- a/src/db/__tests__/canonical-topics.schema.test.ts
+++ b/src/db/__tests__/canonical-topics.schema.test.ts
@@ -15,7 +15,7 @@ import {
   EMBEDDING_DIMENSION as EMBEDDING_DIM,
   EMBEDDING_MODEL,
 } from "@/lib/ai/embed-constants";
-import { expectInsertRejects } from "./schema-test-helpers";
+import { expectInsertRejects } from "@/db/__tests__/schema-test-helpers";
 
 // Stable 1024-dim fixture — content irrelevant for constraint tests.
 const EMBEDDING = Array.from({ length: EMBEDDING_DIM }, () => 0.001);

--- a/src/db/__tests__/canonical-topics.schema.test.ts
+++ b/src/db/__tests__/canonical-topics.schema.test.ts
@@ -15,6 +15,7 @@ import {
   EMBEDDING_DIMENSION as EMBEDDING_DIM,
   EMBEDDING_MODEL,
 } from "@/lib/ai/embed-constants";
+import { expectInsertRejects } from "./schema-test-helpers";
 
 // Stable 1024-dim fixture — content irrelevant for constraint tests.
 const EMBEDDING = Array.from({ length: EMBEDDING_DIM }, () => 0.001);
@@ -33,35 +34,6 @@ const validTopic = {
   contextEmbedding: EMBEDDING,
   embeddingModelVersion: EMBEDDING_MODEL,
 };
-
-// Helper: look for a Postgres SQLSTATE code on the thrown error.
-// The Neon HTTP driver wraps the NeonDbError in `err.cause` rather than
-// surfacing it directly on the thrown object.
-function pgCode(err: unknown): string | undefined {
-  const e = err as { code?: string; cause?: { code?: string } };
-  return e?.cause?.code ?? e?.code;
-}
-
-// Helper: pull the violated constraint name out of a Postgres error so
-// individual constraint tests can pin to the specific check, not just the
-// SQLSTATE class.
-function pgConstraint(err: unknown): string | undefined {
-  const e = err as { constraint?: string; cause?: { constraint?: string } };
-  return e?.cause?.constraint ?? e?.constraint;
-}
-
-// Wrap an insert/update promise and assert it rejects with the given SQLSTATE
-// (and optional constraint name). Centralises the awkward `.catch((e) => e)`
-// pattern so each constraint test reads as a single expectation.
-async function expectInsertRejects(
-  insertPromise: Promise<unknown>,
-  sqlstate: "23514" | "23505",
-  constraint?: string,
-) {
-  const err = await insertPromise.catch((e: unknown) => e);
-  expect(pgCode(err)).toBe(sqlstate);
-  if (constraint) expect(pgConstraint(err)).toBe(constraint);
-}
 
 // Helper: insert a minimal valid episode fixture for junction tests.
 // Returns the episode id from the first episode that exists in the DB.

--- a/src/db/__tests__/schema-test-helpers.ts
+++ b/src/db/__tests__/schema-test-helpers.ts
@@ -1,0 +1,25 @@
+// Shared helpers for schema integration smoke tests.
+// Centralises Postgres error parsing for the Neon HTTP driver, which wraps
+// the NeonDbError in `err.cause` rather than surfacing it directly.
+
+import { expect } from "vitest";
+
+export function pgCode(err: unknown): string | undefined {
+  const e = err as { code?: string; cause?: { code?: string } };
+  return e?.cause?.code ?? e?.code;
+}
+
+export function pgConstraint(err: unknown): string | undefined {
+  const e = err as { constraint?: string; cause?: { constraint?: string } };
+  return e?.cause?.constraint ?? e?.constraint;
+}
+
+export async function expectInsertRejects(
+  insertPromise: Promise<unknown>,
+  sqlstate: "23514" | "23505",
+  constraint?: string,
+) {
+  const err = await insertPromise.catch((e: unknown) => e);
+  expect(pgCode(err)).toBe(sqlstate);
+  if (constraint) expect(pgConstraint(err)).toBe(constraint);
+}

--- a/src/db/__tests__/schema-test-helpers.ts
+++ b/src/db/__tests__/schema-test-helpers.ts
@@ -20,6 +20,7 @@ export async function expectInsertRejects(
   constraint?: string,
 ) {
   const err = await insertPromise.catch((e: unknown) => e);
+  expect(err).toBeDefined();
   expect(pgCode(err)).toBe(sqlstate);
   if (constraint) expect(pgConstraint(err)).toBe(constraint);
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -769,10 +769,11 @@ export const canonicalTopicsRelations = relations(
     mergedFrom: many(canonicalTopics, { relationName: "merged_topics" }),
     aliases: many(canonicalTopicAliases),
     episodes: many(episodeCanonicalTopics),
-    digest: one(canonicalTopicDigests, {
-      fields: [canonicalTopics.id],
-      references: [canonicalTopicDigests.canonicalTopicId],
-    }),
+    // FK lives on canonical_topic_digests.canonical_topic_id; the inverse side
+    // declares fields/references in canonicalTopicDigestsRelations below. Wiring
+    // them here too would make Drizzle infer a non-nullable `digest` even though
+    // a canonical may have no cached digest yet.
+    digest: one(canonicalTopicDigests),
   }),
 );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,6 +7,7 @@ import {
   integer,
   serial,
   json,
+  jsonb,
   decimal,
   real,
   index,
@@ -593,6 +594,33 @@ export const episodeCanonicalTopics = pgTable(
   ],
 );
 
+// Cache table: per-canonical-topic synthesis digest (staleness gate: ADR-042 §"Digest staleness")
+export const canonicalTopicDigests = pgTable(
+  "canonical_topic_digests",
+  {
+    id: serial("id").primaryKey(),
+    canonicalTopicId: integer("canonical_topic_id")
+      .references(() => canonicalTopics.id, { onDelete: "cascade" })
+      .notNull(),
+    digestMarkdown: text("digest_markdown").notNull(),
+    consensusPoints: jsonb("consensus_points").$type<string[]>().notNull(),
+    disagreementPoints: jsonb("disagreement_points")
+      .$type<string[]>()
+      .notNull(),
+    episodeIds: integer("episode_ids").array().notNull(),
+    episodeCountAtGeneration: integer("episode_count_at_generation").notNull(),
+    modelUsed: text("model_used").notNull(),
+    generatedAt: timestamp("generated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("ctd_canonical_topic_uidx").on(table.canonicalTopicId),
+    check(
+      "ctd_episode_count_gte_0",
+      sql`${table.episodeCountAtGeneration} >= 0`,
+    ),
+  ],
+);
+
 // Relations
 export const usersRelations = relations(users, ({ many, one }) => ({
   subscriptions: many(userSubscriptions),
@@ -741,6 +769,10 @@ export const canonicalTopicsRelations = relations(
     mergedFrom: many(canonicalTopics, { relationName: "merged_topics" }),
     aliases: many(canonicalTopicAliases),
     episodes: many(episodeCanonicalTopics),
+    digest: one(canonicalTopicDigests, {
+      fields: [canonicalTopics.id],
+      references: [canonicalTopicDigests.canonicalTopicId],
+    }),
   }),
 );
 
@@ -763,6 +795,16 @@ export const episodeCanonicalTopicsRelations = relations(
     }),
     canonicalTopic: one(canonicalTopics, {
       fields: [episodeCanonicalTopics.canonicalTopicId],
+      references: [canonicalTopics.id],
+    }),
+  }),
+);
+
+export const canonicalTopicDigestsRelations = relations(
+  canonicalTopicDigests,
+  ({ one }) => ({
+    canonicalTopic: one(canonicalTopics, {
+      fields: [canonicalTopicDigests.canonicalTopicId],
       references: [canonicalTopics.id],
     }),
   }),
@@ -913,3 +955,6 @@ export type NewCanonicalTopicAlias = typeof canonicalTopicAliases.$inferInsert;
 export type EpisodeCanonicalTopic = typeof episodeCanonicalTopics.$inferSelect;
 export type NewEpisodeCanonicalTopic =
   typeof episodeCanonicalTopics.$inferInsert;
+
+export type CanonicalTopicDigest = typeof canonicalTopicDigests.$inferSelect;
+export type NewCanonicalTopicDigest = typeof canonicalTopicDigests.$inferInsert;


### PR DESCRIPTION
## Summary

Adds the `canonical_topic_digests` cache table that stores per-canonical-topic synthesis digests produced by the upcoming D1 generator. Snapshots `episode_count_at_generation` so the staleness gate from spec OQ4 (regenerate when derived `linked_episode_count` grows by N=3) reduces to a pure scalar comparison.

Schema-only PR. No reads/writes change in the running app — D1 generator and Feature 2 `/topic/[id]` page consume this in later issues.

- 9 columns matching issue spec exactly
- FK `canonical_topic_id → canonical_topics.id` with `ON DELETE CASCADE`
- UNIQUE on `canonical_topic_id` (`ctd_canonical_topic_uidx`) — one digest per canonical, UPSERT semantics
- CHECK `ctd_episode_count_gte_0` (`episode_count_at_generation >= 0`)
- `jsonb` columns typed as `string[]` via `.$type<string[]>()`
- Schema smoke tests cover happy-path round-trip + UNIQUE rejection (23505) + CHECK rejection (23514) + inclusive lower-bound (= 0) + FK CASCADE on parent delete
- `pgCode` / `pgConstraint` / `expectInsertRejects` extracted to a shared `schema-test-helpers.ts` for both this and `canonical-topics.schema.test.ts` (review-checklist §5)
- Mirrors ADR-042 / PR #407 (`canonical_topics`) conventions; no new ADR (extends existing)

## Test plan

- [x] `bun run lint` exits 0
- [x] `bun run test` — 2500 pass, 31 skipped (smoke tests skip cleanly without `DATABASE_URL`)
- [x] `bun run build` exits 0
- [x] Live DB: 5 digest schema cases pass + 26 canonical-topics cases still pass after helper extraction
- [x] QA verified: insert / duplicate / CASCADE / CHECK behaviors all match expected SQLSTATE codes
- [x] `CHANGELOG.md [Unreleased] → Added` names the new table

## Production schema migration follow-up

⚠️ **Production schema does NOT auto-migrate.** After merging, a maintainer must manually apply the migration to production:

```bash
doppler run --config prd -- bunx drizzle-kit push
```

Preview branches auto-run `drizzle-kit push --force` via `vercel-build`, so previews are fine. The empty new table is read by no production code yet, so risk is bounded — but the rule still applies.

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to store synthesis digests for topics, including consensus points, disagreement points, and associated episode metadata.

* **Chores**
  * Added comprehensive schema validation tests to ensure data integrity.
  * Updated documentation to reflect new database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->