### PR TITLE
chore: allow dlc, project-manager, cdt, and council skill namespaces

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,11 @@
       "Bash(drizzle-kit:*)",
       "Bash(eslint:*)",
       "Bash(tsc:*)",
-      "Bash(vercel:*)"
+      "Bash(vercel:*)",
+      "Skill(dlc:*)",
+      "Skill(project-manager:*)",
+      "Skill(cdt:*)",
+      "Skill(council:*)"
     ],
     "deny": [
       "Bash(sudo:*)",


### PR DESCRIPTION
## Summary
- Add four `Skill(<plugin>:*)` glob entries to `permissions.allow` in `.claude/settings.json` for the `dlc`, `project-manager`, `cdt`, and `council` plugin namespaces.
- Reduces permission prompts when running routine planning, review, audit, and PR-monitoring skills already enabled in `enabledPlugins`. Destructive ops invoked by these skills remain gated by the existing Bash allowlist, the project `deny` rules, and the `pre-pr-validation` PreToolUse hook.

## Test plan
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
- [x] Verified JSON validity and that the four namespaces match `enabledPlugins`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authorization permissions configuration to include additional skill permission patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->