### PR TITLE
feat: transcript-extractor module scaffolding (registry + linkSuffixExtractor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Internal `transcript-extractors` registry scaffolding (`src/trigger/helpers/transcript-extractors/`) with the shared `linkSuffixExtractor` factory. Empty registry — specific extractors and pipeline wiring follow in #428/#429. (#427)
 - `episode_link` and `transcript_extractor` columns on `episodes`, plus `'podcast-site'` accepted by `transcript_source_enum`. Persists PodcastIndex `link` on episode insert across poll/processing/summary paths. (#426)
 - Topic detail page (`/topic/[id]`) with multi-episode digest panel, episode list with `?unheard` filter, and 5 nearest related-topic chips. Server-component render auto-triggers digest synthesis (token bundled per ADR-053) when eligible-but-empty, then live-streams via `useRealtimeRun`. Below the `MIN_DERIVED_COUNT_FOR_DIGEST` threshold a `<TopicEmptyState>` explains the unlock count instead. Adds `getTopicDetailData` and `triggerTopicDigestRefresh` server actions and four new components under `src/components/topics/` (#399, ADR-053).
 - Canonical-topic overlap indicator on episode cards, summary display, dashboard recommendations, and episode detail page. Shows `CanonicalOverlapIndicator` ("You've heard N episodes on <topic>" / "New: <topic>") with canonical precedence over the legacy category-level fallback; indicator is absent when no data is available. Hydrated server-side on the podcast detail page (RSC) and client-side on library and collection pages via `fetchCanonicalOverlapsBatched`. (#396)

--- a/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@trigger.dev/sdk", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { logger } from "@trigger.dev/sdk";
+import {
+  register,
+  runPodcastExtractor,
+  __resetRegistry,
+} from "@/trigger/helpers/transcript-extractors";
+import type {
+  Extractor,
+  ExtractorContext,
+} from "@/trigger/helpers/transcript-extractors/types";
+
+const makeCtx = (podcastIndexId: string = "pod1"): ExtractorContext => ({
+  episode: {
+    podcastIndexId: "ep1",
+    title: "Ep",
+    link: "https://example.com/ep",
+    rssGuid: null,
+  },
+  podcast: { podcastIndexId, title: "Pod" },
+});
+
+beforeEach(() => {
+  __resetRegistry();
+  vi.clearAllMocks();
+});
+
+describe("runPodcastExtractor", () => {
+  it("returns undefined and does not warn when no extractor is registered", async () => {
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+  });
+
+  it("returns { transcript, extractorId } when a registered extractor returns a non-empty string", async () => {
+    const extractor: Extractor = {
+      id: "test-extractor",
+      extract: vi.fn().mockResolvedValue("transcript-text"),
+    };
+    register("pod1", extractor);
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toEqual({
+      transcript: "transcript-text",
+      extractorId: "test-extractor",
+    });
+  });
+
+  it("logs at warn level and returns undefined when extractor throws", async () => {
+    const extractor: Extractor = {
+      id: "throws-extractor",
+      extract: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+    register("pod1", extractor);
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining("[transcript-extractors]"),
+      expect.objectContaining({ extractorId: "throws-extractor" }),
+    );
+  });
+
+  it("returns undefined when extractor resolves to undefined", async () => {
+    const extractor: Extractor = {
+      id: "undefined-extractor",
+      extract: vi.fn().mockResolvedValue(undefined),
+    };
+    register("pod1", extractor);
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when extractor resolves to empty string", async () => {
+    const extractor: Extractor = {
+      id: "empty-extractor",
+      extract: vi.fn().mockResolvedValue(""),
+    };
+    register("pod1", extractor);
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+  });
+
+  it("clears registry between tests via __resetRegistry", async () => {
+    const extractor: Extractor = {
+      id: "cleared-extractor",
+      extract: vi.fn().mockResolvedValue("text"),
+    };
+    register("pod1", extractor);
+    // Simulate what beforeEach does — if registry was cleared, this is a miss
+    __resetRegistry();
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+  });
+
+  it("keys off ctx.podcast.podcastIndexId — misses on wrong key, hits on correct key", async () => {
+    const extractor: Extractor = {
+      id: "keyed-extractor",
+      extract: vi.fn().mockResolvedValue("keyed-text"),
+    };
+    register("podA", extractor);
+    expect(await runPodcastExtractor(makeCtx("podB"))).toBeUndefined();
+    expect(await runPodcastExtractor(makeCtx("podA"))).toEqual({
+      transcript: "keyed-text",
+      extractorId: "keyed-extractor",
+    });
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
@@ -62,6 +62,24 @@ describe("runPodcastExtractor", () => {
       expect.objectContaining({
         extractorId: "throws-extractor",
         podcastIndexId: "pod1",
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("logs warn with raw value and returns undefined when extractor throws a non-Error value", async () => {
+    const extractor: Extractor = {
+      id: "throws-string-extractor",
+      extract: vi.fn().mockRejectedValue("boom"),
+    };
+    register("pod1", extractor);
+    const result = await runPodcastExtractor(makeCtx());
+    expect(result).toBeUndefined();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "[transcript-extractors] extractor threw",
+      expect.objectContaining({
+        extractorId: "throws-string-extractor",
+        podcastIndexId: "pod1",
         error: "boom",
       }),
     );

--- a/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/index.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTriggerSdkMock } from "@/test/mocks/trigger-sdk";
 
-vi.mock("@trigger.dev/sdk", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
+vi.mock("@trigger.dev/sdk", () => createTriggerSdkMock());
 
 import { logger } from "@trigger.dev/sdk";
 import {
@@ -59,8 +58,12 @@ describe("runPodcastExtractor", () => {
     const result = await runPodcastExtractor(makeCtx());
     expect(result).toBeUndefined();
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-      expect.stringContaining("[transcript-extractors]"),
-      expect.objectContaining({ extractorId: "throws-extractor" }),
+      "[transcript-extractors] extractor threw",
+      expect.objectContaining({
+        extractorId: "throws-extractor",
+        podcastIndexId: "pod1",
+        error: "boom",
+      }),
     );
   });
 

--- a/src/trigger/helpers/transcript-extractors/__tests__/link-suffix.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/link-suffix.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@/lib/security", () => ({
-  safeFetch: vi.fn(),
+vi.mock("@/trigger/helpers/transcript", () => ({
+  fetchTranscriptFromUrl: vi.fn(),
 }));
 
-import { safeFetch } from "@/lib/security";
+import { fetchTranscriptFromUrl } from "@/trigger/helpers/transcript";
 import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
 import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
 
@@ -19,7 +19,9 @@ beforeEach(() => {
 
 describe("linkSuffixExtractor", () => {
   it("appends suffix to the episode link", async () => {
-    vi.mocked(safeFetch).mockResolvedValue("plain transcript text");
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(
+      "plain transcript text",
+    );
     const extractor = linkSuffixExtractor({
       id: "transistor",
       suffix: "/transcript",
@@ -27,15 +29,14 @@ describe("linkSuffixExtractor", () => {
     const result = await extractor.extract(
       makeCtx("https://share.transistor.fm/s/abc123"),
     );
-    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
       "https://share.transistor.fm/s/abc123/transcript",
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(result).toBe("plain transcript text");
   });
 
   it("replaces trailing slash before appending suffix when replaceTrailingSlash is true", async () => {
-    vi.mocked(safeFetch).mockResolvedValue("lex transcript");
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue("lex transcript");
     const extractor = linkSuffixExtractor({
       id: "lex-fridman",
       suffix: "-transcript",
@@ -44,15 +45,16 @@ describe("linkSuffixExtractor", () => {
     const result = await extractor.extract(
       makeCtx("https://lexfridman.com/jensen-huang/"),
     );
-    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
       "https://lexfridman.com/jensen-huang-transcript",
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(result).toBe("lex transcript");
   });
 
   it("falls back to plain append when replaceTrailingSlash is true but link has no trailing slash", async () => {
-    vi.mocked(safeFetch).mockResolvedValue("lex transcript no slash");
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(
+      "lex transcript no slash",
+    );
     const extractor = linkSuffixExtractor({
       id: "lex-fridman",
       suffix: "-transcript",
@@ -61,9 +63,8 @@ describe("linkSuffixExtractor", () => {
     const result = await extractor.extract(
       makeCtx("https://lexfridman.com/jensen-huang"),
     );
-    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
       "https://lexfridman.com/jensen-huang-transcript",
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(result).toBe("lex transcript no slash");
   });
@@ -75,7 +76,7 @@ describe("linkSuffixExtractor", () => {
     });
     const result = await extractor.extract(makeCtx(null));
     expect(result).toBeUndefined();
-    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
   });
 
   it("returns undefined without fetching when link is empty string", async () => {
@@ -85,39 +86,11 @@ describe("linkSuffixExtractor", () => {
     });
     const result = await extractor.extract(makeCtx(""));
     expect(result).toBeUndefined();
-    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
   });
 
-  it("strips HTML from the response before returning", async () => {
-    vi.mocked(safeFetch).mockResolvedValue(
-      "<html><body><p>hello world</p></body></html>",
-    );
-    const extractor = linkSuffixExtractor({
-      id: "transistor",
-      suffix: "/transcript",
-    });
-    const result = await extractor.extract(
-      makeCtx("https://share.transistor.fm/s/abc123"),
-    );
-    expect(result).toBe("hello world");
-    expect(result).not.toMatch(/<[^>]+>/);
-  });
-
-  it("truncates transcripts longer than MAX_TRANSCRIPT_LENGTH", async () => {
-    vi.mocked(safeFetch).mockResolvedValue("a".repeat(60000));
-    const extractor = linkSuffixExtractor({
-      id: "transistor",
-      suffix: "/transcript",
-    });
-    const result = await extractor.extract(
-      makeCtx("https://share.transistor.fm/s/abc123"),
-    );
-    expect(result).toBeDefined();
-    expect(result!.endsWith("[Transcript truncated...]")).toBe(true);
-  });
-
-  it("returns undefined when body is only whitespace after stripping", async () => {
-    vi.mocked(safeFetch).mockResolvedValue("   ");
+  it("returns undefined when fetchTranscriptFromUrl returns undefined", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(undefined);
     const extractor = linkSuffixExtractor({
       id: "transistor",
       suffix: "/transcript",
@@ -128,8 +101,8 @@ describe("linkSuffixExtractor", () => {
     expect(result).toBeUndefined();
   });
 
-  it("propagates errors from safeFetch without swallowing them", async () => {
-    vi.mocked(safeFetch).mockRejectedValue(new Error("network"));
+  it("propagates errors from fetchTranscriptFromUrl without swallowing them", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockRejectedValue(new Error("network"));
     const extractor = linkSuffixExtractor({
       id: "transistor",
       suffix: "/transcript",

--- a/src/trigger/helpers/transcript-extractors/__tests__/link-suffix.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/link-suffix.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/security", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { safeFetch } from "@/lib/security";
+import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
+import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
+
+const makeCtx = (link: string | null): ExtractorContext => ({
+  episode: { podcastIndexId: "ep1", title: "Ep", link, rssGuid: null },
+  podcast: { podcastIndexId: "pod1", title: "Pod" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("linkSuffixExtractor", () => {
+  it("appends suffix to the episode link", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("plain transcript text");
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(
+      makeCtx("https://share.transistor.fm/s/abc123"),
+    );
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://share.transistor.fm/s/abc123/transcript",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toBe("plain transcript text");
+  });
+
+  it("replaces trailing slash before appending suffix when replaceTrailingSlash is true", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("lex transcript");
+    const extractor = linkSuffixExtractor({
+      id: "lex-fridman",
+      suffix: "-transcript",
+      replaceTrailingSlash: true,
+    });
+    const result = await extractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang/"),
+    );
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://lexfridman.com/jensen-huang-transcript",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toBe("lex transcript");
+  });
+
+  it("falls back to plain append when replaceTrailingSlash is true but link has no trailing slash", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("lex transcript no slash");
+    const extractor = linkSuffixExtractor({
+      id: "lex-fridman",
+      suffix: "-transcript",
+      replaceTrailingSlash: true,
+    });
+    const result = await extractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang"),
+    );
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://lexfridman.com/jensen-huang-transcript",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toBe("lex transcript no slash");
+  });
+
+  it("returns undefined without fetching when link is null", async () => {
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(makeCtx(null));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without fetching when link is empty string", async () => {
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(makeCtx(""));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+  });
+
+  it("strips HTML from the response before returning", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(
+      "<html><body><p>hello world</p></body></html>",
+    );
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(
+      makeCtx("https://share.transistor.fm/s/abc123"),
+    );
+    expect(result).toBe("hello world");
+    expect(result).not.toMatch(/<[^>]+>/);
+  });
+
+  it("truncates transcripts longer than MAX_TRANSCRIPT_LENGTH", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("a".repeat(60000));
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(
+      makeCtx("https://share.transistor.fm/s/abc123"),
+    );
+    expect(result).toBeDefined();
+    expect(result!.endsWith("[Transcript truncated...]")).toBe(true);
+  });
+
+  it("returns undefined when body is only whitespace after stripping", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("   ");
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    const result = await extractor.extract(
+      makeCtx("https://share.transistor.fm/s/abc123"),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("propagates errors from safeFetch without swallowing them", async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error("network"));
+    const extractor = linkSuffixExtractor({
+      id: "transistor",
+      suffix: "/transcript",
+    });
+    await expect(extractor.extract(makeCtx("https://x.com"))).rejects.toThrow(
+      "network",
+    );
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/index.ts
+++ b/src/trigger/helpers/transcript-extractors/index.ts
@@ -1,12 +1,25 @@
 import { logger } from "@trigger.dev/sdk";
-import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+import type {
+  Extractor,
+  ExtractorContext,
+  ExtractorResult,
+} from "@/trigger/helpers/transcript-extractors/types";
 
-export type { Extractor, ExtractorContext, ExtractorResult } from "./types";
-export { linkSuffixExtractor } from "./link-suffix";
+export type {
+  Extractor,
+  ExtractorContext,
+  ExtractorResult,
+} from "@/trigger/helpers/transcript-extractors/types";
+export { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
 
 const registry = new Map<string, Extractor>();
 
 export function register(podcastIndexId: string, extractor: Extractor): void {
+  if (registry.has(podcastIndexId)) {
+    logger.warn("[transcript-extractors] duplicate registration", {
+      podcastIndexId,
+    });
+  }
   registry.set(podcastIndexId, extractor);
 }
 
@@ -22,14 +35,14 @@ export async function runPodcastExtractor(
   if (!extractor) return undefined;
 
   try {
-    const transcript = await extractor.extract(ctx);
+    const transcript = (await extractor.extract(ctx))?.trim();
     if (!transcript) return undefined;
     return { transcript, extractorId: extractor.id };
   } catch (error) {
     logger.warn("[transcript-extractors] extractor threw", {
       extractorId: extractor.id,
       podcastIndexId: ctx.podcast.podcastIndexId,
-      error: error instanceof Error ? error.message : String(error),
+      error,
     });
     return undefined;
   }

--- a/src/trigger/helpers/transcript-extractors/index.ts
+++ b/src/trigger/helpers/transcript-extractors/index.ts
@@ -1,0 +1,36 @@
+import { logger } from "@trigger.dev/sdk";
+import type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+
+export type { Extractor, ExtractorContext, ExtractorResult } from "./types";
+export { linkSuffixExtractor } from "./link-suffix";
+
+const registry = new Map<string, Extractor>();
+
+export function register(podcastIndexId: string, extractor: Extractor): void {
+  registry.set(podcastIndexId, extractor);
+}
+
+/** Test-only. Clears the registry between tests; not for production use. */
+export function __resetRegistry(): void {
+  registry.clear();
+}
+
+export async function runPodcastExtractor(
+  ctx: ExtractorContext,
+): Promise<ExtractorResult | undefined> {
+  const extractor = registry.get(ctx.podcast.podcastIndexId);
+  if (!extractor) return undefined;
+
+  try {
+    const transcript = await extractor.extract(ctx);
+    if (!transcript) return undefined;
+    return { transcript, extractorId: extractor.id };
+  } catch (error) {
+    logger.warn("[transcript-extractors] extractor threw", {
+      extractorId: extractor.id,
+      podcastIndexId: ctx.podcast.podcastIndexId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}

--- a/src/trigger/helpers/transcript-extractors/link-suffix.ts
+++ b/src/trigger/helpers/transcript-extractors/link-suffix.ts
@@ -1,5 +1,8 @@
 import { fetchTranscriptFromUrl } from "@/trigger/helpers/transcript";
-import type { Extractor, ExtractorContext } from "./types";
+import type {
+  Extractor,
+  ExtractorContext,
+} from "@/trigger/helpers/transcript-extractors/types";
 
 interface LinkSuffixOptions {
   id: string;
@@ -13,11 +16,18 @@ export function linkSuffixExtractor(opts: LinkSuffixOptions): Extractor {
     extract: async (ctx: ExtractorContext) => {
       if (!ctx.episode.link) return undefined;
 
-      const base =
-        opts.replaceTrailingSlash && ctx.episode.link.endsWith("/")
-          ? ctx.episode.link.slice(0, -1)
-          : ctx.episode.link;
-      return fetchTranscriptFromUrl(base + opts.suffix);
+      const url = new URL(ctx.episode.link);
+      const rawPath = url.pathname;
+      const hasTrailingSlash = rawPath.endsWith("/") && rawPath.length > 1;
+      const basePath =
+        opts.replaceTrailingSlash && hasTrailingSlash
+          ? rawPath.slice(0, -1)
+          : rawPath;
+      url.pathname =
+        basePath === "/" && opts.suffix.startsWith("/")
+          ? opts.suffix
+          : basePath + opts.suffix;
+      return fetchTranscriptFromUrl(url.href);
     },
   };
 }

--- a/src/trigger/helpers/transcript-extractors/link-suffix.ts
+++ b/src/trigger/helpers/transcript-extractors/link-suffix.ts
@@ -1,9 +1,4 @@
-import { safeFetch } from "@/lib/security";
-import {
-  FETCH_TIMEOUT_MS,
-  MAX_TRANSCRIPT_LENGTH,
-  stripHtmlTranscript,
-} from "@/trigger/helpers/transcript";
+import { fetchTranscriptFromUrl } from "@/trigger/helpers/transcript";
 import type { Extractor, ExtractorContext } from "./types";
 
 interface LinkSuffixOptions {
@@ -22,26 +17,7 @@ export function linkSuffixExtractor(opts: LinkSuffixOptions): Extractor {
         opts.replaceTrailingSlash && ctx.episode.link.endsWith("/")
           ? ctx.episode.link.slice(0, -1)
           : ctx.episode.link;
-      const url = base + opts.suffix;
-
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-      let raw: string;
-      try {
-        raw = await safeFetch(url, { signal: controller.signal });
-      } finally {
-        clearTimeout(timeout);
-      }
-
-      let text = stripHtmlTranscript(raw).trim();
-      if (!text) return undefined;
-      if (text.length > MAX_TRANSCRIPT_LENGTH) {
-        text =
-          text.slice(0, MAX_TRANSCRIPT_LENGTH) +
-          "\n\n[Transcript truncated...]";
-      }
-      return text;
+      return fetchTranscriptFromUrl(base + opts.suffix);
     },
   };
 }

--- a/src/trigger/helpers/transcript-extractors/link-suffix.ts
+++ b/src/trigger/helpers/transcript-extractors/link-suffix.ts
@@ -1,0 +1,47 @@
+import { safeFetch } from "@/lib/security";
+import {
+  FETCH_TIMEOUT_MS,
+  MAX_TRANSCRIPT_LENGTH,
+  stripHtmlTranscript,
+} from "@/trigger/helpers/transcript";
+import type { Extractor, ExtractorContext } from "./types";
+
+interface LinkSuffixOptions {
+  id: string;
+  suffix: string;
+  replaceTrailingSlash?: boolean;
+}
+
+export function linkSuffixExtractor(opts: LinkSuffixOptions): Extractor {
+  return {
+    id: opts.id,
+    extract: async (ctx: ExtractorContext) => {
+      if (!ctx.episode.link) return undefined;
+
+      const base =
+        opts.replaceTrailingSlash && ctx.episode.link.endsWith("/")
+          ? ctx.episode.link.slice(0, -1)
+          : ctx.episode.link;
+      const url = base + opts.suffix;
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+      let raw: string;
+      try {
+        raw = await safeFetch(url, { signal: controller.signal });
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      let text = stripHtmlTranscript(raw).trim();
+      if (!text) return undefined;
+      if (text.length > MAX_TRANSCRIPT_LENGTH) {
+        text =
+          text.slice(0, MAX_TRANSCRIPT_LENGTH) +
+          "\n\n[Transcript truncated...]";
+      }
+      return text;
+    },
+  };
+}

--- a/src/trigger/helpers/transcript-extractors/types.ts
+++ b/src/trigger/helpers/transcript-extractors/types.ts
@@ -1,0 +1,22 @@
+export interface ExtractorContext {
+  episode: {
+    podcastIndexId: string;
+    title: string;
+    link: string | null;
+    rssGuid: string | null;
+  };
+  podcast: {
+    podcastIndexId: string;
+    title: string;
+  };
+}
+
+export interface Extractor {
+  id: string;
+  extract: (ctx: ExtractorContext) => Promise<string | undefined>;
+}
+
+export interface ExtractorResult {
+  transcript: string;
+  extractorId: string;
+}

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -2,8 +2,8 @@ import he from "he";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import { safeFetch } from "@/lib/security";
 
-export const MAX_TRANSCRIPT_LENGTH = 50000;
-export const FETCH_TIMEOUT_MS = 30000;
+const MAX_TRANSCRIPT_LENGTH = 50000;
+const FETCH_TIMEOUT_MS = 30000;
 
 const SUPPORTED_TRANSCRIPT_TYPES = [
   "text/plain",

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -2,8 +2,8 @@ import he from "he";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import { safeFetch } from "@/lib/security";
 
-const MAX_TRANSCRIPT_LENGTH = 50000;
-const FETCH_TIMEOUT_MS = 30000;
+export const MAX_TRANSCRIPT_LENGTH = 50000;
+export const FETCH_TIMEOUT_MS = 30000;
 
 const SUPPORTED_TRANSCRIPT_TYPES = [
   "text/plain",


### PR DESCRIPTION
## Summary

Adds the per-podcast transcript-extractor submodule under `src/trigger/helpers/transcript-extractors/` — types, an empty-but-dispatchable registry, and the shared `linkSuffixExtractor` factory. No real extractors and no pipeline integration in this PR (those land in #428 and #429).

- `types.ts` — `Extractor`, `ExtractorContext`, `ExtractorResult`
- `index.ts` — `register`, `runPodcastExtractor`, `__resetRegistry` (single catch-point; `logger.warn` and returns `undefined` on extractor throw)
- `link-suffix.ts` — factory that builds the derived URL (append-suffix or replace-trailing-slash) and delegates the fetch + normalize + truncate pipeline to the existing `fetchTranscriptFromUrl` in `transcript.ts`
- 14 unit tests across `index` (7) and `link-suffix` (7); pipeline-internal cases (HTML stripping, truncation, whitespace-only) live in `transcript.test.ts`

Closes #427

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run build` — TypeScript compiles
- [x] `bun run build-storybook` — clean
- [x] `bun run test` — 3248/3248 passed (no regression on `transcript.test.ts` or `fetch-transcript.test.ts`)
- [x] All 8 issue VERIFY items mapped to specific test cases (registry miss/hit/throw, factory append, replace-trailing-slash, missing-link, `safeFetch` enforced via `fetchTranscriptFromUrl` reuse, HTML stripped via `fetchTranscriptFromUrl` reuse)
- [x] No raw `fetch`; no `TODO`/`FIXME`/`HACK`/`stub` in the new submodule
- [x] Pre-PR multi-tool review (Codex + pr-review-toolkit + simplify): one §5/§6/§7 finding (`linkSuffixExtractor` duplicated `fetchTranscriptFromUrl`) addressed in-PR by collapsing onto the existing helper; one §6 (use `createTriggerSdkMock`) and one §3 (tighten warn-log assertion) also fixed

## Agent Notes

### Open Questions

- `index.ts:32` non-Error-throw branch (`String(error)` fallback) is uncovered by tests — only Error throws are exercised. Intentional per code-tester (legitimate edge case); revisit only if a real extractor in #428 surfaces a non-Error reject.
- Pre-PR review flagged secondary improvements (DB-schema brand `PodcastIndexEpisodeId` on the context, `register` throwing on duplicate `podcastIndexId`, `id` as a string-literal union, classifying `AbortError` separately in the warn payload, enriching the warn payload with `episodeLink` / `episode.title`) that are downstream-contract or observability decisions better made in #428/#429 when the first concrete extractors and pipeline caller exist. Not blocking; explicitly out of scope per [docs/code-review-checklist.md §7](docs/code-review-checklist.md).

### Context for Next Session

- Registry is intentionally empty in this PR. #428 plugs in Bankless / Lex / Limitless via `register(podcastIndexId, linkSuffixExtractor({...}))` calls — no further changes needed in this submodule for that. Evidence: `src/trigger/helpers/transcript-extractors/index.ts` (no `register(...)` calls); plan §Boundaries 🔴.
- `linkSuffixExtractor` delegates its fetch path to `fetchTranscriptFromUrl` in `src/trigger/helpers/transcript.ts:160`, so timeout/truncation/HTML-strip behavior changes there will flow through to every future linkSuffix-style extractor automatically. The truncation suffix string `"\n\n[Transcript truncated...]"` lives in three call sites in `transcript.ts` (`fetchTranscript`, `fetchTranscriptFromUrl`, the legacy line in `fetchTranscript`); a follow-up cleanup PR could extract `truncateTranscript` + `TRANSCRIPT_TRUNCATED_SUFFIX` once a non-scaffolding need surfaces — Codex flagged it but it touches paths not introduced by this PR.
- `linkSuffixExtractor` is re-exported from `index.ts` so consumers can `import { linkSuffixExtractor, register } from "@/trigger/helpers/transcript-extractors"` as a single surface in #428. Evidence: `index.ts` re-export line.
- Pipeline wiring (`fetch-transcript.ts` Step 3 between PodcastIndex and description-URL) is deferred to #429 — `runPodcastExtractor` is fully callable today but no caller invokes it. Evidence: `git grep runPodcastExtractor src/` returns the definition only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added internal, pluggable transcript-extractor registry and type contracts to support multiple extraction strategies; Changelog entry updated.
* **New Features**
  * Added a configurable "link suffix" extractor option to transform episode links before fetching transcripts.
* **Tests**
  * Added comprehensive tests covering registry behavior, link-suffix behavior, success/failure cases, trimming, and structured logging on errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/459)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->