### PR TITLE
docs: surface drizzle prod-push convention in AGENTS.md + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- 1-3 bullets focused on the "why" -->
+
+## Test plan
+
+<!-- Bulleted markdown checklist of tests / verifications -->
+
+<!--
+🛢️ If this PR adds a file under `drizzle/`, also add a `## Production deploy note`
+section. Preview branches auto-migrate; production does not. Per ADR-002:
+
+    doppler run --config prd -- bunx drizzle-kit push
+
+See PRs #340, #408, #418, #446 for established phrasings.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,10 +7,6 @@
 <!-- Bulleted markdown checklist of tests / verifications -->
 
 <!--
-🛢️ If this PR adds a file under `drizzle/`, also add a `## Production deploy note`
-section. Preview branches auto-migrate; production does not. Per ADR-002:
-
-    doppler run --config prd -- bunx drizzle-kit push
-
-See PRs #340, #408, #418, #446 for established phrasings.
+If this PR adds a file under `drizzle/`, also add a `## Production deploy note`
+section. See AGENTS.md / ADR-002 for the canonical command.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 <!-- Bulleted markdown checklist of tests / verifications -->
 
 <!--
-If this PR adds a file under `drizzle/`, also add a `## Production deploy note`
-section. See AGENTS.md / ADR-002 for the canonical command.
+If this PR adds a `drizzle/*.sql` file, also add a `## Production deploy note`
+section. See [ADR-002](../docs/adr/002-preview-database-migrations.md) for the
+canonical command.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ bun run test:coverage  # Run tests with coverage (80% line threshold, see vitest
 bun run storybook      # Launch Storybook dev server (port 6006)
 bun run build-storybook # Build static Storybook
 bun run db:generate    # Generate Drizzle migrations
-bun run db:push        # Push schema to database
+bun run db:push        # Push schema to dev DB (uses default Doppler config)
 bun run db:studio      # Open Drizzle Studio (DB browser)
 bun run trigger:dev    # Start Trigger.dev dev server
 bun run trigger:deploy # Deploy tasks to Trigger.dev Cloud
@@ -69,6 +69,7 @@ bun run trigger:deploy # Deploy tasks to Trigger.dev Cloud
 - Unit tests live in `__tests__/` directories co-located with source. Stories live alongside components as `*.stories.tsx` files.
 - The pre-commit hook (Husky) automatically runs format:check, lint, and tests on commit.
 - ADRs live in `docs/adr/` — read the relevant ADR before modifying areas it covers.
+- **Drizzle migrations require a manual prod push.** Preview deploys auto-run `drizzle-kit push --force` via `vercel-build`; production does not. After merging a migration-bearing PR, run `doppler run --config prd -- bunx drizzle-kit push`. PRs that add a `drizzle/*.sql` file MUST include a "Production deploy note" in the PR body. See [ADR-002](docs/adr/002-preview-database-migrations.md).
 - **UI verification (agents):** Vitest/RTL runs in jsdom and can't catch real rendering, layout, or interaction bugs. For any UI work, **invoke the `agent-browser` skill** to test the web app in a real browser:
   - **App flows / pages:** start `bun run dev` (port 3000), then use `agent-browser` to navigate to `http://localhost:3000`, click through the flow, fill forms, and take screenshots.
   - **Isolated components:** start `bun run storybook` (port 6006), then use `agent-browser` to open `http://localhost:6006`, navigate to the relevant story, and screenshot it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ bun run trigger:deploy # Deploy tasks to Trigger.dev Cloud
 - Unit tests live in `__tests__/` directories co-located with source. Stories live alongside components as `*.stories.tsx` files.
 - The pre-commit hook (Husky) automatically runs format:check, lint, and tests on commit.
 - ADRs live in `docs/adr/` — read the relevant ADR before modifying areas it covers.
-- **Drizzle migrations require a manual prod push.** Preview deploys auto-run `drizzle-kit push --force` via `vercel-build`; production does not. After merging a migration-bearing PR, run `doppler run --config prd -- bunx drizzle-kit push`. PRs that add a `drizzle/*.sql` file MUST include a "Production deploy note" in the PR body. See [ADR-002](docs/adr/002-preview-database-migrations.md).
+- **Drizzle migrations: manual prod push after merge.** PRs that add a `drizzle/*.sql` file MUST include a `## Production deploy note` section in the PR body. See [ADR-002](docs/adr/002-preview-database-migrations.md) for the canonical command and rationale.
 - **UI verification (agents):** Vitest/RTL runs in jsdom and can't catch real rendering, layout, or interaction bugs. For any UI work, **invoke the `agent-browser` skill** to test the web app in a real browser:
   - **App flows / pages:** start `bun run dev` (port 3000), then use `agent-browser` to navigate to `http://localhost:3000`, click through the flow, fill forms, and take screenshots.
   - **Isolated components:** start `bun run storybook` (port 6006), then use `agent-browser` to open `http://localhost:6006`, navigate to the relevant story, and screenshot it.

--- a/docs/adr/002-preview-database-migrations.md
+++ b/docs/adr/002-preview-database-migrations.md
@@ -45,7 +45,7 @@ Remove the Vercel Neon integration and manage all branch creation, DATABASE_URL 
 - **Idempotent.** `drizzle-kit push` is safe to run multiple times — it only applies changes that differ from the current schema. Multiple queued builds for the same PR won't conflict.
 - **No race conditions.** The migration runs synchronously before `next build`, so the schema is guaranteed to be ready before any server-side code executes.
 - **Vercel integration handles lifecycle.** Branch creation on PR open and cleanup on PR merge are already managed by the Neon Vercel integration — no custom GitHub Actions needed.
-- **`--force` is safe for preview.** Preview Neon branches are ephemeral and isolated. The `--force` flag prevents interactive prompts in the non-TTY Vercel build environment. Production deployments skip the migration entirely (manual control via `bun run db:push`).
+- **`--force` is safe for preview.** Preview Neon branches are ephemeral and isolated. The `--force` flag prevents interactive prompts in the non-TTY Vercel build environment. Production deployments skip the migration entirely — see the Production deploy section below.
 
 ## Implementation
 
@@ -53,9 +53,19 @@ Remove the Vercel Neon integration and manage all branch creation, DATABASE_URL 
 - Add a `vercel-build` script to `package.json` that conditionally runs `drizzle-kit push --force` for preview environments before `next build`.
 - Vercel auto-detects the `vercel-build` script when the dashboard build command is not overridden.
 
+## Production deploy (manual, post-merge)
+
+Production schema is **not** auto-migrated. After a migration-bearing PR merges to `main`, run:
+
+```bash
+doppler run --config prd -- bunx drizzle-kit push
+```
+
+Note: `bun run db:push` is **not** equivalent — that script uses the default Doppler config (typically dev). The explicit `--config prd` form is required for the production database.
+
 ## Consequences
 
-- Production schema migrations remain a manual step (`bun run db:push` locally or via a dedicated migration workflow).
+- Production schema migrations remain a manual post-merge step (canonical command above).
 - The `NEON_API_KEY` GitHub Actions secret and `NEON_PROJECT_ID` variable can be removed if no other workflows need them.
 - Orphaned `preview/pr-*` Neon branches from the old workflow will expire via their 14-day TTL or can be manually deleted.
 - Migration visibility moves from a GitHub Actions check to Vercel build logs.


### PR DESCRIPTION
## Summary

- Add a one-liner to `AGENTS.md` Testing-instructions list pointing at ADR-002 for the manual prod `drizzle-kit push` step, and require migration-bearing PRs to include a `## Production deploy note` section.
- Add a minimal `.github/pull_request_template.md` (Summary + Test plan headers) with an HTML-comment migration reminder. The comment is invisible in the rendered PR body, so non-migration PRs carry zero boilerplate.
- Refine the `db:push` script comment in AGENTS.md to clarify it targets the dev DB (uses default Doppler config).

## Why

ADR-002 documents the convention but it wasn't surfaced where contributors look first. Recent migration-bearing PRs (#340, #408, #418, #446) carry a "Production deploy note" callout, while others (#432, #433, #437, #416, #414) shipped migrations without one — relying on the merging maintainer to remember. Surfacing the rule in AGENTS.md (loaded by every agent every session) and in the PR template (visible at PR-open time) closes the gap with minimal noise.

## Test plan

- [x] `bun run format`, `bun run lint`, `bun run test`, `bun run build`, `bun run build-storybook` clean locally
- [ ] Verify the new template renders cleanly in this PR's body — Summary/Test plan headers visible, migration reminder hidden behind the HTML comment
- [ ] Verify the AGENTS.md addition reads naturally in the Testing-instructions list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a PR template prompting concise summaries, test plans, and a required “Production deploy note” for PRs that introduce DB migration files.

* **Documentation**
  * Clarified developer workflow: preview builds now run migrations during the preview build step; production requires an explicit post-merge deploy step. Noted that a local DB-push command uses the default config and is not equivalent to the production deploy step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/450)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->