### PR TITLE
refactor: extract shared SQL-fixture-queue + STABLE_EMBEDDING helpers (#421)

### DIFF
--- a/src/db/__tests__/canonical-topic-digests.schema.test.ts
+++ b/src/db/__tests__/canonical-topic-digests.schema.test.ts
@@ -7,11 +7,8 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { canonicalTopics, canonicalTopicDigests } from "@/db/schema";
-import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import { expectInsertRejects } from "@/db/__tests__/schema-test-helpers";
-
-// Stable fixture embedding — content irrelevant for constraint tests.
-const EMBEDDING = Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
+import { STABLE_EMBEDDING as EMBEDDING } from "@/test/embeddings";
 
 // Base row that satisfies every constraint (happy path).
 const validDigest = {

--- a/src/lib/__tests__/entity-resolution.concurrent.test.ts
+++ b/src/lib/__tests__/entity-resolution.concurrent.test.ts
@@ -9,21 +9,16 @@ import { sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { canonicalTopics } from "@/db/schema";
-import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import {
   EntityResolutionError,
   resolveTopic,
   type ResolveTopicInput,
 } from "@/lib/entity-resolution";
+import { STABLE_EMBEDDING } from "@/test/embeddings";
 
 vi.mock("@/lib/ai/generate", () => ({
   generateCompletion: vi.fn(),
 }));
-
-const STABLE_EMBEDDING = Array.from(
-  { length: EMBEDDING_DIMENSION },
-  () => 0.001,
-);
 
 // Same embedding as STABLE — when the seeded canonical's label differs only
 // by a version token (e.g. "Opus 4.6" vs "Opus 4.7") the version-gate forces

--- a/src/lib/__tests__/entity-resolution.golden.test.ts
+++ b/src/lib/__tests__/entity-resolution.golden.test.ts
@@ -13,64 +13,20 @@ import {
 
 // ---- Mocks (must precede all production imports) ----------------------------
 
-// SQL-fixture-queue harness — mirrors entity-resolution.test.ts exactly.
-const txFixturesQueue: TxFixtures[] = [];
-const txCallLog: RecordedCall[][] = [];
-
-interface TxFixtures {
-  rows: SqlFixture[];
-}
-
-interface SqlFixture {
-  match: string | RegExp;
-  rows: unknown[];
-}
-
-interface RecordedCall {
-  sql: string;
-  params: unknown[];
-}
-
-function setTxFixtures(rows: SqlFixture[]): void {
-  txFixturesQueue.push({ rows });
-}
-
-function allRecordedCalls(): RecordedCall[] {
-  return txCallLog.flat();
-}
+// SQL-fixture-queue harness lives in `@/test/sql-fixture-queue` — see that
+// file's header for the Vitest hoisting constraint that forces the factory
+// body to dynamic-import the harness.
 
 // When the fixture queue is empty, fall through to the real `transactional`
 // so the real-DB sub-suite (concurrent-insert-race) hits Postgres normally.
 // Mocked sub-suites queue fixtures via `setTxFixtures` and the mock intercepts.
 vi.mock("@/db/pool", async () => {
   const actual = await vi.importActual<typeof import("@/db/pool")>("@/db/pool");
+  const { createTransactionalFixtureMockWithFallthrough } =
+    await import("@/test/sql-fixture-queue");
   return {
     ...actual,
-    transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-      if (txFixturesQueue.length === 0) {
-        return (
-          actual.transactional as unknown as (
-            cb: (tx: unknown) => Promise<unknown>,
-          ) => Promise<unknown>
-        )(fn);
-      }
-      const fixtures = txFixturesQueue.shift() ?? { rows: [] };
-      const recorded: RecordedCall[] = [];
-      txCallLog.push(recorded);
-      const tx = {
-        execute: async (sqlObj: unknown) => {
-          const { sqlText, params } = serializeSql(sqlObj);
-          recorded.push({ sql: sqlText, params });
-          const fixture = fixtures.rows.find((f) =>
-            typeof f.match === "string"
-              ? sqlText.includes(f.match)
-              : f.match.test(sqlText),
-          );
-          return { rows: fixture?.rows ?? [] };
-        },
-      };
-      return fn(tx);
-    }),
+    transactional: createTransactionalFixtureMockWithFallthrough(actual),
   };
 });
 
@@ -108,7 +64,6 @@ import { transactional } from "@/db/pool";
 import { generateEmbeddings } from "@/lib/ai/embed";
 import { db } from "@/db";
 import { sql } from "drizzle-orm";
-import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import {
   hasVersionTokenMismatch,
   resolveTopic,
@@ -123,50 +78,18 @@ import {
 import { resolveAndPersistEpisodeTopics } from "@/trigger/helpers/resolve-topics";
 import { normalizeTopics } from "@/trigger/helpers/ai-summary";
 import type { TopicKind } from "@/lib/openrouter";
+import {
+  type SqlFixture,
+  allRecordedCalls,
+  resetTxState,
+  setTxFixtures,
+} from "@/test/sql-fixture-queue";
+import { STABLE_EMBEDDING } from "@/test/embeddings";
 
 // First runtime-allocated canonical id used by the mock harness.
 // Fixtures referencing newly-inserted canonicals (e.g. concept-clustering)
 // rely on this value to seed kNN candidates for subsequent inputs.
 const MOCK_NEW_CANONICAL_BASE_ID = 900;
-
-// ---- Serializer (verbatim from entity-resolution.test.ts) -------------------
-
-function serializeSql(sqlObj: unknown): { sqlText: string; params: unknown[] } {
-  const params: unknown[] = [];
-  const parts: string[] = [];
-  const visit = (chunk: unknown) => {
-    if (chunk == null) return;
-    if (Array.isArray(chunk)) {
-      chunk.forEach(visit);
-      return;
-    }
-    if (
-      typeof chunk === "string" ||
-      typeof chunk === "number" ||
-      typeof chunk === "boolean"
-    ) {
-      params.push(chunk);
-      parts.push("$");
-      return;
-    }
-    const obj = chunk as { value?: unknown; queryChunks?: unknown[] };
-    if (Array.isArray(obj.queryChunks)) {
-      obj.queryChunks.forEach(visit);
-      return;
-    }
-    if (Array.isArray(obj.value)) {
-      parts.push(obj.value.join(""));
-      return;
-    }
-    if (obj.value !== undefined) {
-      params.push(obj.value);
-      parts.push("$");
-      return;
-    }
-  };
-  visit(sqlObj);
-  return { sqlText: parts.join(" "), params };
-}
 
 // ---- Types ------------------------------------------------------------------
 
@@ -217,13 +140,6 @@ type ResolverGoldenFixture = {
   // Optional: used by philosophical-no-topic fixture
   aiRawOutput?: { topics: unknown[] };
 };
-
-// ---- Embedding helper -------------------------------------------------------
-
-const STABLE_EMBEDDING = Array.from(
-  { length: EMBEDDING_DIMENSION },
-  () => 0.001,
-);
 
 function buildInput(
   entry: ResolverGoldenFixture["inputs"][number],
@@ -469,16 +385,14 @@ async function runFixtureWithRealDb(
 // ---- Lifecycle --------------------------------------------------------------
 
 beforeEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
   generateCompletionMock.mockReset();
   vi.mocked(transactional).mockClear();
   vi.mocked(generateEmbeddings).mockClear();
 });
 
 afterEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
 });
 
 // ---- Fixtures (imported via resolveJsonModule) ------------------------------

--- a/src/lib/__tests__/entity-resolution.golden.test.ts
+++ b/src/lib/__tests__/entity-resolution.golden.test.ts
@@ -26,7 +26,9 @@ vi.mock("@/db/pool", async () => {
     await import("@/test/sql-fixture-queue");
   return {
     ...actual,
-    transactional: createTransactionalFixtureMockWithFallthrough(actual),
+    transactional: createTransactionalFixtureMockWithFallthrough(
+      actual.transactional,
+    ),
   };
 });
 

--- a/src/lib/__tests__/entity-resolution.test.ts
+++ b/src/lib/__tests__/entity-resolution.test.ts
@@ -29,11 +29,8 @@ import { buildEmbedding } from "@/test/embeddings";
 
 // Each call to `transactional(cb)` runs `cb(mockTx)` against a fresh MockTx
 // pre-loaded with fixtures keyed by SQL substring. Tests register fixtures
-// per-tx via `setTxFixtures(...)`.
-//
-// Note: `vi.mock` is hoisted above all imports, so the factory must dynamic-
-// import the harness — top-level imports aren't bound when the factory runs.
-
+// per-tx via `setTxFixtures(...)`. See @/test/sql-fixture-queue header for
+// the factory dynamic-import rationale.
 vi.mock("@/db/pool", async () => {
   const { createTransactionalFixtureMock } =
     await import("@/test/sql-fixture-queue");

--- a/src/lib/__tests__/entity-resolution.test.ts
+++ b/src/lib/__tests__/entity-resolution.test.ts
@@ -9,125 +9,41 @@ import {
   resolveTopic,
   type ResolveTopicInput,
 } from "@/lib/entity-resolution";
-import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import {
   AUTO_MATCH_SIMILARITY_THRESHOLD,
   DISAMBIGUATE_SIMILARITY_THRESHOLD,
 } from "@/lib/entity-resolution-constants";
+import {
+  type RecordedCall,
+  allRecordedCalls,
+  getTxLog,
+  resetTxState,
+  setTxFixtures,
+  txCallLog,
+  txFixturesQueue,
+  serializeSql,
+} from "@/test/sql-fixture-queue";
+import { buildEmbedding } from "@/test/embeddings";
 
 // ---- Mocks ------------------------------------------------------------------
 
 // Each call to `transactional(cb)` runs `cb(mockTx)` against a fresh MockTx
 // pre-loaded with fixtures keyed by SQL substring. Tests register fixtures
 // per-tx via `setTxFixtures(...)`.
-const txFixturesQueue: TxFixtures[] = [];
-const txCallLog: RecordedCall[][] = [];
+//
+// Note: `vi.mock` is hoisted above all imports, so the factory must dynamic-
+// import the harness — top-level imports aren't bound when the factory runs.
 
-interface TxFixtures {
-  rows: SqlFixture[];
-}
-
-interface SqlFixture {
-  match: string | RegExp;
-  rows: unknown[];
-}
-
-interface RecordedCall {
-  sql: string;
-  params: unknown[];
-}
-
-function setTxFixtures(rows: SqlFixture[]): void {
-  txFixturesQueue.push({ rows });
-}
-
-function getTxLog(index: number): RecordedCall[] {
-  return txCallLog[index] ?? [];
-}
-
-function allRecordedCalls(): RecordedCall[] {
-  return txCallLog.flat();
-}
-
-vi.mock("@/db/pool", () => ({
-  transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-    const fixtures = txFixturesQueue.shift() ?? { rows: [] };
-    const recorded: RecordedCall[] = [];
-    txCallLog.push(recorded);
-    const tx = {
-      execute: async (sqlObj: unknown) => {
-        const { sqlText, params } = serializeSql(sqlObj);
-        recorded.push({ sql: sqlText, params });
-        const fixture = fixtures.rows.find((f) =>
-          typeof f.match === "string"
-            ? sqlText.includes(f.match)
-            : f.match.test(sqlText),
-        );
-        return { rows: fixture?.rows ?? [] };
-      },
-    };
-    return fn(tx);
-  }),
-}));
+vi.mock("@/db/pool", async () => {
+  const { createTransactionalFixtureMock } =
+    await import("@/test/sql-fixture-queue");
+  return { transactional: createTransactionalFixtureMock() };
+});
 
 const generateCompletionMock = vi.fn();
 vi.mock("@/lib/ai/generate", () => ({
   generateCompletion: (...args: unknown[]) => generateCompletionMock(...args),
 }));
-
-// Walk a Drizzle SQL object and produce a stable serialized string + params
-// list. We don't need DB-correct rendering — we just need stable substrings
-// for fixture matching and parameter extraction for assertions.
-function serializeSql(sqlObj: unknown): {
-  sqlText: string;
-  params: unknown[];
-} {
-  const params: unknown[] = [];
-  const parts: string[] = [];
-  const visit = (chunk: unknown) => {
-    if (chunk == null) return;
-    if (Array.isArray(chunk)) {
-      chunk.forEach(visit);
-      return;
-    }
-    if (
-      typeof chunk === "string" ||
-      typeof chunk === "number" ||
-      typeof chunk === "boolean"
-    ) {
-      // Bare primitives at the top level of queryChunks are template-literal
-      // interpolations — drizzle treats them as bound params. Static SQL
-      // text comes through as StringChunk objects (handled below).
-      params.push(chunk);
-      parts.push("$");
-      return;
-    }
-    const obj = chunk as { value?: unknown; queryChunks?: unknown[] };
-    if (Array.isArray(obj.queryChunks)) {
-      obj.queryChunks.forEach(visit);
-      return;
-    }
-    // StringChunk: { value: string[] }
-    if (Array.isArray(obj.value)) {
-      parts.push(obj.value.join(""));
-      return;
-    }
-    // Param-like: any other object with `value` is treated as a bound param
-    if (obj.value !== undefined) {
-      params.push(obj.value);
-      parts.push("$");
-      return;
-    }
-  };
-  visit(sqlObj);
-  return { sqlText: parts.join(" "), params };
-}
-
-// ---- Helpers ----------------------------------------------------------------
-
-function buildEmbedding(): number[] {
-  return Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
-}
 
 function makeInput(
   overrides: Partial<ResolveTopicInput> = {},
@@ -154,14 +70,12 @@ function findCalls(haystack: RecordedCall[], needle: string): RecordedCall[] {
 // ---- Tests ------------------------------------------------------------------
 
 beforeEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
   generateCompletionMock.mockReset();
 });
 
 afterEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
 });
 
 describe("normalizeLabel", () => {
@@ -447,8 +361,7 @@ describe("resolveTopic", () => {
       expect(knnIdx).toBeGreaterThan(setLocalIdx);
 
       // Sub-test B: exact-lookup hit — SET LOCAL is NOT emitted.
-      txCallLog.length = 0;
-      txFixturesQueue.length = 0;
+      resetTxState();
       setTxFixtures([
         {
           match: "lower(normalized_label)",

--- a/src/test/embeddings.ts
+++ b/src/test/embeddings.ts
@@ -1,0 +1,26 @@
+// Shared embedding fixtures for tests that need a deterministic vector. The
+// content is irrelevant to constraint / harness tests — they only need an
+// array of the correct length to satisfy pgvector / Drizzle column types.
+
+import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
+
+export { EMBEDDING_DIMENSION };
+
+/**
+ * Stable fixture vector — content is irrelevant to constraint/harness tests
+ * that only need an array of the correct length. Not frozen because callers
+ * pass it to Drizzle field types declared as `number[]`.
+ */
+export const STABLE_EMBEDDING: number[] = Array.from(
+  { length: EMBEDDING_DIMENSION },
+  () => 0.001,
+);
+
+/**
+ * Build a fresh embedding vector. Defaults to the same constant value used by
+ * `STABLE_EMBEDDING`; callers can pass `value` to differentiate vectors when
+ * a test depends on cosine-distance variance.
+ */
+export function buildEmbedding(value: number = 0.001): number[] {
+  return Array.from({ length: EMBEDDING_DIMENSION }, () => value);
+}

--- a/src/test/embeddings.ts
+++ b/src/test/embeddings.ts
@@ -4,23 +4,12 @@
 
 import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 
-export { EMBEDDING_DIMENSION };
-
-/**
- * Stable fixture vector — content is irrelevant to constraint/harness tests
- * that only need an array of the correct length. Not frozen because callers
- * pass it to Drizzle field types declared as `number[]`.
- */
-export const STABLE_EMBEDDING: number[] = Array.from(
-  { length: EMBEDDING_DIMENSION },
-  () => 0.001,
-);
-
-/**
- * Build a fresh embedding vector. Defaults to the same constant value used by
- * `STABLE_EMBEDDING`; callers can pass `value` to differentiate vectors when
- * a test depends on cosine-distance variance.
- */
-export function buildEmbedding(value: number = 0.001): number[] {
-  return Array.from({ length: EMBEDDING_DIMENSION }, () => value);
+/** Build a fresh embedding vector with every element equal to `0.001`. */
+export function buildEmbedding(): number[] {
+  return Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
 }
+
+// Singleton fixture vector. Callers that need their own array (e.g. to mutate
+// or to compare references) should use `buildEmbedding()`; callers that only
+// read should reuse this constant. Reading-only callers don't mutate it.
+export const STABLE_EMBEDDING: number[] = buildEmbedding();

--- a/src/test/sql-fixture-queue.ts
+++ b/src/test/sql-fixture-queue.ts
@@ -47,26 +47,32 @@ export interface RecordedCall {
 export const txFixturesQueue: SqlFixture[][] = [];
 export const txCallLog: RecordedCall[][] = [];
 
+/** Register the next batch of SQL fixtures to be consumed by a single `transactional()` call. */
 export function setTxFixtures(rows: SqlFixture[]): void {
   txFixturesQueue.push(rows);
 }
 
+/** Return the list of SQL calls recorded during the nth transaction (0-indexed). */
 export function getTxLog(index: number): RecordedCall[] {
   return txCallLog[index] ?? [];
 }
 
+/** Return every SQL call recorded across all transactions, in execution order. */
 export function allRecordedCalls(): RecordedCall[] {
   return txCallLog.flat();
 }
 
+/** Clear the fixture queue and call log. Call in `beforeEach` or `afterEach` to isolate tests. */
 export function resetTxState(): void {
   txFixturesQueue.length = 0;
   txCallLog.length = 0;
 }
 
-// Walk a Drizzle SQL object and produce a stable serialized string + params
-// list. We don't need DB-correct rendering — just stable substrings for
-// fixture matching and parameter extraction for assertions.
+/**
+ * Walk a Drizzle SQL object and produce a stable `sqlText` + `params` pair.
+ * Rendering need not be DB-correct — only stable substrings for fixture matching
+ * and parameter extraction for assertions.
+ */
 export function serializeSql(sqlObj: unknown): {
   sqlText: string;
   params: unknown[];

--- a/src/test/sql-fixture-queue.ts
+++ b/src/test/sql-fixture-queue.ts
@@ -1,0 +1,165 @@
+// Shared SQL-fixture-queue test harness used by tests that mock
+// `transactional()` from `@/db/pool`. Fixtures match against substrings of
+// serialized SQL emitted by Drizzle SQL objects, so callers don't need a live
+// Postgres to exercise the resolver's branch table.
+//
+// Vitest hoisting note: `vi.mock("@/db/pool", factory)` is hoisted per file
+// above all imports, and CANNOT be re-exported from this module — the call
+// itself must remain inline in each consumer test file. Top-level imports
+// referenced inside the factory body fail with "cannot access ... before
+// initialization", so the factory must be `async` and dynamic-import the
+// helpers it needs:
+//
+//   vi.mock("@/db/pool", async () => {
+//     const { createTransactionalFixtureMock } = await import(
+//       "@/test/sql-fixture-queue"
+//     );
+//     return { transactional: createTransactionalFixtureMock() };
+//   });
+//
+// Use `createTransactionalFixtureMock()` for pure-mock files (no real-DB
+// sub-suite) or `createTransactionalFixtureMockWithFallthrough(actual)`
+// (delegates to real `transactional` when the fixture queue is empty) for
+// mixed-mode files that interleave mocked sub-suites with real-DB sub-suites
+// guarded by `describe.skipIf(!DATABASE_URL)`.
+//
+// Module-scoped state is per worker/file (Vitest isolates test files into
+// separate module graphs by default), so two test files can each maintain
+// their own fixture queue without cross-talk.
+
+import { vi } from "vitest";
+
+export interface SqlFixture {
+  match: string | RegExp;
+  rows: unknown[];
+}
+
+export interface RecordedCall {
+  sql: string;
+  params: unknown[];
+}
+
+export interface TxFixtures {
+  rows: SqlFixture[];
+}
+
+export const txFixturesQueue: TxFixtures[] = [];
+export const txCallLog: RecordedCall[][] = [];
+
+export function setTxFixtures(rows: SqlFixture[]): void {
+  txFixturesQueue.push({ rows });
+}
+
+export function getTxLog(index: number): RecordedCall[] {
+  return txCallLog[index] ?? [];
+}
+
+export function allRecordedCalls(): RecordedCall[] {
+  return txCallLog.flat();
+}
+
+export function resetTxState(): void {
+  txFixturesQueue.length = 0;
+  txCallLog.length = 0;
+}
+
+// Walk a Drizzle SQL object and produce a stable serialized string + params
+// list. We don't need DB-correct rendering — just stable substrings for
+// fixture matching and parameter extraction for assertions.
+export function serializeSql(sqlObj: unknown): {
+  sqlText: string;
+  params: unknown[];
+} {
+  const params: unknown[] = [];
+  const parts: string[] = [];
+  const visit = (chunk: unknown) => {
+    if (chunk == null) return;
+    if (Array.isArray(chunk)) {
+      chunk.forEach(visit);
+      return;
+    }
+    if (
+      typeof chunk === "string" ||
+      typeof chunk === "number" ||
+      typeof chunk === "boolean"
+    ) {
+      // Bare primitives at the top level of queryChunks are template-literal
+      // interpolations — drizzle treats them as bound params. Static SQL
+      // text comes through as StringChunk objects (handled below).
+      params.push(chunk);
+      parts.push("$");
+      return;
+    }
+    const obj = chunk as { value?: unknown; queryChunks?: unknown[] };
+    if (Array.isArray(obj.queryChunks)) {
+      obj.queryChunks.forEach(visit);
+      return;
+    }
+    // StringChunk: { value: string[] }
+    if (Array.isArray(obj.value)) {
+      parts.push(obj.value.join(""));
+      return;
+    }
+    // Param-like: any other object with `value` is treated as a bound param
+    if (obj.value !== undefined) {
+      params.push(obj.value);
+      parts.push("$");
+      return;
+    }
+  };
+  visit(sqlObj);
+  return { sqlText: parts.join(" "), params };
+}
+
+function consumeFixturesAndRun(
+  fn: (tx: unknown) => Promise<unknown>,
+): Promise<unknown> {
+  const fixtures = txFixturesQueue.shift() ?? { rows: [] };
+  const recorded: RecordedCall[] = [];
+  txCallLog.push(recorded);
+  const tx = {
+    execute: async (sqlObj: unknown) => {
+      const { sqlText, params } = serializeSql(sqlObj);
+      recorded.push({ sql: sqlText, params });
+      const fixture = fixtures.rows.find((f) =>
+        typeof f.match === "string"
+          ? sqlText.includes(f.match)
+          : f.match.test(sqlText),
+      );
+      return { rows: fixture?.rows ?? [] };
+    },
+  };
+  return fn(tx);
+}
+
+/**
+ * Build a `vi.fn` `transactional` mock that always consumes the next entry
+ * from `txFixturesQueue` and records every `tx.execute(sql)` call. Use this
+ * in pure-mock test files (no real-DB sub-suite).
+ */
+export function createTransactionalFixtureMock() {
+  return vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+    consumeFixturesAndRun(fn),
+  );
+}
+
+/**
+ * Build a `vi.fn` `transactional` mock that falls through to the real
+ * `transactional` (from `vi.importActual`) when the fixture queue is empty.
+ * Required for mixed-mode test files that interleave mocked sub-suites with
+ * real-DB sub-suites guarded by `describe.skipIf(!DATABASE_URL)`.
+ */
+export function createTransactionalFixtureMockWithFallthrough(
+  actual: typeof import("@/db/pool"),
+) {
+  return vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+    if (txFixturesQueue.length === 0) {
+      return (
+        actual.transactional as unknown as (
+          cb: (tx: unknown) => Promise<unknown>,
+        ) => Promise<unknown>
+      )(fn);
+    }
+    return consumeFixturesAndRun(fn);
+  });
+}

--- a/src/test/sql-fixture-queue.ts
+++ b/src/test/sql-fixture-queue.ts
@@ -5,10 +5,13 @@
 //
 // Vitest hoisting note: `vi.mock("@/db/pool", factory)` is hoisted per file
 // above all imports, and CANNOT be re-exported from this module — the call
-// itself must remain inline in each consumer test file. Top-level imports
-// referenced inside the factory body fail with "cannot access ... before
-// initialization", so the factory must be `async` and dynamic-import the
-// helpers it needs:
+// itself must remain inline in each consumer test file. A factory body that
+// references a *static* top-level import races module-init: the factory runs
+// the first time `@/db/pool` is imported, which (for resolver-under-test
+// files) happens via the production import chain *before* the test file's
+// own helper imports finish evaluating, producing
+// "Cannot access '__vi_import_*__' before initialization". The robust fix is
+// an `async` factory that dynamic-imports the helpers it needs:
 //
 //   vi.mock("@/db/pool", async () => {
 //     const { createTransactionalFixtureMock } = await import(
@@ -23,9 +26,11 @@
 // mixed-mode files that interleave mocked sub-suites with real-DB sub-suites
 // guarded by `describe.skipIf(!DATABASE_URL)`.
 //
-// Module-scoped state is per worker/file (Vitest isolates test files into
-// separate module graphs by default), so two test files can each maintain
-// their own fixture queue without cross-talk.
+// Module-scoped state is safe under Vitest's default per-file isolation
+// (`isolate: true`, the project's setting): each test file evaluates the
+// module graph independently, so two files can't cross-pollute the queue.
+// Setting `isolate: false` would invalidate that — call out in review if
+// the project ever flips it.
 
 import { vi } from "vitest";
 
@@ -39,15 +44,11 @@ export interface RecordedCall {
   params: unknown[];
 }
 
-export interface TxFixtures {
-  rows: SqlFixture[];
-}
-
-export const txFixturesQueue: TxFixtures[] = [];
+export const txFixturesQueue: SqlFixture[][] = [];
 export const txCallLog: RecordedCall[][] = [];
 
 export function setTxFixtures(rows: SqlFixture[]): void {
-  txFixturesQueue.push({ rows });
+  txFixturesQueue.push(rows);
 }
 
 export function getTxLog(index: number): RecordedCall[] {
@@ -111,17 +112,22 @@ export function serializeSql(sqlObj: unknown): {
   return { sqlText: parts.join(" "), params };
 }
 
+// A fixture is matched via `find` (not consumed), so the same fixture row
+// can answer multiple `tx.execute(...)` calls within a single tx — needed
+// for resolver paths that issue the same SQL twice (e.g. recovery
+// exact-lookup). To distinguish first vs second calls, install a custom
+// `mockImplementationOnce` on the mocked `transactional`.
 function consumeFixturesAndRun(
   fn: (tx: unknown) => Promise<unknown>,
 ): Promise<unknown> {
-  const fixtures = txFixturesQueue.shift() ?? { rows: [] };
+  const fixtures = txFixturesQueue.shift() ?? [];
   const recorded: RecordedCall[] = [];
   txCallLog.push(recorded);
   const tx = {
     execute: async (sqlObj: unknown) => {
       const { sqlText, params } = serializeSql(sqlObj);
       recorded.push({ sql: sqlText, params });
-      const fixture = fixtures.rows.find((f) =>
+      const fixture = fixtures.find((f) =>
         typeof f.match === "string"
           ? sqlText.includes(f.match)
           : f.match.test(sqlText),
@@ -150,12 +156,12 @@ export function createTransactionalFixtureMock() {
  * real-DB sub-suites guarded by `describe.skipIf(!DATABASE_URL)`.
  */
 export function createTransactionalFixtureMockWithFallthrough(
-  actual: typeof import("@/db/pool"),
+  realTransactional: typeof import("@/db/pool").transactional,
 ) {
   return vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
     if (txFixturesQueue.length === 0) {
       return (
-        actual.transactional as unknown as (
+        realTransactional as unknown as (
           cb: (tx: unknown) => Promise<unknown>,
         ) => Promise<unknown>
       )(fn);

--- a/src/trigger/helpers/__tests__/database-canonical.test.ts
+++ b/src/trigger/helpers/__tests__/database-canonical.test.ts
@@ -2,77 +2,22 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EMBEDDING_DIMENSION } from "@/lib/ai/embed-constants";
 import type { ResolveTopicInput } from "@/lib/entity-resolution";
 import { EXACT_MATCH_SIMILARITY } from "@/lib/entity-resolution-constants";
+import {
+  type RecordedCall,
+  getTxLog,
+  resetTxState,
+  serializeSql,
+  setTxFixtures,
+  txCallLog,
+} from "@/test/sql-fixture-queue";
+import { buildEmbedding } from "@/test/embeddings";
 
-// ---- Transactional mock (mirrors entity-resolution.test.ts pattern) ----------
-
-const txFixturesQueue: TxFixtures[] = [];
-const txCallLog: RecordedCall[][] = [];
-
-interface TxFixtures {
-  rows: SqlFixture[];
-}
-
-interface SqlFixture {
-  match: string | RegExp;
-  rows: unknown[];
-}
-
-interface RecordedCall {
-  sql: string;
-  params: unknown[];
-}
-
-/** Register fixtures for the NEXT transactional() call. Call once per tx. */
-function setTxFixtures(rows: SqlFixture[]): void {
-  txFixturesQueue.push({ rows });
-}
-
-function getTxLog(index: number): RecordedCall[] {
-  return txCallLog[index] ?? [];
-}
-
-function serializeSql(sqlObj: unknown): { sqlText: string; params: unknown[] } {
-  const params: unknown[] = [];
-  const parts: string[] = [];
-  const visit = (chunk: unknown) => {
-    if (chunk == null) return;
-    if (Array.isArray(chunk)) {
-      chunk.forEach(visit);
-      return;
-    }
-    if (
-      typeof chunk === "string" ||
-      typeof chunk === "number" ||
-      typeof chunk === "boolean"
-    ) {
-      params.push(chunk);
-      parts.push("$");
-      return;
-    }
-    const obj = chunk as { value?: unknown; queryChunks?: unknown[] };
-    if (Array.isArray(obj.queryChunks)) {
-      obj.queryChunks.forEach(visit);
-      return;
-    }
-    if (Array.isArray(obj.value)) {
-      parts.push(obj.value.join(""));
-      return;
-    }
-    if (obj.value !== undefined) {
-      params.push(obj.value);
-      parts.push("$");
-      return;
-    }
-  };
-  visit(sqlObj);
-  return { sqlText: parts.join(" "), params };
-}
-
+// Test-file-local recording tx used by step-counter custom mocks (e.g. the
+// "recovery exact-lookup" case below). Pushes its recorded-call array into
+// the shared `txCallLog` so the test can introspect via `getTxLog(0)`.
 type ResolveRows = (sqlText: string, params: unknown[]) => unknown[];
-
 function createRecordingTx(resolveRows: ResolveRows): {
   execute: (sqlObj: unknown) => Promise<{ rows: unknown[] }>;
 } {
@@ -87,20 +32,13 @@ function createRecordingTx(resolveRows: ResolveRows): {
   };
 }
 
-vi.mock("@/db/pool", () => ({
-  transactional: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
-    const fixtures = txFixturesQueue.shift() ?? { rows: [] };
-    const tx = createRecordingTx((sqlText) => {
-      const fixture = fixtures.rows.find((f) =>
-        typeof f.match === "string"
-          ? sqlText.includes(f.match)
-          : f.match.test(sqlText),
-      );
-      return fixture?.rows ?? [];
-    });
-    return fn(tx);
-  }),
-}));
+// ---- Transactional mock (delegates to shared fixture-queue harness) ---------
+
+vi.mock("@/db/pool", async () => {
+  const { createTransactionalFixtureMock } =
+    await import("@/test/sql-fixture-queue");
+  return { transactional: createTransactionalFixtureMock() };
+});
 
 // These modules are not used by the new helpers but are imported transitively
 // through database.ts — stub them to prevent side-effect errors.
@@ -117,10 +55,6 @@ vi.mock("drizzle-orm", async (importOriginal) => {
 });
 
 // ---- Helpers -----------------------------------------------------------------
-
-function buildEmbedding(): number[] {
-  return Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001);
-}
 
 function makeInput(
   overrides: Partial<ResolveTopicInput> = {},
@@ -147,13 +81,11 @@ function findCalls(haystack: RecordedCall[], needle: string): RecordedCall[] {
 // ---- Tests -------------------------------------------------------------------
 
 beforeEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
 });
 
 afterEach(() => {
-  txFixturesQueue.length = 0;
-  txCallLog.length = 0;
+  resetTxState();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
Closes #421.

## Summary

- Two new test-only modules under `src/test/`:
  - `sql-fixture-queue.ts` — SQL-fixture-queue harness (state, types, helpers, two factory builders: standard + fall-through-to-real-DB).
  - `embeddings.ts` — `STABLE_EMBEDDING` constant + `buildEmbedding()` helper.
- All 5 callsites listed in the issue migrated to import from the shared modules:
  - `src/lib/__tests__/entity-resolution.test.ts`
  - `src/lib/__tests__/entity-resolution.golden.test.ts` (preserves the fall-through `vi.importActual` pattern)
  - `src/lib/__tests__/entity-resolution.concurrent.test.ts`
  - `src/trigger/helpers/__tests__/database-canonical.test.ts`
  - `src/db/__tests__/canonical-topic-digests.schema.test.ts`
- No production-code changes (verifiable via `git diff main -- src/lib/entity-resolution*.ts src/trigger/helpers/database.ts src/db/schema.ts vitest.config.ts`).

### Vitest hoisting note

The `vi.mock("@/db/pool", factory)` call must stay inline per consumer (Vitest hoists it above all imports). When the factory body references a *static* top-level import, the production-code import chain pulls `@/db/pool` before the test file's own helper imports finish evaluating, producing `Cannot access '__vi_import_*__' before initialization`. The robust fix is an `async` factory that dynamic-imports the harness — the same pattern the golden test already used for `vi.importActual`. Documented in the harness header.

## Out of scope (legitimately deferred per checklist §7)

- `src/trigger/helpers/__tests__/canonical-merge.test.ts` has a similar-shape but **semantically different** harness (one-shot `splice`-on-match instead of `find`, per-tx `_calls` array on the tx object instead of cumulative `txCallLog`, supports caller-supplied `opts.tx`). Issue #421 explicitly scopes only 5 files, the PR does not modify it, and migrating would require widening the shared API rather than mechanical extraction. Worth a follow-up that decides whether to widen the harness or keep the canonical-merge variant bespoke.
- `src/trigger/helpers/__tests__/resolve-topics.test.ts:52` has its own `buildEmbedding(seed)` that produces a per-index gradient (`seed + i * 0.000001`), not a constant fill. Different signature; legitimately deferrable until a callsite needs the constant variant.
- `src/db/__tests__/canonical-topics.schema.test.ts:21` and `src/lib/admin/__tests__/topic-queries-episode-count.regression.test.ts:13` each inline `Array.from({ length: EMBEDDING_DIMENSION }, () => 0.001)`. Both files predate this PR and are outside its stated scope; could be swept in a follow-up that picks up new callsites.

## Test plan

- [x] `bun run test` — 2678 passed / 35 skipped (matches main; no regressions).
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean.
- [x] `bun run build` — clean.
- [x] `doppler run -- bun run test entity-resolution.golden` — 5 passed (real-DB `concurrent-insert-race` still hits Postgres via the fall-through).
- [x] `doppler run -- bun run test entity-resolution.concurrent` — 3 passed (real-DB).
- [x] `doppler run -- bun run test canonical-topic-digests` — 5 passed (real-DB schema constraints).
- [x] `git grep -n "Array.from({ length: EMBEDDING_DIMENSION"` returns no hits in any of the 5 migrated files (only `src/test/embeddings.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure across multiple test files to utilize centralized test helpers for managing embeddings and SQL fixtures.

* **Chores**
  * Consolidated duplicated test setup, teardown, and mocking logic across the test suite, reducing code duplication and improving test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->