### PR TITLE
fix: wire ws polyfill for Neon Pool in Trigger.dev runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "web-push": "^3.6.7",
+        "ws": "^8.20.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -68,6 +69,7 @@
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.0",
         "@types/web-push": "^3.6.4",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.1.3",
         "@vitest/coverage-v8": "^4.0.18",
         "drizzle-kit": "^0.31.8",
@@ -829,6 +831,8 @@
     "@types/wait-on": ["@types/wait-on@5.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw=="],
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -2378,7 +2382,7 @@
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -2518,9 +2522,13 @@
 
     "@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": "dist/bin/uuid" }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "@trigger.dev/sdk/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "@types/wait-on/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "@types/web-push/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
+
+    "@types/ws/@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.58.2", "", {}, "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ=="],
 
@@ -2761,6 +2769,8 @@
     "socket.io-client/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "storybook/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "string-length/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "web-push": "^3.6.7",
+    "ws": "^8.20.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -90,6 +91,7 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "@types/web-push": "^3.6.4",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.1.3",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.31.8",

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,9 +1,17 @@
 import "server-only";
 
-import { Pool } from "@neondatabase/serverless";
+import { Pool, neonConfig } from "@neondatabase/serverless";
 import { drizzle, type NeonDatabase } from "drizzle-orm/neon-serverless";
+import ws from "ws";
 
 import * as schema from "@/db/schema";
+
+// Trigger.dev's worker runtime has no global `WebSocket`, so the Neon Pool
+// driver throws "All attempts to open a WebSocket … failed" on every
+// transaction. Wiring the `ws` polyfill here makes transactional() work in
+// any Node runtime; environments that already expose a global `WebSocket`
+// (Vercel Node 22+) ignore this override at connect time.
+neonConfig.webSocketConstructor = ws;
 
 /**
  * Pool-backed Drizzle client + `transactional()` helper.

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -8,10 +8,11 @@ import * as schema from "@/db/schema";
 
 // Trigger.dev's worker runtime has no global `WebSocket`, so the Neon Pool
 // driver throws "All attempts to open a WebSocket … failed" on every
-// transaction. Wiring the `ws` polyfill here makes transactional() work in
-// any Node runtime; environments that already expose a global `WebSocket`
-// (Vercel Node 22+) ignore this override at connect time.
-neonConfig.webSocketConstructor = ws;
+// transaction. Guard avoids overriding a native WebSocket in environments
+// that already have one (e.g., Vercel Node 22+).
+if (typeof globalThis.WebSocket === "undefined") {
+  neonConfig.webSocketConstructor = ws;
+}
 
 /**
  * Pool-backed Drizzle client + `transactional()` helper.


### PR DESCRIPTION
## Summary

- Resolves #413 — entity-resolution Pool fails to open WebSocket in Trigger.dev runtime, so `canonical_topics` / `episode_canonical_topics` stay empty on prod despite #412 + schema push.
- Wires `ws` via `neonConfig.webSocketConstructor` in `src/db/pool.ts` before any `new Pool(...)` call.
- Adds `ws` (runtime) and `@types/ws` (dev) deps. Harmless on Vercel Node 22+ (global `WebSocket` wins).

## Test plan

- [x] `bun run format:check && bun run lint && bun run test && bun run build` — all green locally.
- [ ] After deploy: re-summarize episode 53896 (`podcast_index_id=54002566796`).
- [ ] Trigger.dev dashboard log for that run shows no `WebSocket` error.
- [ ] `SELECT count(*) FROM canonical_topics` ≥ 1 globally.
- [ ] `SELECT count(*) FROM episode_canonical_topics WHERE episode_id = 53896` ≥ 1.
- [ ] Episode card on `https://www.contentgenie.ch/podcast/5662698` for the Microsoft/OpenAI episode renders clickable canonical-topic `<Link>` chips (snapshot finds them as Link, not StaticText).
- [ ] Existing HTTP-driver paths (`persistEpisodeSummary` etc.) keep working — verified by `summary_status='completed'` on the same re-summarized episode.

Closes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed database transaction failures in Node runtime environments (such as serverless worker platforms) where WebSocket is not globally available. Database operations now function reliably across different execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->