### PR TITLE
test: golden-dataset fixtures for entity resolution (#388)

### DIFF
--- a/src/lib/__tests__/entity-resolution.golden.test.ts
+++ b/src/lib/__tests__/entity-resolution.golden.test.ts
@@ -39,26 +39,40 @@ function allRecordedCalls(): RecordedCall[] {
   return txCallLog.flat();
 }
 
-vi.mock("@/db/pool", () => ({
-  transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-    const fixtures = txFixturesQueue.shift() ?? { rows: [] };
-    const recorded: RecordedCall[] = [];
-    txCallLog.push(recorded);
-    const tx = {
-      execute: async (sqlObj: unknown) => {
-        const { sqlText, params } = serializeSql(sqlObj);
-        recorded.push({ sql: sqlText, params });
-        const fixture = fixtures.rows.find((f) =>
-          typeof f.match === "string"
-            ? sqlText.includes(f.match)
-            : f.match.test(sqlText),
-        );
-        return { rows: fixture?.rows ?? [] };
-      },
-    };
-    return fn(tx);
-  }),
-}));
+// When the fixture queue is empty, fall through to the real `transactional`
+// so the real-DB sub-suite (concurrent-insert-race) hits Postgres normally.
+// Mocked sub-suites queue fixtures via `setTxFixtures` and the mock intercepts.
+vi.mock("@/db/pool", async () => {
+  const actual = await vi.importActual<typeof import("@/db/pool")>("@/db/pool");
+  return {
+    ...actual,
+    transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      if (txFixturesQueue.length === 0) {
+        return (
+          actual.transactional as unknown as (
+            cb: (tx: unknown) => Promise<unknown>,
+          ) => Promise<unknown>
+        )(fn);
+      }
+      const fixtures = txFixturesQueue.shift() ?? { rows: [] };
+      const recorded: RecordedCall[] = [];
+      txCallLog.push(recorded);
+      const tx = {
+        execute: async (sqlObj: unknown) => {
+          const { sqlText, params } = serializeSql(sqlObj);
+          recorded.push({ sql: sqlText, params });
+          const fixture = fixtures.rows.find((f) =>
+            typeof f.match === "string"
+              ? sqlText.includes(f.match)
+              : f.match.test(sqlText),
+          );
+          return { rows: fixture?.rows ?? [] };
+        },
+      };
+      return fn(tx);
+    }),
+  };
+});
 
 const generateCompletionMock = vi.fn();
 vi.mock("@/lib/ai/generate", () => ({
@@ -92,7 +106,6 @@ vi.mock("@/trigger/helpers/database", () => ({
 // vi.mock is hoisted — top-level imports see the mocks.
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
-import { canonicalTopics } from "@/db/schema";
 import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import {
   hasVersionTokenMismatch,
@@ -103,10 +116,16 @@ import {
 import {
   AUTO_MATCH_SIMILARITY_THRESHOLD,
   DISAMBIGUATE_SIMILARITY_THRESHOLD,
+  type MatchMethod,
 } from "@/lib/entity-resolution-constants";
 import { resolveAndPersistEpisodeTopics } from "@/trigger/helpers/resolve-topics";
 import { normalizeTopics } from "@/trigger/helpers/ai-summary";
 import type { TopicKind } from "@/lib/openrouter";
+
+// First runtime-allocated canonical id used by the mock harness.
+// Fixtures referencing newly-inserted canonicals (e.g. concept-clustering)
+// rely on this value to seed kNN candidates for subsequent inputs.
+const MOCK_NEW_CANONICAL_BASE_ID = 900;
 
 // ---- Serializer (verbatim from entity-resolution.test.ts) -------------------
 
@@ -185,10 +204,10 @@ type ResolverGoldenFixture = {
     canonicalCount?: number;
     canonicalCountAtMost?: number;
     aliasCountAtLeast?: number;
-    matchMethodDistribution?: Partial<Record<string, number>>;
+    matchMethodDistribution?: Partial<Record<MatchMethod, number>>;
     versionTokenForcedDisambig?: number;
     perInput?: Array<{
-      matchMethod?: string;
+      matchMethod?: MatchMethod;
       versionTokenForcedDisambig?: boolean;
     }>;
     junctionCountForSingleCanonical?: number;
@@ -269,7 +288,7 @@ async function runFixtureWithMockDb(
   const seedMap = new Map((fixture.seedCanonicals ?? []).map((s) => [s.id, s]));
 
   // Running counter for new canonical IDs inserted during this run.
-  let nextNewId = 900;
+  let nextNewId = MOCK_NEW_CANONICAL_BASE_ID;
 
   for (const entry of fixture.inputs) {
     const normalizedInputLabel = entry.label.trim().toLowerCase();
@@ -469,43 +488,62 @@ describe("entity-resolution golden dataset", () => {
         versionAdjacentReleasesFixture as unknown as ResolverGoldenFixture;
       const results = await runFixtureWithMockDb(fixture);
 
-      expect(results).toHaveLength(1);
-      expect(results[0].result.matchMethod).toBe(
-        fixture.expected.perInput?.[0]?.matchMethod,
+      // Anchor against literal expected behaviour, not just the fixture's own
+      // declarations — pinning at the assertion site stops a fixture edit from
+      // silently flipping the contract.
+      expect(fixture.expected.perInput?.[0]?.matchMethod).toBe("new");
+      expect(fixture.expected.perInput?.[0]?.versionTokenForcedDisambig).toBe(
+        true,
       );
-      expect(results[0].result.versionTokenForcedDisambig).toBe(
-        fixture.expected.perInput?.[0]?.versionTokenForcedDisambig,
-      );
+      expect(fixture.expected.canonicalCount).toBe(2);
+      expect(fixture.expected.versionTokenForcedDisambig).toBe(1);
 
-      // canonicalCount=2: seed + newly inserted canonical
-      expect(seenCanonicalIds.size).toBe(fixture.expected.canonicalCount);
+      expect(results).toHaveLength(fixture.inputs.length);
+      expect(results[0].result.matchMethod).toBe("new");
+      expect(results[0].result.versionTokenForcedDisambig).toBe(true);
+      expect(seenCanonicalIds.size).toBe(2);
 
-      // versionTokenForcedDisambig count across all inputs
       const forcedCount = results.filter(
         (r) => r.result.versionTokenForcedDisambig,
       ).length;
-      expect(forcedCount).toBe(fixture.expected.versionTokenForcedDisambig);
+      expect(forcedCount).toBe(1);
     });
 
     it("alias-clusters", async () => {
       const fixture = aliasClustersFixture as unknown as ResolverGoldenFixture;
       const results = await runFixtureWithMockDb(fixture);
 
-      expect(results).toHaveLength(4);
+      expect(results).toHaveLength(fixture.inputs.length);
 
-      // All 4 inputs resolve to the same canonical
       const uniqueCanonicals = new Set(
         results.map((r) => r.result.canonicalId),
       );
       expect(uniqueCanonicals.size).toBe(fixture.expected.canonicalCount);
 
-      // Alias SQL emissions: count actual INSERT INTO canonical_topic_aliases calls
+      // Counts production SQL emissions, not pre-registered fixture rows —
+      // verifies the resolver actually attempted ≥4 alias upserts.
       const aliasInsertCalls = allRecordedCalls().filter((c) =>
         c.sql.includes("INSERT INTO canonical_topic_aliases"),
       );
-      expect(aliasInsertCalls.length).toBeGreaterThanOrEqual(
-        fixture.expected.aliasCountAtLeast!,
-      );
+      const minAliases = fixture.expected.aliasCountAtLeast;
+      expect(minAliases, "aliasCountAtLeast must be set").toBeDefined();
+      expect(aliasInsertCalls.length).toBeGreaterThanOrEqual(minAliases ?? 0);
+
+      // Pin the match-method distribution that the fixture's _meta describes:
+      // 3 auto + 1 llm_disambig (input 3 forces version-token disambig).
+      const distribution: Partial<Record<MatchMethod, number>> = {};
+      for (const { result } of results) {
+        distribution[result.matchMethod] =
+          (distribution[result.matchMethod] ?? 0) + 1;
+      }
+      const expectedDistribution = fixture.expected.matchMethodDistribution;
+      expect(
+        expectedDistribution,
+        "matchMethodDistribution must be set",
+      ).toBeDefined();
+      for (const [method, count] of Object.entries(expectedDistribution!)) {
+        expect(distribution[method as MatchMethod] ?? 0).toBe(count);
+      }
     });
 
     it("concept-clustering", async () => {
@@ -513,30 +551,29 @@ describe("entity-resolution golden dataset", () => {
         conceptClusteringFixture as unknown as ResolverGoldenFixture;
       const results = await runFixtureWithMockDb(fixture);
 
-      expect(results).toHaveLength(3);
+      expect(results).toHaveLength(fixture.inputs.length);
 
+      // Pin the canonical-split count: a regression that collapses all 3
+      // creatine forms onto one canonical must fail loudly, not pass with
+      // `>= 1 && <= 2`.
       const uniqueCanonicals = new Set(
         results.map((r) => r.result.canonicalId),
       );
-      expect(uniqueCanonicals.size).toBeGreaterThanOrEqual(1);
-      if (fixture.expected.canonicalCountAtMost !== undefined) {
-        expect(uniqueCanonicals.size).toBeLessThanOrEqual(
-          fixture.expected.canonicalCountAtMost,
-        );
-      }
+      expect(fixture.expected.canonicalCount).toBe(2);
+      expect(uniqueCanonicals.size).toBe(2);
 
-      // Assert match method distribution
-      const distribution: Record<string, number> = {};
+      const distribution: Partial<Record<MatchMethod, number>> = {};
       for (const { result } of results) {
         distribution[result.matchMethod] =
           (distribution[result.matchMethod] ?? 0) + 1;
       }
-      if (fixture.expected.matchMethodDistribution) {
-        for (const [method, count] of Object.entries(
-          fixture.expected.matchMethodDistribution,
-        )) {
-          expect(distribution[method] ?? 0).toBe(count);
-        }
+      const expectedDistribution = fixture.expected.matchMethodDistribution;
+      expect(
+        expectedDistribution,
+        "matchMethodDistribution must be set",
+      ).toBeDefined();
+      for (const [method, count] of Object.entries(expectedDistribution!)) {
+        expect(distribution[method as MatchMethod] ?? 0).toBe(count);
       }
     });
 
@@ -580,12 +617,7 @@ describe("entity-resolution golden dataset", () => {
     });
 
     afterAll(async () => {
-      await db.execute(
-        sql`DELETE FROM canonical_topic_aliases WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}))`,
-      );
-      await db.execute(
-        sql`DELETE FROM episode_canonical_topics WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}))`,
-      );
+      // FK cascade from canonical_topics handles aliases and junctions.
       await db.execute(
         sql`DELETE FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX})`,
       );
@@ -594,10 +626,7 @@ describe("entity-resolution golden dataset", () => {
     it("concurrent-insert-race", async () => {
       const fixture =
         concurrentInsertRaceFixture as unknown as ResolverGoldenFixture;
-
-      const { generateCompletion } = await import("@/lib/ai/generate");
-      const mockedGen = vi.mocked(generateCompletion);
-      mockedGen.mockReset();
+      const inputKind = fixture.inputs[0].kind;
 
       const { resultA, resultB } = await runFixtureWithRealDb(
         fixture,
@@ -605,29 +634,31 @@ describe("entity-resolution golden dataset", () => {
         episodeIdB,
       );
 
-      // Both calls collapse to the same canonical
+      expect(fixture.expected.canonicalCount).toBe(1);
+      expect(fixture.expected.junctionCountForSingleCanonical).toBe(2);
+
       expect(resultA.canonicalId).toBe(resultB.canonicalId);
 
-      // Exactly 1 canonical in the DB for this label prefix
+      // Strict scope: a stray row of the same prefix but different kind
+      // would slip past a starts_with-only check.
       const canonicalRows = await db.execute<{ id: number }>(
-        sql`SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}) ORDER BY id LIMIT 10`,
+        sql`SELECT id FROM canonical_topics
+            WHERE starts_with(label, ${CONCURRENT_PREFIX})
+              AND kind = ${inputKind}`,
       );
-      expect(canonicalRows.rows.length).toBe(
-        fixture.expected.canonicalCount ?? 1,
-      );
+      expect(canonicalRows.rows.length).toBe(fixture.expected.canonicalCount);
 
-      // Exactly 2 junction rows pointing at the canonical
       const junctionRows = await db.execute<{ episode_id: number }>(
         sql`SELECT episode_id FROM episode_canonical_topics WHERE canonical_topic_id = ${resultA.canonicalId}`,
       );
       expect(junctionRows.rows.length).toBe(
-        fixture.expected.junctionCountForSingleCanonical ?? 2,
+        fixture.expected.junctionCountForSingleCanonical,
       );
       const epIds = junctionRows.rows.map((r) => r.episode_id).sort();
       expect(epIds).toEqual([episodeIdA, episodeIdB].sort());
 
-      // Disambiguator must NOT have been called (empty-slot fast path)
-      expect(mockedGen).not.toHaveBeenCalled();
+      // Empty-slot fast path: TX-1 exact-lookup catches both arrivals.
+      expect(generateCompletionMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/__tests__/entity-resolution.golden.test.ts
+++ b/src/lib/__tests__/entity-resolution.golden.test.ts
@@ -1,0 +1,633 @@
+// @vitest-environment node
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---- Mocks (must precede all production imports) ----------------------------
+
+// SQL-fixture-queue harness — mirrors entity-resolution.test.ts exactly.
+const txFixturesQueue: TxFixtures[] = [];
+const txCallLog: RecordedCall[][] = [];
+
+interface TxFixtures {
+  rows: SqlFixture[];
+}
+
+interface SqlFixture {
+  match: string | RegExp;
+  rows: unknown[];
+}
+
+interface RecordedCall {
+  sql: string;
+  params: unknown[];
+}
+
+function setTxFixtures(rows: SqlFixture[]): void {
+  txFixturesQueue.push({ rows });
+}
+
+function allRecordedCalls(): RecordedCall[] {
+  return txCallLog.flat();
+}
+
+vi.mock("@/db/pool", () => ({
+  transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+    const fixtures = txFixturesQueue.shift() ?? { rows: [] };
+    const recorded: RecordedCall[] = [];
+    txCallLog.push(recorded);
+    const tx = {
+      execute: async (sqlObj: unknown) => {
+        const { sqlText, params } = serializeSql(sqlObj);
+        recorded.push({ sql: sqlText, params });
+        const fixture = fixtures.rows.find((f) =>
+          typeof f.match === "string"
+            ? sqlText.includes(f.match)
+            : f.match.test(sqlText),
+        );
+        return { rows: fixture?.rows ?? [] };
+      },
+    };
+    return fn(tx);
+  }),
+}));
+
+const generateCompletionMock = vi.fn();
+vi.mock("@/lib/ai/generate", () => ({
+  generateCompletion: (...args: unknown[]) => generateCompletionMock(...args),
+}));
+
+// Required: resolve-topics.ts imports @trigger.dev/sdk at module load.
+vi.mock("@trigger.dev/sdk", () => ({
+  metadata: {
+    root: {
+      increment: vi.fn(),
+    },
+  },
+  logger: { info: vi.fn(), warn: vi.fn() },
+}));
+
+// Required: resolve-topics.ts imports @/lib/ai/embed at module load.
+vi.mock("@/lib/ai/embed", () => ({
+  generateEmbeddings: vi.fn(),
+}));
+
+// Required: resolve-topics.ts imports @/trigger/helpers/database at module load.
+vi.mock("@/trigger/helpers/database", () => ({
+  forceInsertNewCanonical: vi.fn(),
+  trackEpisodeRun: vi.fn(),
+  persistEpisodeSummary: vi.fn(),
+  updateEpisodeStatus: vi.fn(),
+  addAliasIfNew: vi.fn(),
+}));
+
+// vi.mock is hoisted — top-level imports see the mocks.
+import { db } from "@/db";
+import { sql } from "drizzle-orm";
+import { canonicalTopics } from "@/db/schema";
+import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
+import {
+  hasVersionTokenMismatch,
+  resolveTopic,
+  type ResolveTopicInput,
+  type ResolveTopicResult,
+} from "@/lib/entity-resolution";
+import {
+  AUTO_MATCH_SIMILARITY_THRESHOLD,
+  DISAMBIGUATE_SIMILARITY_THRESHOLD,
+} from "@/lib/entity-resolution-constants";
+import { resolveAndPersistEpisodeTopics } from "@/trigger/helpers/resolve-topics";
+import { normalizeTopics } from "@/trigger/helpers/ai-summary";
+import type { TopicKind } from "@/lib/openrouter";
+
+// ---- Serializer (verbatim from entity-resolution.test.ts) -------------------
+
+function serializeSql(sqlObj: unknown): { sqlText: string; params: unknown[] } {
+  const params: unknown[] = [];
+  const parts: string[] = [];
+  const visit = (chunk: unknown) => {
+    if (chunk == null) return;
+    if (Array.isArray(chunk)) {
+      chunk.forEach(visit);
+      return;
+    }
+    if (
+      typeof chunk === "string" ||
+      typeof chunk === "number" ||
+      typeof chunk === "boolean"
+    ) {
+      params.push(chunk);
+      parts.push("$");
+      return;
+    }
+    const obj = chunk as { value?: unknown; queryChunks?: unknown[] };
+    if (Array.isArray(obj.queryChunks)) {
+      obj.queryChunks.forEach(visit);
+      return;
+    }
+    if (Array.isArray(obj.value)) {
+      parts.push(obj.value.join(""));
+      return;
+    }
+    if (obj.value !== undefined) {
+      params.push(obj.value);
+      parts.push("$");
+      return;
+    }
+  };
+  visit(sqlObj);
+  return { sqlText: parts.join(" "), params };
+}
+
+// ---- Types ------------------------------------------------------------------
+
+type ResolverGoldenFixture = {
+  _meta: {
+    name: string;
+    scenario: string;
+    expectedOutcome: string;
+  };
+  seedCanonicals?: Array<{
+    id: number;
+    label: string;
+    normalizedLabel: string;
+    kind: TopicKind;
+    summary: string;
+    ongoing?: boolean;
+    relevance?: number;
+  }>;
+  inputs: Array<{
+    label: string;
+    kind: TopicKind;
+    summary: string;
+    aliases: string[];
+    ongoing: boolean;
+    relevance: number;
+    coverageScore: number;
+    knnCandidates?: Array<{
+      id: number;
+      label: string;
+      kind: TopicKind;
+      summary: string;
+      similarity: number;
+    }>;
+    disambiguatorResponse?: { chosenId: number | null } | { rawJson: string };
+  }>;
+  expected: {
+    canonicalCount?: number;
+    canonicalCountAtMost?: number;
+    aliasCountAtLeast?: number;
+    matchMethodDistribution?: Partial<Record<string, number>>;
+    versionTokenForcedDisambig?: number;
+    perInput?: Array<{
+      matchMethod?: string;
+      versionTokenForcedDisambig?: boolean;
+    }>;
+    junctionCountForSingleCanonical?: number;
+  };
+  // Optional: used by philosophical-no-topic fixture
+  aiRawOutput?: { topics: unknown[] };
+};
+
+// ---- Embedding helper -------------------------------------------------------
+
+const STABLE_EMBEDDING = Array.from(
+  { length: EMBEDDING_DIMENSION },
+  () => 0.001,
+);
+
+function buildInput(
+  entry: ResolverGoldenFixture["inputs"][number],
+  episodeId: number,
+): ResolveTopicInput {
+  return {
+    label: entry.label,
+    kind: entry.kind,
+    summary: entry.summary,
+    aliases: entry.aliases,
+    ongoing: entry.ongoing,
+    relevance: entry.relevance,
+    coverageScore: entry.coverageScore,
+    episodeId,
+    identityEmbedding: STABLE_EMBEDDING,
+    contextEmbedding: STABLE_EMBEDDING,
+  };
+}
+
+// Detect which TX-1 path an input will take based on kNN candidates and version
+// tokens — mirrors the decision tree in runTx1.
+function detectTx1Path(
+  entry: ResolverGoldenFixture["inputs"][number],
+  exactHit: boolean,
+): "exact" | "knn-auto" | "disambig" | "new-insert" {
+  if (exactHit) return "exact";
+  const top = (entry.knnCandidates ?? [])[0];
+  if (!top) return "new-insert";
+  const versionMismatch = hasVersionTokenMismatch(entry.label, top.label);
+  if (
+    top.similarity > AUTO_MATCH_SIMILARITY_THRESHOLD &&
+    top.kind === entry.kind &&
+    !versionMismatch
+  ) {
+    return "knn-auto";
+  }
+  if (
+    versionMismatch ||
+    (entry.knnCandidates ?? []).some(
+      (c) => c.similarity >= DISAMBIGUATE_SIMILARITY_THRESHOLD,
+    )
+  ) {
+    return "disambig";
+  }
+  return "new-insert";
+}
+
+// ---- Fixture adapters -------------------------------------------------------
+
+interface RunFixtureResult {
+  input: ResolverGoldenFixture["inputs"][number];
+  result: ResolveTopicResult;
+}
+
+// Tracks canonical IDs seen across inputs so we can assert canonicalCount.
+let seenCanonicalIds: Set<number>;
+
+async function runFixtureWithMockDb(
+  fixture: ResolverGoldenFixture,
+): Promise<RunFixtureResult[]> {
+  seenCanonicalIds = new Set((fixture.seedCanonicals ?? []).map((s) => s.id));
+  const results: RunFixtureResult[] = [];
+
+  const seedMap = new Map((fixture.seedCanonicals ?? []).map((s) => [s.id, s]));
+
+  // Running counter for new canonical IDs inserted during this run.
+  let nextNewId = 900;
+
+  for (const entry of fixture.inputs) {
+    const normalizedInputLabel = entry.label.trim().toLowerCase();
+
+    const exactHit = Array.from(seedMap.values()).find(
+      (s) => s.normalizedLabel === normalizedInputLabel,
+    );
+
+    const path = detectTx1Path(entry, exactHit !== undefined);
+
+    // Queue disambiguator response before registering fixtures.
+    if (entry.disambiguatorResponse !== undefined) {
+      const resp = entry.disambiguatorResponse;
+      const jsonStr =
+        "rawJson" in resp
+          ? resp.rawJson
+          : `{"chosen_id": ${resp.chosenId === null ? "null" : resp.chosenId}}`;
+      generateCompletionMock.mockResolvedValueOnce(jsonStr);
+    }
+
+    const knnRows = (entry.knnCandidates ?? []).map((c) => ({
+      id: c.id,
+      label: c.label,
+      kind: c.kind,
+      summary: c.summary,
+      last_seen: new Date(),
+      ongoing: false,
+      similarity: c.similarity,
+    }));
+
+    if (path === "exact") {
+      setTxFixtures([
+        {
+          match: "lower(normalized_label)",
+          rows: [{ id: exactHit!.id, kind: exactHit!.kind }],
+        },
+        { match: "UPDATE canonical_topics", rows: [] },
+        { match: "INSERT INTO canonical_topic_aliases", rows: [{ id: 1 }] },
+        { match: "INSERT INTO episode_canonical_topics", rows: [] },
+      ]);
+    } else if (path === "knn-auto") {
+      const top = entry.knnCandidates![0];
+      setTxFixtures([
+        { match: "lower(normalized_label)", rows: [] },
+        { match: "SET LOCAL hnsw.ef_search", rows: [] },
+        { match: "identity_embedding <=>", rows: knnRows },
+        { match: "UPDATE canonical_topics", rows: [] },
+        { match: "INSERT INTO canonical_topic_aliases", rows: [{ id: 1 }] },
+        { match: "INSERT INTO episode_canonical_topics", rows: [] },
+      ]);
+      seenCanonicalIds.add(top.id);
+    } else if (path === "disambig") {
+      // TX-1: exact miss + kNN
+      setTxFixtures([
+        { match: "lower(normalized_label)", rows: [] },
+        { match: "SET LOCAL hnsw.ef_search", rows: [] },
+        { match: "identity_embedding <=>", rows: knnRows },
+      ]);
+
+      // TX-2: depends on what the LLM returns
+      const resp = entry.disambiguatorResponse;
+      const chosenId = resp && !("rawJson" in resp) ? resp.chosenId : null;
+      const tx2Fixtures: SqlFixture[] = [
+        { match: "lower(normalized_label)", rows: [] },
+      ];
+
+      if (chosenId !== null && chosenId !== undefined) {
+        const candidate = (entry.knnCandidates ?? []).find(
+          (c) => c.id === chosenId,
+        );
+        tx2Fixtures.push({ match: "SET LOCAL hnsw.ef_search", rows: [] });
+        tx2Fixtures.push({
+          match: "WHERE id =",
+          rows: candidate
+            ? [
+                {
+                  id: chosenId,
+                  kind: candidate.kind,
+                  similarity: candidate.similarity,
+                },
+              ]
+            : [],
+        });
+        if (candidate && candidate.kind === entry.kind) {
+          tx2Fixtures.push({ match: "UPDATE canonical_topics", rows: [] });
+          tx2Fixtures.push({
+            match: "INSERT INTO canonical_topic_aliases",
+            rows: [{ id: 1 }],
+          });
+          tx2Fixtures.push({
+            match: "INSERT INTO episode_canonical_topics",
+            rows: [],
+          });
+          seenCanonicalIds.add(chosenId);
+        } else {
+          const newId = nextNewId++;
+          tx2Fixtures.push({
+            match: "INSERT INTO canonical_topics",
+            rows: [{ id: newId }],
+          });
+          tx2Fixtures.push({
+            match: "INSERT INTO canonical_topic_aliases",
+            rows: [{ id: 1 }],
+          });
+          tx2Fixtures.push({
+            match: "INSERT INTO episode_canonical_topics",
+            rows: [],
+          });
+          seenCanonicalIds.add(newId);
+        }
+      } else {
+        // LLM returned null → new insert
+        const newId = nextNewId++;
+        tx2Fixtures.push({
+          match: "INSERT INTO canonical_topics",
+          rows: [{ id: newId }],
+        });
+        tx2Fixtures.push({
+          match: "INSERT INTO canonical_topic_aliases",
+          rows: [{ id: 1 }],
+        });
+        tx2Fixtures.push({
+          match: "INSERT INTO episode_canonical_topics",
+          rows: [],
+        });
+        seenCanonicalIds.add(newId);
+      }
+      setTxFixtures(tx2Fixtures);
+    } else {
+      // new-insert via TX-1
+      const newId = nextNewId++;
+      setTxFixtures([
+        { match: "lower(normalized_label)", rows: [] },
+        { match: "SET LOCAL hnsw.ef_search", rows: [] },
+        { match: "identity_embedding <=>", rows: [] },
+        { match: "INSERT INTO canonical_topics", rows: [{ id: newId }] },
+        { match: "INSERT INTO canonical_topic_aliases", rows: [{ id: 1 }] },
+        { match: "INSERT INTO episode_canonical_topics", rows: [] },
+      ]);
+      seenCanonicalIds.add(newId);
+    }
+
+    const result = await resolveTopic(buildInput(entry, 1000 + results.length));
+    seenCanonicalIds.add(result.canonicalId);
+    results.push({ input: entry, result });
+  }
+
+  return results;
+}
+
+async function runFixtureWithRealDb(
+  fixture: ResolverGoldenFixture,
+  episodeIdA: number,
+  episodeIdB: number,
+): Promise<{ resultA: ResolveTopicResult; resultB: ResolveTopicResult }> {
+  const ts = Date.now();
+  const inputs = fixture.inputs.map((entry) => ({
+    ...entry,
+    label: entry.label.replace("<TS>", String(ts)),
+  }));
+
+  const [resultA, resultB] = await Promise.all([
+    resolveTopic(buildInput(inputs[0], episodeIdA)),
+    resolveTopic(buildInput(inputs[1], episodeIdB)),
+  ]);
+
+  return { resultA, resultB };
+}
+
+// ---- Lifecycle --------------------------------------------------------------
+
+beforeEach(() => {
+  txFixturesQueue.length = 0;
+  txCallLog.length = 0;
+  generateCompletionMock.mockReset();
+});
+
+afterEach(() => {
+  txFixturesQueue.length = 0;
+  txCallLog.length = 0;
+});
+
+// ---- Fixtures (imported via resolveJsonModule) ------------------------------
+
+import versionAdjacentReleasesFixture from "./fixtures/entity-resolution/version-adjacent-releases.json";
+import aliasClustersFixture from "./fixtures/entity-resolution/alias-clusters.json";
+import conceptClusteringFixture from "./fixtures/entity-resolution/concept-clustering.json";
+import philosophicalNoTopicFixture from "./fixtures/entity-resolution/philosophical-no-topic.json";
+import concurrentInsertRaceFixture from "./fixtures/entity-resolution/concurrent-insert-race.json";
+
+// ---- Test suites ------------------------------------------------------------
+
+describe("entity-resolution golden dataset", () => {
+  describe("with mocked DB", () => {
+    it("version-adjacent-releases", async () => {
+      const fixture =
+        versionAdjacentReleasesFixture as unknown as ResolverGoldenFixture;
+      const results = await runFixtureWithMockDb(fixture);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].result.matchMethod).toBe(
+        fixture.expected.perInput?.[0]?.matchMethod,
+      );
+      expect(results[0].result.versionTokenForcedDisambig).toBe(
+        fixture.expected.perInput?.[0]?.versionTokenForcedDisambig,
+      );
+
+      // canonicalCount=2: seed + newly inserted canonical
+      expect(seenCanonicalIds.size).toBe(fixture.expected.canonicalCount);
+
+      // versionTokenForcedDisambig count across all inputs
+      const forcedCount = results.filter(
+        (r) => r.result.versionTokenForcedDisambig,
+      ).length;
+      expect(forcedCount).toBe(fixture.expected.versionTokenForcedDisambig);
+    });
+
+    it("alias-clusters", async () => {
+      const fixture = aliasClustersFixture as unknown as ResolverGoldenFixture;
+      const results = await runFixtureWithMockDb(fixture);
+
+      expect(results).toHaveLength(4);
+
+      // All 4 inputs resolve to the same canonical
+      const uniqueCanonicals = new Set(
+        results.map((r) => r.result.canonicalId),
+      );
+      expect(uniqueCanonicals.size).toBe(fixture.expected.canonicalCount);
+
+      // Alias SQL emissions: count actual INSERT INTO canonical_topic_aliases calls
+      const aliasInsertCalls = allRecordedCalls().filter((c) =>
+        c.sql.includes("INSERT INTO canonical_topic_aliases"),
+      );
+      expect(aliasInsertCalls.length).toBeGreaterThanOrEqual(
+        fixture.expected.aliasCountAtLeast!,
+      );
+    });
+
+    it("concept-clustering", async () => {
+      const fixture =
+        conceptClusteringFixture as unknown as ResolverGoldenFixture;
+      const results = await runFixtureWithMockDb(fixture);
+
+      expect(results).toHaveLength(3);
+
+      const uniqueCanonicals = new Set(
+        results.map((r) => r.result.canonicalId),
+      );
+      expect(uniqueCanonicals.size).toBeGreaterThanOrEqual(1);
+      if (fixture.expected.canonicalCountAtMost !== undefined) {
+        expect(uniqueCanonicals.size).toBeLessThanOrEqual(
+          fixture.expected.canonicalCountAtMost,
+        );
+      }
+
+      // Assert match method distribution
+      const distribution: Record<string, number> = {};
+      for (const { result } of results) {
+        distribution[result.matchMethod] =
+          (distribution[result.matchMethod] ?? 0) + 1;
+      }
+      if (fixture.expected.matchMethodDistribution) {
+        for (const [method, count] of Object.entries(
+          fixture.expected.matchMethodDistribution,
+        )) {
+          expect(distribution[method] ?? 0).toBe(count);
+        }
+      }
+    });
+
+    it("philosophical-no-topic", async () => {
+      const fixture =
+        philosophicalNoTopicFixture as unknown as ResolverGoldenFixture & {
+          aiRawOutput: { topics: unknown[] };
+        };
+
+      // normalizeTopics returns [] for empty array input
+      const normalized = normalizeTopics(fixture.aiRawOutput.topics, []);
+      expect(normalized).toHaveLength(0);
+
+      // resolveAndPersistEpisodeTopics early-exits: no SQL, zeroed result
+      const result = await resolveAndPersistEpisodeTopics(1, [], "summary");
+      expect(result.topicCount).toBe(0);
+      expect(result.resolved).toBe(0);
+      expect(result.failed).toBe(0);
+
+      // No transactional() was called (no SQL emissions)
+      expect(txCallLog).toHaveLength(0);
+    });
+  });
+
+  describe.skipIf(!process.env.DATABASE_URL)("with real DB", () => {
+    let episodeIdA: number;
+    let episodeIdB: number;
+    const CONCURRENT_PREFIX = "__er_golden_concurrent_";
+
+    beforeAll(async () => {
+      const rows = await db.execute<{ id: number }>(
+        sql`SELECT id FROM episodes ORDER BY id LIMIT 2`,
+      );
+      if (rows.rows.length < 2) {
+        throw new Error(
+          "Need at least 2 episodes in the dev DB to run golden concurrent test.",
+        );
+      }
+      episodeIdA = rows.rows[0].id;
+      episodeIdB = rows.rows[1].id;
+    });
+
+    afterAll(async () => {
+      await db.execute(
+        sql`DELETE FROM canonical_topic_aliases WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}))`,
+      );
+      await db.execute(
+        sql`DELETE FROM episode_canonical_topics WHERE canonical_topic_id IN (SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}))`,
+      );
+      await db.execute(
+        sql`DELETE FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX})`,
+      );
+    });
+
+    it("concurrent-insert-race", async () => {
+      const fixture =
+        concurrentInsertRaceFixture as unknown as ResolverGoldenFixture;
+
+      const { generateCompletion } = await import("@/lib/ai/generate");
+      const mockedGen = vi.mocked(generateCompletion);
+      mockedGen.mockReset();
+
+      const { resultA, resultB } = await runFixtureWithRealDb(
+        fixture,
+        episodeIdA,
+        episodeIdB,
+      );
+
+      // Both calls collapse to the same canonical
+      expect(resultA.canonicalId).toBe(resultB.canonicalId);
+
+      // Exactly 1 canonical in the DB for this label prefix
+      const canonicalRows = await db.execute<{ id: number }>(
+        sql`SELECT id FROM canonical_topics WHERE starts_with(label, ${CONCURRENT_PREFIX}) ORDER BY id LIMIT 10`,
+      );
+      expect(canonicalRows.rows.length).toBe(
+        fixture.expected.canonicalCount ?? 1,
+      );
+
+      // Exactly 2 junction rows pointing at the canonical
+      const junctionRows = await db.execute<{ episode_id: number }>(
+        sql`SELECT episode_id FROM episode_canonical_topics WHERE canonical_topic_id = ${resultA.canonicalId}`,
+      );
+      expect(junctionRows.rows.length).toBe(
+        fixture.expected.junctionCountForSingleCanonical ?? 2,
+      );
+      const epIds = junctionRows.rows.map((r) => r.episode_id).sort();
+      expect(epIds).toEqual([episodeIdA, episodeIdB].sort());
+
+      // Disambiguator must NOT have been called (empty-slot fast path)
+      expect(mockedGen).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/__tests__/entity-resolution.golden.test.ts
+++ b/src/lib/__tests__/entity-resolution.golden.test.ts
@@ -104,6 +104,8 @@ vi.mock("@/trigger/helpers/database", () => ({
 }));
 
 // vi.mock is hoisted — top-level imports see the mocks.
+import { transactional } from "@/db/pool";
+import { generateEmbeddings } from "@/lib/ai/embed";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
 import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
@@ -276,13 +278,17 @@ interface RunFixtureResult {
   result: ResolveTopicResult;
 }
 
-// Tracks canonical IDs seen across inputs so we can assert canonicalCount.
-let seenCanonicalIds: Set<number>;
+interface RunFixtureOutput {
+  results: RunFixtureResult[];
+  seenCanonicalIds: Set<number>;
+}
 
 async function runFixtureWithMockDb(
   fixture: ResolverGoldenFixture,
-): Promise<RunFixtureResult[]> {
-  seenCanonicalIds = new Set((fixture.seedCanonicals ?? []).map((s) => s.id));
+): Promise<RunFixtureOutput> {
+  const seenCanonicalIds = new Set(
+    (fixture.seedCanonicals ?? []).map((s) => s.id),
+  );
   const results: RunFixtureResult[] = [];
 
   const seedMap = new Map((fixture.seedCanonicals ?? []).map((s) => [s.id, s]));
@@ -359,7 +365,6 @@ async function runFixtureWithMockDb(
         const candidate = (entry.knnCandidates ?? []).find(
           (c) => c.id === chosenId,
         );
-        tx2Fixtures.push({ match: "SET LOCAL hnsw.ef_search", rows: [] });
         tx2Fixtures.push({
           match: "WHERE id =",
           rows: candidate
@@ -389,6 +394,7 @@ async function runFixtureWithMockDb(
             match: "INSERT INTO canonical_topics",
             rows: [{ id: newId }],
           });
+          tx2Fixtures.push({ match: "UPDATE canonical_topics", rows: [] });
           tx2Fixtures.push({
             match: "INSERT INTO canonical_topic_aliases",
             rows: [{ id: 1 }],
@@ -406,6 +412,7 @@ async function runFixtureWithMockDb(
           match: "INSERT INTO canonical_topics",
           rows: [{ id: newId }],
         });
+        tx2Fixtures.push({ match: "UPDATE canonical_topics", rows: [] });
         tx2Fixtures.push({
           match: "INSERT INTO canonical_topic_aliases",
           rows: [{ id: 1 }],
@@ -425,6 +432,7 @@ async function runFixtureWithMockDb(
         { match: "SET LOCAL hnsw.ef_search", rows: [] },
         { match: "identity_embedding <=>", rows: [] },
         { match: "INSERT INTO canonical_topics", rows: [{ id: newId }] },
+        { match: "UPDATE canonical_topics", rows: [] },
         { match: "INSERT INTO canonical_topic_aliases", rows: [{ id: 1 }] },
         { match: "INSERT INTO episode_canonical_topics", rows: [] },
       ]);
@@ -436,7 +444,7 @@ async function runFixtureWithMockDb(
     results.push({ input: entry, result });
   }
 
-  return results;
+  return { results, seenCanonicalIds };
 }
 
 async function runFixtureWithRealDb(
@@ -464,6 +472,8 @@ beforeEach(() => {
   txFixturesQueue.length = 0;
   txCallLog.length = 0;
   generateCompletionMock.mockReset();
+  vi.mocked(transactional).mockClear();
+  vi.mocked(generateEmbeddings).mockClear();
 });
 
 afterEach(() => {
@@ -486,7 +496,7 @@ describe("entity-resolution golden dataset", () => {
     it("version-adjacent-releases", async () => {
       const fixture =
         versionAdjacentReleasesFixture as unknown as ResolverGoldenFixture;
-      const results = await runFixtureWithMockDb(fixture);
+      const { results, seenCanonicalIds } = await runFixtureWithMockDb(fixture);
 
       // Anchor against literal expected behaviour, not just the fixture's own
       // declarations — pinning at the assertion site stops a fixture edit from
@@ -511,45 +521,37 @@ describe("entity-resolution golden dataset", () => {
 
     it("alias-clusters", async () => {
       const fixture = aliasClustersFixture as unknown as ResolverGoldenFixture;
-      const results = await runFixtureWithMockDb(fixture);
+      const { results } = await runFixtureWithMockDb(fixture);
 
       expect(results).toHaveLength(fixture.inputs.length);
 
       const uniqueCanonicals = new Set(
         results.map((r) => r.result.canonicalId),
       );
-      expect(uniqueCanonicals.size).toBe(fixture.expected.canonicalCount);
+      expect(uniqueCanonicals.size).toBe(1);
 
       // Counts production SQL emissions, not pre-registered fixture rows —
       // verifies the resolver actually attempted ≥4 alias upserts.
       const aliasInsertCalls = allRecordedCalls().filter((c) =>
         c.sql.includes("INSERT INTO canonical_topic_aliases"),
       );
-      const minAliases = fixture.expected.aliasCountAtLeast;
-      expect(minAliases, "aliasCountAtLeast must be set").toBeDefined();
-      expect(aliasInsertCalls.length).toBeGreaterThanOrEqual(minAliases ?? 0);
+      expect(aliasInsertCalls.length).toBeGreaterThanOrEqual(4);
 
-      // Pin the match-method distribution that the fixture's _meta describes:
-      // 3 auto + 1 llm_disambig (input 3 forces version-token disambig).
+      // Pin the match-method distribution: 3 auto + 1 llm_disambig.
+      // Input 3 ("Anthropic's new Opus") triggers version-token disambig.
       const distribution: Partial<Record<MatchMethod, number>> = {};
       for (const { result } of results) {
         distribution[result.matchMethod] =
           (distribution[result.matchMethod] ?? 0) + 1;
       }
-      const expectedDistribution = fixture.expected.matchMethodDistribution;
-      expect(
-        expectedDistribution,
-        "matchMethodDistribution must be set",
-      ).toBeDefined();
-      for (const [method, count] of Object.entries(expectedDistribution!)) {
-        expect(distribution[method as MatchMethod] ?? 0).toBe(count);
-      }
+      expect(distribution.auto ?? 0).toBe(3);
+      expect(distribution.llm_disambig ?? 0).toBe(1);
     });
 
     it("concept-clustering", async () => {
       const fixture =
         conceptClusteringFixture as unknown as ResolverGoldenFixture;
-      const results = await runFixtureWithMockDb(fixture);
+      const { results } = await runFixtureWithMockDb(fixture);
 
       expect(results).toHaveLength(fixture.inputs.length);
 
@@ -567,14 +569,10 @@ describe("entity-resolution golden dataset", () => {
         distribution[result.matchMethod] =
           (distribution[result.matchMethod] ?? 0) + 1;
       }
-      const expectedDistribution = fixture.expected.matchMethodDistribution;
-      expect(
-        expectedDistribution,
-        "matchMethodDistribution must be set",
-      ).toBeDefined();
-      for (const [method, count] of Object.entries(expectedDistribution!)) {
-        expect(distribution[method as MatchMethod] ?? 0).toBe(count);
-      }
+      // Pin literal distribution: 2 new-inserts + 1 llm_disambig.
+      // "creatine supplementation" merges via LLM; "creatine monohydrate" splits.
+      expect(distribution.new ?? 0).toBe(2);
+      expect(distribution.llm_disambig ?? 0).toBe(1);
     });
 
     it("philosophical-no-topic", async () => {
@@ -593,8 +591,10 @@ describe("entity-resolution golden dataset", () => {
       expect(result.resolved).toBe(0);
       expect(result.failed).toBe(0);
 
-      // No transactional() was called (no SQL emissions)
-      expect(txCallLog).toHaveLength(0);
+      // Pin the early-exit contract: transactional() and generateEmbeddings()
+      // must not be called for empty-topic input.
+      expect(vi.mocked(transactional)).not.toHaveBeenCalled();
+      expect(vi.mocked(generateEmbeddings)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/__tests__/fixtures/entity-resolution/alias-clusters.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/alias-clusters.json
@@ -1,0 +1,99 @@
+{
+  "_meta": {
+    "name": "alias-clusters",
+    "scenario": "Four surface-form variants of 'Claude Opus 4.7' are resolved sequentially against a pre-seeded canonical. All four kNN lookups return the seed at similarity 0.94 (above AUTO_MATCH_SIMILARITY_THRESHOLD 0.92). Inputs 1, 2, 4 have version tokens matching the seed ('4.7'), so they auto-match. Input 3 ('Anthropic's new Opus') has no version token while the seed has '4.7' — hasVersionTokenMismatch returns true — which forces the disambiguator; the LLM returns chosen_id pointing at the seed, producing llm_disambig. Each successful match path issues one alias-upsert call, accumulating >=4 alias SQL emissions in total (ADR-042 §alias upsert).",
+    "expectedOutcome": "canonicalCount=1 (all 4 inputs collapse to the single seed canonical); aliasCountAtLeast=4 (each input issues one INSERT INTO canonical_topic_aliases call to the mock DB, verified by counting SQL call emissions, not fixture-row registrations)."
+  },
+  "seedCanonicals": [
+    {
+      "id": 10,
+      "label": "Claude Opus 4.7",
+      "normalizedLabel": "claude opus 4.7",
+      "kind": "release",
+      "summary": "Anthropic's flagship model Opus 4.7.",
+      "ongoing": false,
+      "relevance": 0.9
+    }
+  ],
+  "inputs": [
+    {
+      "label": "Opus 4.7",
+      "kind": "release",
+      "summary": "The Opus 4.7 model from Anthropic.",
+      "aliases": ["Opus 4.7 model"],
+      "ongoing": false,
+      "relevance": 0.85,
+      "coverageScore": 0.7,
+      "knnCandidates": [
+        {
+          "id": 10,
+          "label": "Claude Opus 4.7",
+          "kind": "release",
+          "summary": "Anthropic's flagship model Opus 4.7.",
+          "similarity": 0.94
+        }
+      ]
+    },
+    {
+      "label": "Claude Opus 4.7",
+      "kind": "release",
+      "summary": "Claude Opus 4.7 capabilities overview.",
+      "aliases": ["Claude Opus 4.7 model"],
+      "ongoing": false,
+      "relevance": 0.9,
+      "coverageScore": 0.75,
+      "knnCandidates": [
+        {
+          "id": 10,
+          "label": "Claude Opus 4.7",
+          "kind": "release",
+          "summary": "Anthropic's flagship model Opus 4.7.",
+          "similarity": 0.94
+        }
+      ]
+    },
+    {
+      "label": "Anthropic's new Opus",
+      "kind": "release",
+      "summary": "Anthropic released a new Opus model.",
+      "aliases": ["new Opus model"],
+      "ongoing": false,
+      "relevance": 0.8,
+      "coverageScore": 0.65,
+      "knnCandidates": [
+        {
+          "id": 10,
+          "label": "Claude Opus 4.7",
+          "kind": "release",
+          "summary": "Anthropic's flagship model Opus 4.7.",
+          "similarity": 0.94
+        }
+      ],
+      "disambiguatorResponse": {
+        "chosenId": 10
+      }
+    },
+    {
+      "label": "Opus 4.7 release",
+      "kind": "release",
+      "summary": "The official Opus 4.7 release from Anthropic.",
+      "aliases": ["Opus 4.7 launch"],
+      "ongoing": false,
+      "relevance": 0.85,
+      "coverageScore": 0.7,
+      "knnCandidates": [
+        {
+          "id": 10,
+          "label": "Claude Opus 4.7",
+          "kind": "release",
+          "summary": "Anthropic's flagship model Opus 4.7.",
+          "similarity": 0.94
+        }
+      ]
+    }
+  ],
+  "expected": {
+    "canonicalCount": 1,
+    "aliasCountAtLeast": 4
+  }
+}

--- a/src/lib/__tests__/fixtures/entity-resolution/alias-clusters.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/alias-clusters.json
@@ -94,6 +94,10 @@
   ],
   "expected": {
     "canonicalCount": 1,
-    "aliasCountAtLeast": 4
+    "aliasCountAtLeast": 4,
+    "matchMethodDistribution": {
+      "auto": 3,
+      "llm_disambig": 1
+    }
   }
 }

--- a/src/lib/__tests__/fixtures/entity-resolution/concept-clustering.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/concept-clustering.json
@@ -1,0 +1,69 @@
+{
+  "_meta": {
+    "name": "concept-clustering",
+    "scenario": "Three surface forms of the 'creatine' concept are resolved sequentially starting from an empty seed. Input 1 ('creatine') finds no kNN candidates and creates a new canonical (mock harness assigns id=900). Input 2 ('creatine supplementation') returns canonical 900 at similarity 0.88, which is in the disambig band (>= DISAMBIGUATE_SIMILARITY_THRESHOLD=0.82, < AUTO_MATCH_SIMILARITY_THRESHOLD=0.92); the LLM returns chosen_id=900, producing llm_disambig. Input 3 ('creatine monohydrate') returns canonical 900 at similarity 0.85 (also in disambig band); the LLM returns chosen_id=null, producing a second new canonical (id=901). This tests the concept-clustering behaviour where similar but semantically distinct sub-concepts are correctly split.",
+    "expectedOutcome": "canonicalCountAtMost=2; matchMethodDistribution={new: 2, llm_disambig: 1} — two distinct canonicals emerge, and the middle form is merged via LLM disambiguation."
+  },
+  "seedCanonicals": [],
+  "inputs": [
+    {
+      "label": "creatine",
+      "kind": "concept",
+      "summary": "Creatine is a naturally occurring compound used in energy production.",
+      "aliases": [],
+      "ongoing": false,
+      "relevance": 0.85,
+      "coverageScore": 0.7,
+      "knnCandidates": []
+    },
+    {
+      "label": "creatine supplementation",
+      "kind": "concept",
+      "summary": "Using creatine as a dietary supplement to enhance athletic performance.",
+      "aliases": ["creatine supplements"],
+      "ongoing": false,
+      "relevance": 0.8,
+      "coverageScore": 0.65,
+      "knnCandidates": [
+        {
+          "id": 900,
+          "label": "creatine",
+          "kind": "concept",
+          "summary": "Creatine is a naturally occurring compound used in energy production.",
+          "similarity": 0.88
+        }
+      ],
+      "disambiguatorResponse": {
+        "chosenId": 900
+      }
+    },
+    {
+      "label": "creatine monohydrate",
+      "kind": "concept",
+      "summary": "Creatine monohydrate is the most studied form of creatine supplement.",
+      "aliases": ["mono creatine"],
+      "ongoing": false,
+      "relevance": 0.8,
+      "coverageScore": 0.65,
+      "knnCandidates": [
+        {
+          "id": 900,
+          "label": "creatine",
+          "kind": "concept",
+          "summary": "Creatine is a naturally occurring compound used in energy production.",
+          "similarity": 0.85
+        }
+      ],
+      "disambiguatorResponse": {
+        "chosenId": null
+      }
+    }
+  ],
+  "expected": {
+    "canonicalCountAtMost": 2,
+    "matchMethodDistribution": {
+      "new": 2,
+      "llm_disambig": 1
+    }
+  }
+}

--- a/src/lib/__tests__/fixtures/entity-resolution/concept-clustering.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/concept-clustering.json
@@ -60,7 +60,7 @@
     }
   ],
   "expected": {
-    "canonicalCountAtMost": 2,
+    "canonicalCount": 2,
     "matchMethodDistribution": {
       "new": 2,
       "llm_disambig": 1

--- a/src/lib/__tests__/fixtures/entity-resolution/concurrent-insert-race.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/concurrent-insert-race.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "name": "concurrent-insert-race",
+    "scenario": "Two parallel resolveTopic calls are fired with identical (label, kind) pairs against a real Postgres instance. The advisory-lock + ON CONFLICT DO NOTHING mechanism (ADR-044 §4 exact-lookup catches both arrivals) ensures exactly one canonical row is created regardless of which call wins the insert race. The label uses a timestamp placeholder to avoid cross-run collisions. The disambiguator must NOT be called (empty-slot fast path — the second arrival finds the canonical via exact-lookup in TX-1).",
+    "expectedOutcome": "canonicalCount=1 in the database (both calls see the same canonical id); junctionCountForSingleCanonical=2 (one junction per distinct episode id); generateCompletion never called."
+  },
+  "seedCanonicals": [],
+  "inputs": [
+    {
+      "label": "__er_golden_concurrent_<TS>",
+      "kind": "concept",
+      "summary": "Concurrent insert race test topic.",
+      "aliases": [],
+      "ongoing": false,
+      "relevance": 0.5,
+      "coverageScore": 0.5
+    },
+    {
+      "label": "__er_golden_concurrent_<TS>",
+      "kind": "concept",
+      "summary": "Concurrent insert race test topic.",
+      "aliases": [],
+      "ongoing": false,
+      "relevance": 0.5,
+      "coverageScore": 0.5
+    }
+  ],
+  "expected": {
+    "canonicalCount": 1,
+    "junctionCountForSingleCanonical": 2
+  }
+}

--- a/src/lib/__tests__/fixtures/entity-resolution/philosophical-no-topic.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/philosophical-no-topic.json
@@ -1,14 +1,12 @@
 {
   "_meta": {
     "name": "philosophical-no-topic",
-    "scenario": "An AI summarization model returns an empty topic array — e.g., for abstract philosophical content where no discrete topics could be extracted. normalizeTopics([], []) returns [] and resolveAndPersistEpisodeTopics early-exits (resolve-topics.ts:66) before calling generateEmbeddings or transactional(). No canonical inserts occur.",
+    "scenario": "An AI summarization model returns an empty topic array — e.g., for abstract philosophical content where no discrete topics could be extracted. normalizeTopics([], []) returns [] and resolveAndPersistEpisodeTopics early-exits (in resolveAndPersistEpisodeTopics's empty-topics guard) before calling generateEmbeddings or transactional(). No canonical inserts occur.",
     "expectedOutcome": "normalizeTopics returns []; resolveAndPersistEpisodeTopics returns {topicCount: 0, resolved: 0, failed: 0}; txCallLog is empty (no transactional() invocations)."
   },
   "aiRawOutput": {
     "topics": []
   },
   "inputs": [],
-  "expected": {
-    "canonicalCount": 0
-  }
+  "expected": {}
 }

--- a/src/lib/__tests__/fixtures/entity-resolution/philosophical-no-topic.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/philosophical-no-topic.json
@@ -1,0 +1,14 @@
+{
+  "_meta": {
+    "name": "philosophical-no-topic",
+    "scenario": "An AI summarization model returns an empty topic array — e.g., for abstract philosophical content where no discrete topics could be extracted. normalizeTopics([], []) returns [] and resolveAndPersistEpisodeTopics early-exits (resolve-topics.ts:66) before calling generateEmbeddings or transactional(). No canonical inserts occur.",
+    "expectedOutcome": "normalizeTopics returns []; resolveAndPersistEpisodeTopics returns {topicCount: 0, resolved: 0, failed: 0}; txCallLog is empty (no transactional() invocations)."
+  },
+  "aiRawOutput": {
+    "topics": []
+  },
+  "inputs": [],
+  "expected": {
+    "canonicalCount": 0
+  }
+}

--- a/src/lib/__tests__/fixtures/entity-resolution/version-adjacent-releases.json
+++ b/src/lib/__tests__/fixtures/entity-resolution/version-adjacent-releases.json
@@ -1,0 +1,51 @@
+{
+  "_meta": {
+    "name": "version-adjacent-releases",
+    "scenario": "A new model release 'Claude Opus 4.7' is resolved against an existing canonical 'Claude Opus 4.6'. The kNN returns the seed at high cosine similarity (0.95, above AUTO_MATCH_SIMILARITY_THRESHOLD 0.92), but the version-token pre-gate (ADR-042 §version-token regex pre-gate) detects a version mismatch and forces the disambiguator path. The LLM returns chosen_id: null (they are different releases), producing a new canonical.",
+    "expectedOutcome": "canonicalCount=2 (seed + new); the resolved input has matchMethod='new' and versionTokenForcedDisambig=true, confirming the version gate fired and the disambiguator correctly rejected the existing canonical."
+  },
+  "seedCanonicals": [
+    {
+      "id": 1,
+      "label": "Claude Opus 4.6",
+      "normalizedLabel": "claude opus 4.6",
+      "kind": "release",
+      "summary": "Anthropic released Claude Opus 4.6.",
+      "ongoing": false,
+      "relevance": 0.9
+    }
+  ],
+  "inputs": [
+    {
+      "label": "Claude Opus 4.7",
+      "kind": "release",
+      "summary": "Anthropic released Claude Opus 4.7 with improved reasoning.",
+      "aliases": ["Opus 4.7"],
+      "ongoing": false,
+      "relevance": 0.9,
+      "coverageScore": 0.8,
+      "knnCandidates": [
+        {
+          "id": 1,
+          "label": "Claude Opus 4.6",
+          "kind": "release",
+          "summary": "Anthropic released Claude Opus 4.6.",
+          "similarity": 0.95
+        }
+      ],
+      "disambiguatorResponse": {
+        "chosenId": null
+      }
+    }
+  ],
+  "expected": {
+    "canonicalCount": 2,
+    "versionTokenForcedDisambig": 1,
+    "perInput": [
+      {
+        "matchMethod": "new",
+        "versionTokenForcedDisambig": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Five JSON fixtures under `src/lib/__tests__/fixtures/entity-resolution/` covering version-adjacent releases (Opus 4.6 vs 4.7 at 0.95 cosine), alias clusters, concept-kind clustering, philosophical/no-topic episodes, and concurrent inserts of the same brand-new entity exercising the advisory-lock serialization (R16 / ADR-044 §4).
- Companion `src/lib/__tests__/entity-resolution.golden.test.ts` routes the 4 mock-DB scenarios through the existing `SqlFixture`-queue harness pattern and the concurrent-insert-race fixture through real Postgres under `describe.skipIf(!process.env.DATABASE_URL)`. The mock harness falls through to the real `transactional` when no fixtures are queued, so the same file can host both modes without crossing wires.
- Alias-cluster assertion counts production-code SQL emissions (`INSERT INTO canonical_topic_aliases`) via `allRecordedCalls()`, not pre-registered fixture rows — verifying the resolver actually issued the upserts. Concept-clustering assertion is pinned to the exact split count (`=== 2`) so a regression that collapses all 3 inputs onto one canonical fails loudly.
- All assertions anchor on literal expected values rather than the fixture's own declarations to prevent silent fixture-edit drift. `matchMethodDistribution` and `perInput[].matchMethod` typed against `MatchMethod` from the source enum.
- No production code changes (verified by empty `git diff main -- src/lib/entity-resolution.ts src/lib/entity-resolution-constants.ts src/trigger/helpers/resolve-topics.ts src/trigger/helpers/database.ts src/db/schema.ts vitest.config.ts`).

Closes #388

## Test plan

- [x] `bun run format:check` — clean
- [x] `bun run lint` — zero warnings or errors
- [x] `bun run test` — 2620 passed, 35 skipped (+5 new tests vs main; concurrent fixture skips without `DATABASE_URL`)
- [x] `doppler run -- bun run test entity-resolution.golden` — 5 passed (concurrent test exercises real Postgres advisory-lock serialization)
- [x] `bun run build` — succeeds
- [x] All 10 plan VERIFY items confirmed (see `.dev/cdt/plans/plan-20260430-1539.md` Acceptance Criteria — every item ticked)
- [x] Multi-tool pre-PR review applied: Codex, code-reviewer, pr-test-analyzer, type-design-analyzer, comment-analyzer, simplify (3 agents). Validated findings landed in commit 7dba6dc; deferred items (harness extraction, Zod fixture parsing, full discriminated union) are tracked as follow-ups.

## Agent Notes

### Open Questions

- The pre-PR review surfaced one strong consensus follow-up: extract the SQL-fixture-queue harness (`txFixturesQueue`, `serializeSql`, `setTxFixtures`, `allRecordedCalls`) into a shared module. The plan explicitly authorized verbatim duplication ("test infrastructure"), but with this PR the same harness now lives in 2 files (`entity-resolution.test.ts` and `entity-resolution.golden.test.ts`); a third consumer would tip the calculus toward extraction per `docs/code-review-checklist.md` §5/§6. Deferring as a separate refactor PR.
- Type-design analyzer flagged `as unknown as ResolverGoldenFixture` casts (5 sites) as defeating the type. Adding a Zod schema would catch fixture typos at parse time. Out of scope for #388; worth a follow-up if golden-fixture suites proliferate.
- Disambiguator-mock queue order is positional (input-array order). Works for the current 4 sequential-input fixtures but is silently order-coupled. The fix is `mockImplementation` keyed on label, but it would invalidate the simpler current pattern. Open to revisit if a future fixture introduces parallelism.

### Context for Next Session

- The `vi.mock("@/db/pool")` at the top of the test file deliberately falls through to the real `transactional` when the fixture queue is empty. Mocked-DB sub-suites queue fixtures via `setTxFixtures`; real-DB sub-suite (concurrent-insert-race) leaves the queue empty so the mock delegates to actual Postgres. This is the keystone that lets one test file host both modes — without it, the concurrent test silently runs against the empty mock queue and the resolver throws `conflict_recovery_failed` as the second arrival's exact-lookup hits no rows. The pre-PR review caught this — the original commit's QA pass had `DATABASE_URL` unset so the concurrent test was skipped and the bug stayed latent.
- Required `vi.mock` calls at the top of the test file: `@/db/pool`, `@/lib/ai/generate`, `@trigger.dev/sdk`, `@/lib/ai/embed`, `@/trigger/helpers/database`. The last three are needed because the philosophical-no-topic test transitively imports `resolve-topics.ts` which depends on those modules at module-eval time.
- Concurrent fixture cleanup uses prefix `__er_golden_concurrent_<TS>` (timestamp substituted at runtime). The `afterAll` cleanup is a single `DELETE FROM canonical_topics` — FK CASCADE handles aliases and junctions per schema definitions.
- `MOCK_NEW_CANONICAL_BASE_ID = 900` is the harness-internal counter for runtime-allocated canonical IDs in the mock-DB sub-suite. The concept-clustering fixture references id 900 in its second input's kNN candidate to chain off the first input's new-insert.
- Plan + handoff: `.dev/cdt/plans/plan-20260430-1539.md` (acceptance criteria all ticked); session handoff at `.dev/cdt/handoffs/handoff-20260430-1622.md`.