### PR TITLE
chore: wrap getEpisodeTopicOverlap in ActionResult envelope

### DIFF
--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -875,7 +875,7 @@ describe("getEpisodeTopicOverlap", () => {
     vi.resetModules();
   });
 
-  it("returns null result when not authenticated", async () => {
+  it("returns Unauthorized when not authenticated", async () => {
     mockAuth.mockResolvedValue({ userId: null });
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
@@ -883,11 +883,10 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-123"),
     );
 
-    expect(result.label).toBeNull();
-    expect(result.overlapCount).toBe(0);
+    expect(result).toEqual({ success: false, error: "Unauthorized" });
   });
 
-  it("returns null result when episode is not found in DB", async () => {
+  it("returns empty overlap when episode is not found in DB", async () => {
     // limit returns empty — episode not in DB
     mockLimit.mockResolvedValue([]);
 
@@ -896,7 +895,7 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-999"),
     );
 
-    expect(result.label).toBeNull();
+    expect(result).toMatchObject({ success: true, data: { label: null } });
   });
 
   it("returns computed overlap for a found episode", async () => {
@@ -928,12 +927,17 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-42"),
     );
 
-    expect(result.label).toBe("You've heard 4 similar episodes");
-    expect(result.overlapCount).toBe(4);
-    expect(result.topOverlapTopic).toBe("Leadership");
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        label: "You've heard 4 similar episodes",
+        overlapCount: 4,
+        topOverlapTopic: "Leadership",
+      },
+    });
   });
 
-  it("returns null result when episode has no topic tags", async () => {
+  it("returns empty overlap when episode has no topic tags", async () => {
     mockLimit.mockResolvedValue([{ id: 42 }]);
     mockUnion.mockResolvedValue([
       { episodeId: 1 },
@@ -956,10 +960,10 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-42"),
     );
 
-    expect(result.label).toBeNull();
+    expect(result).toMatchObject({ success: true, data: { label: null } });
   });
 
-  it("returns null result on DB error (graceful fallback)", async () => {
+  it("returns error result on DB error", async () => {
     mockLimit.mockRejectedValue(new Error("DB failure"));
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
@@ -967,8 +971,10 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-42"),
     );
 
-    expect(result.label).toBeNull();
-    expect(result.overlapCount).toBe(0);
+    expect(result).toEqual({
+      success: false,
+      error: "Failed to compute episode topic overlap",
+    });
   });
 });
 

--- a/src/app/actions/__tests__/dashboard.test.ts
+++ b/src/app/actions/__tests__/dashboard.test.ts
@@ -4,6 +4,7 @@ import {
   asPodcastIndexEpisodeId,
   type PodcastIndexEpisodeId,
 } from "@/types/ids";
+import { EMPTY_OVERLAP_RESULT } from "@/lib/topic-overlap";
 
 // Mock Clerk auth
 const mockAuth = vi.fn();
@@ -886,6 +887,22 @@ describe("getEpisodeTopicOverlap", () => {
     expect(result).toEqual({ success: false, error: "Unauthorized" });
   });
 
+  it("returns Unauthorized for unauthenticated callers even with falsy input (auth-first)", async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("" as PodcastIndexEpisodeId);
+
+    expect(result).toEqual({ success: false, error: "Unauthorized" });
+  });
+
+  it("returns empty overlap for falsy podcastIndexEpisodeId", async () => {
+    const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
+    const result = await getEpisodeTopicOverlap("" as PodcastIndexEpisodeId);
+
+    expect(result).toEqual({ success: true, data: EMPTY_OVERLAP_RESULT });
+  });
+
   it("returns empty overlap when episode is not found in DB", async () => {
     // limit returns empty — episode not in DB
     mockLimit.mockResolvedValue([]);
@@ -895,7 +912,7 @@ describe("getEpisodeTopicOverlap", () => {
       asPodcastIndexEpisodeId("ep-999"),
     );
 
-    expect(result).toMatchObject({ success: true, data: { label: null } });
+    expect(result).toEqual({ success: true, data: EMPTY_OVERLAP_RESULT });
   });
 
   it("returns computed overlap for a found episode", async () => {
@@ -947,20 +964,14 @@ describe("getEpisodeTopicOverlap", () => {
     mockBuildUserTopicProfile.mockReturnValue(new Map());
     // No topics for this episode
     mockWhere.mockResolvedValue([]);
-    mockComputeTopicOverlap.mockReturnValue({
-      overlapCount: 0,
-      topOverlapTopic: null,
-      isNewTopic: false,
-      label: null,
-      labelKind: null,
-    });
+    mockComputeTopicOverlap.mockReturnValue(EMPTY_OVERLAP_RESULT);
 
     const { getEpisodeTopicOverlap } = await import("@/app/actions/dashboard");
     const result = await getEpisodeTopicOverlap(
       asPodcastIndexEpisodeId("ep-42"),
     );
 
-    expect(result).toMatchObject({ success: true, data: { label: null } });
+    expect(result).toEqual({ success: true, data: EMPTY_OVERLAP_RESULT });
   });
 
   it("returns error result on DB error", async () => {

--- a/src/app/actions/dashboard.ts
+++ b/src/app/actions/dashboard.ts
@@ -43,6 +43,7 @@ import {
   HIGH_OVERLAP_THRESHOLD,
   type CanonicalOverlapResult,
   type CanonicalOverlapTargetRow,
+  type TopicOverlapResult,
 } from "@/lib/topic-overlap";
 import { withAuthAction } from "@/lib/auth-wrapper";
 import { type ActionResult } from "@/types/action-result";
@@ -525,52 +526,64 @@ export async function getRecommendedEpisodes(
 // Get topic overlap for a single episode — used by the episode detail page.
 export async function getEpisodeTopicOverlap(
   podcastIndexEpisodeId: PodcastIndexEpisodeId,
-) {
-  if (!podcastIndexEpisodeId) return EMPTY_OVERLAP_RESULT;
+): Promise<ActionResult<TopicOverlapResult>> {
+  return withAuthAction(async (userId) => {
+    if (!podcastIndexEpisodeId)
+      return { success: true, data: EMPTY_OVERLAP_RESULT };
 
-  const { userId } = await auth();
-  if (!userId) return EMPTY_OVERLAP_RESULT;
+    try {
+      // Parallelize: episode lookup and user profile construction are independent
+      const [episodeRow, profileResult] = await Promise.all([
+        db
+          .select({ id: episodes.id })
+          .from(episodes)
+          .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
+          .limit(1),
+        fetchUserTopicProfile(userId),
+      ]);
 
-  try {
-    // Parallelize: episode lookup and user profile construction are independent
-    const [episodeRow, profileResult] = await Promise.all([
-      db
-        .select({ id: episodes.id })
-        .from(episodes)
-        .where(eq(episodes.podcastIndexId, podcastIndexEpisodeId))
-        .limit(1),
-      fetchUserTopicProfile(userId),
-    ]);
+      if (episodeRow.length === 0)
+        return { success: true, data: EMPTY_OVERLAP_RESULT };
+      const episodeDbId = episodeRow[0].id;
+      const { profile: userProfile, totalConsumed } = profileResult;
 
-    if (episodeRow.length === 0) return EMPTY_OVERLAP_RESULT;
-    const episodeDbId = episodeRow[0].id;
-    const { profile: userProfile, totalConsumed } = profileResult;
+      const epTopicRows = await db
+        .select({
+          topic: episodeTopics.topic,
+          relevance: episodeTopics.relevance,
+          topicRank: episodeTopics.topicRank,
+        })
+        .from(episodeTopics)
+        .where(eq(episodeTopics.episodeId, episodeDbId))
+        .orderBy(desc(episodeTopics.relevance));
 
-    const epTopicRows = await db
-      .select({
-        topic: episodeTopics.topic,
-        relevance: episodeTopics.relevance,
-        topicRank: episodeTopics.topicRank,
-      })
-      .from(episodeTopics)
-      .where(eq(episodeTopics.episodeId, episodeDbId))
-      .orderBy(desc(episodeTopics.relevance));
+      const epTopics = epTopicRows.map((r) => ({
+        topic: r.topic,
+        relevance: r.relevance,
+      }));
+      const bestRank = epTopicRows.reduce<number | null>((best, r) => {
+        if (r.topicRank === null) return best;
+        if (best === null) return r.topicRank;
+        return Math.min(best, r.topicRank);
+      }, null);
 
-    const epTopics = epTopicRows.map((r) => ({
-      topic: r.topic,
-      relevance: r.relevance,
-    }));
-    const bestRank = epTopicRows.reduce<number | null>((best, r) => {
-      if (r.topicRank === null) return best;
-      if (best === null) return r.topicRank;
-      return Math.min(best, r.topicRank);
-    }, null);
-
-    return computeTopicOverlap(userProfile, epTopics, totalConsumed, bestRank);
-  } catch (err) {
-    console.error("Failed to compute episode topic overlap:", err);
-    return EMPTY_OVERLAP_RESULT;
-  }
+      return {
+        success: true,
+        data: computeTopicOverlap(
+          userProfile,
+          epTopics,
+          totalConsumed,
+          bestRank,
+        ),
+      };
+    } catch (err) {
+      console.error("Failed to compute episode topic overlap:", err);
+      return {
+        success: false,
+        error: "Failed to compute episode topic overlap",
+      };
+    }
+  });
 }
 
 // Get stats for the dashboard

--- a/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
@@ -75,11 +75,14 @@ vi.mock("@/components/episodes/episode-transcript-fetch-button", () => ({
 vi.mock("@/components/episodes/summary-display", () => ({
   SummaryDisplay: ({
     onGenerateSummary,
+    overlapLabel,
   }: {
     onGenerateSummary?: () => void;
+    overlapLabel?: string | null;
   }) => (
     <div data-testid="summary-display">
       can-generate:{String(Boolean(onGenerateSummary))}
+      {overlapLabel && <span data-testid="overlap-label">{overlapLabel}</span>}
     </div>
   ),
 }));
@@ -204,6 +207,44 @@ describe("AuthenticatedEpisodeDetail", () => {
       expect(mocks.getEpisodeTopicOverlap).toHaveBeenCalled(),
     );
     // Component renders without errors; overlap label stays absent
+  });
+
+  it("clears overlap label when getEpisodeTopicOverlap transitions from success to { success: false }", async () => {
+    mocks.getEpisodeTopicOverlap
+      .mockResolvedValueOnce({
+        success: true,
+        data: { label: "Strong Match", labelKind: "match" },
+      })
+      .mockResolvedValueOnce({ success: false, error: "Unauthorized" });
+
+    const { rerender } = render(
+      <AuthenticatedEpisodeDetail
+        episodeId="rss-abc"
+        userId="user-1"
+        isAdmin={false}
+      />,
+    );
+
+    await screen.findByRole("heading", { name: "RSS Episode" });
+    await waitFor(() =>
+      expect(screen.getByTestId("overlap-label")).toHaveTextContent(
+        "Strong Match",
+      ),
+    );
+
+    // Swap to a new episodeId so the overlap effect re-runs with the failure mock
+    stubEpisodeFetch({ id: "rss-xyz" });
+    rerender(
+      <AuthenticatedEpisodeDetail
+        episodeId="rss-xyz"
+        userId="user-1"
+        isAdmin={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("overlap-label")).not.toBeInTheDocument(),
+    );
   });
 
   it("hides numeric-only processing actions for rss episodes", async () => {

--- a/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
@@ -174,8 +174,8 @@ describe("AuthenticatedEpisodeDetail", () => {
     vi.clearAllMocks();
     mocks.isEpisodeSaved.mockResolvedValue(false);
     mocks.getEpisodeTopicOverlap.mockResolvedValue({
-      label: null,
-      labelKind: null,
+      success: true,
+      data: { label: null, labelKind: null },
     });
     mocks.getCachedEpisode.mockResolvedValue(undefined);
     stubEpisodeFetch();

--- a/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
+++ b/src/components/episodes/__tests__/authenticated-episode-detail.test.tsx
@@ -185,6 +185,27 @@ describe("AuthenticatedEpisodeDetail", () => {
     vi.unstubAllGlobals();
   });
 
+  it("handles getEpisodeTopicOverlap returning { success: false } gracefully", async () => {
+    mocks.getEpisodeTopicOverlap.mockResolvedValue({
+      success: false,
+      error: "Unauthorized",
+    });
+
+    render(
+      <AuthenticatedEpisodeDetail
+        episodeId="rss-abc"
+        userId="user-1"
+        isAdmin={false}
+      />,
+    );
+
+    await screen.findByRole("heading", { name: "RSS Episode" });
+    await waitFor(() =>
+      expect(mocks.getEpisodeTopicOverlap).toHaveBeenCalled(),
+    );
+    // Component renders without errors; overlap label stays absent
+  });
+
   it("hides numeric-only processing actions for rss episodes", async () => {
     render(
       <AuthenticatedEpisodeDetail

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -302,10 +302,10 @@ export function AuthenticatedEpisodeDetail({
     let ignore = false;
     getEpisodeTopicOverlap(episodeIdBranded)
       .then((result) => {
-        if (!ignore)
+        if (!ignore && result.success)
           setOverlapResult({
-            label: result.label,
-            labelKind: result.labelKind,
+            label: result.data.label,
+            labelKind: result.data.labelKind,
           });
       })
       .catch(() => {

--- a/src/components/episodes/authenticated-episode-detail.tsx
+++ b/src/components/episodes/authenticated-episode-detail.tsx
@@ -302,11 +302,16 @@ export function AuthenticatedEpisodeDetail({
     let ignore = false;
     getEpisodeTopicOverlap(episodeIdBranded)
       .then((result) => {
-        if (!ignore && result.success)
-          setOverlapResult({
-            label: result.data.label,
-            labelKind: result.data.labelKind,
-          });
+        if (!ignore) {
+          if (result.success) {
+            setOverlapResult({
+              label: result.data.label,
+              labelKind: result.data.labelKind,
+            });
+          } else {
+            setOverlapResult({ label: null, labelKind: null });
+          }
+        }
       })
       .catch(() => {
         // Non-critical: overlap label is a presentation-only enhancement


### PR DESCRIPTION
## Summary

- Wraps `getEpisodeTopicOverlap` in `withAuthAction` so unauthenticated callers receive `{ success: false, error: "Unauthorized" }` instead of the silent `EMPTY_OVERLAP_RESULT` fallback
- DB errors now surface as `{ success: false, error: "..." }` rather than being swallowed
- Fixes stale overlap badge regression: adds `else { setOverlapResult({ label: null, labelKind: null }) }` so a prior successful badge is cleared when the action subsequently returns an error
- Updates the call site in `authenticated-episode-detail.tsx` to unwrap `result.data` behind a `result.success` guard
- Rewrites and expands the test suite: 5 assertion updates + 3 new tests (auth-first contract, falsy ID, component `success: false` path)

Closes #441

## Test plan

- [ ] `getEpisodeTopicOverlap` returns `Promise<ActionResult<TopicOverlapResult>>`
- [ ] Unauthenticated call → `{ success: false, error: "Unauthorized" }`
- [ ] Auth check runs before falsy-ID guard (auth-first contract test added)
- [ ] Falsy `podcastIndexEpisodeId` → `{ success: true, data: EMPTY_OVERLAP_RESULT }`
- [ ] DB error → `{ success: false, error: "Failed to compute episode topic overlap" }`
- [ ] `{ success: false }` response clears any stale overlap badge in component
- [ ] `bun run format:check && bun run lint && bun run test && bun run build` all pass (2971 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for episode topic overlap computations
  * Improved authorization checks for accessing episode topic data
  * Fixed handling of invalid or missing episode identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->