### PR TITLE
feat: Bankless, Lex Fridman, Limitless transcript extractors (#428)

### DIFF
--- a/.agentnotes/cdt/feature-transcript-extractors.md
+++ b/.agentnotes/cdt/feature-transcript-extractors.md
@@ -1,0 +1,31 @@
+# Branch: feature/transcript-extractors
+
+**Created**: 2026-05-10
+**First plan**: .dev/cdt/plans/plan-20260510-1756.md
+
+---
+
+## Session 20260510-1817
+
+**Task**: 428 — feat: Bankless, Lex Fridman, Limitless transcript extractors
+**Plan**: .dev/cdt/plans/plan-20260510-1756.md
+
+### What's Done
+
+Three concrete transcript extractors implemented + registered against the #459 scaffolding (Lex Fridman + Limitless via `linkSuffixExtractor`, Bankless bespoke with verified anchor-pair narrowing). 95+ tests across 7 files green; full repo 3278 passed; coverage on extractor submodule ≥80%. Pre-PR multi-tool review (8 specialists + Codex) ran on the first commit and surfaced 1 P2 correctness bug (Codex: heading-only marker section returned the literal "TRANSCRIPT" string), 2 §5 in-PR duplication-extraction findings, 1 regex correctness issue (`id="insideEpisodeFoo"` prefix-match), 1 missing-test gap (registry → extractor wiring), tautological fixture roundtrip tests, and several mechanical comment/style nits — all addressed in a follow-up review-fixes commit before the PR opened.
+
+### Open Questions
+
+- The Bankless container regex `<div\s+id=["']?insideEpisode\b["']?[^>]*>` now uses a `\b` after `insideEpisode` to reject prefix-matches like `id="insideEpisodeFoo"`. The end-anchor regex was tightened to anchor on the `<tag` boundary so the scoped slice doesn't end mid-tag. Both changes are validated by the new boundary tests; if Bankless ever switches to multi-attribute markup (e.g., `class="foo postSidebar"`), the end-anchor would miss and we'd fall through to `<\/article>` / `<aside`. Worth re-validating against 2–3 more live episodes before #429 wires the pipeline.
+- `bankless.ts` empty-body branch: the original "defensive guard" was unreachable (the marker text "TRANSCRIPT" always survived stripping). After slicing past the marker (Codex P2 fix), the guard is now meaningful — it catches genuinely empty post-marker sections. No log added; the registry's outer `logger.warn` covers diagnostic visibility for any throw, and an empty-body return is a normal "no transcript" signal.
+
+### Context for Next Session
+
+- #429 integrates this registry into `src/trigger/fetch-transcript.ts`. The dispatcher is `runPodcastExtractor(ctx)` from `src/trigger/helpers/transcript-extractors/index.ts`; it returns `{ transcript, extractorId } | undefined`. Keys off `ctx.podcast.podcastIndexId`. Per the #459 scaffolding contract, the dispatcher catches extractor throws and converts them to `undefined`, so `fetch-transcript.ts` only needs to handle the success/fallthrough cases.
+- Bankless uses `episode.title` (not `episode.link`) to derive the URL, unlike Lex/Limitless which use `episode.link + suffix`. The integration in #429 needs to pass full `ExtractorContext` including `title` — see `src/trigger/helpers/transcript-extractors/types.ts:1-9`.
+- `safeFetchWithTimeout` and `truncateTranscript` are now exported from `src/trigger/helpers/transcript.ts` and reused across `fetchTranscript`, `fetchTranscriptFromUrl`, and `banklessExtractor`. Future extractors should use these helpers rather than recreating the abort/timeout/truncation pattern.
+- PodcastIndex feed IDs are hard-coded as string consts (`*_PODCAST_INDEX_ID`) in each extractor file. If a podcast is re-imported with a different feed source, the registry key won't match — IDs may need updating in those files.
+
+### References
+
+- PR: https://github.com/Chalet-Labs/contentgenie/pull/461

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,7 @@
       "Bash(tsc:*)",
       "Bash(vercel:*)",
       "Skill(dlc:*)",
-      "Skill(project-manager:*)",
+      "Skill(pm:*)",
       "Skill(cdt:*)",
       "Skill(council:*)"
     ],
@@ -54,7 +54,7 @@
     "frontend-design@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "project-manager@rube-cc-skills": true,
+    "pm@rube-cc-skills": true,
     "jules-review@rube-cc-skills": true,
     "council@rube-cc-skills": true,
     "dlc@rube-cc-skills": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,3 +110,5 @@ See [docs/secrets-management.md](docs/secrets-management.md) for the full variab
 - All non-public routes protected by Clerk middleware.
 - No `.env` files committed — Doppler handles secrets injection.
 - Server actions validate `auth()` before mutations. API routes verify authentication before processing.
+
+When picking up work in an unfamiliar area, run `rg -l "" .agentnotes/cdt/` to surface prior CDT session logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Bankless, Lex Fridman, and Limitless transcript extractors (`src/trigger/helpers/transcript-extractors/`). Each podcast's episode page is parsed (Bankless via bespoke HTML anchor pair; Lex Fridman + Limitless via the shared `linkSuffixExtractor`) to surface a transcript when PodcastIndex / RSS feeds don't carry one. Pipeline wiring in `fetch-transcript.ts` follows in #429. (#428)
 - Internal `transcript-extractors` registry scaffolding (`src/trigger/helpers/transcript-extractors/`) with the shared `linkSuffixExtractor` factory. Empty registry — specific extractors and pipeline wiring follow in #428/#429. (#427)
 - `episode_link` and `transcript_extractor` columns on `episodes`, plus `'podcast-site'` accepted by `transcript_source_enum`. Persists PodcastIndex `link` on episode insert across poll/processing/summary paths. (#426)
 - Dashboard "this week's takes" digest list showing the 5 most recent canonical-topic digests from the last 7 days, positioned above the trending-topics card. Section is fully omitted when empty or unauthenticated. (#400)

--- a/src/trigger/helpers/transcript-extractors/__tests__/bankless.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/bankless.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
+
+import { safeFetch } from "@/lib/security";
+import {
+  banklessExtractor,
+  banklessSlug,
+} from "@/trigger/helpers/transcript-extractors/bankless";
+import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const banklessFixture = readFileSync(
+  join(__dirname, "fixtures", "bankless.html"),
+  "utf8",
+);
+
+const makeCtx = (
+  title: string,
+  link: string | null = "https://www.bankless.com/podcast/x",
+): ExtractorContext => ({
+  episode: { podcastIndexId: "ep1", title, link, rssGuid: null },
+  podcast: { podcastIndexId: "bankless-pod", title: "Bankless" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("banklessSlug", () => {
+  it("slugifies a normal title (VERIFY 3)", () => {
+    expect(
+      banklessSlug("MegaETH Token Launch with Co-founders Shuyao and Lei"),
+    ).toBe("megaeth-token-launch-with-co-founders-shuyao-and-lei");
+  });
+
+  it("strips apostrophes rather than hyphenating them", () => {
+    expect(
+      banklessSlug(
+        "Finding Satoshi: How a Private Investigator Solved the Mystery of Bitcoin's Creator",
+      ),
+    ).toBe(
+      "finding-satoshi-how-a-private-investigator-solved-the-mystery-of-bitcoins-creator",
+    );
+  });
+
+  it("preserves numbers and strips # symbol", () => {
+    expect(banklessSlug("Rollup #120: Oil vs New Highs")).toBe(
+      "rollup-120-oil-vs-new-highs",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(banklessSlug("")).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(banklessSlug("   ")).toBe("");
+  });
+
+  it("strips apostrophes again to lock in the rule (Crypto's)", () => {
+    expect(banklessSlug("Crypto's Nasdaq Problem")).toBe(
+      "cryptos-nasdaq-problem",
+    );
+  });
+
+  it("strips curly right-single-quote U+2019 like a straight apostrophe", () => {
+    // Regression: Prettier previously mangled the regex to ASCII-only chars,
+    // causing curly apostrophes (common in CMS/Word-authored RSS titles) to
+    // produce a hyphen instead of being stripped → wrong slug → 404.
+    expect(banklessSlug("Bitcoin’s Creator")).toBe("bitcoins-creator");
+  });
+
+  it("strips smart double quotes U+201C / U+201D", () => {
+    expect(banklessSlug("“Bitcoin” Token Launch")).toBe("bitcoin-token-launch");
+  });
+});
+
+describe("banklessExtractor.extract", () => {
+  it("happy path: derives URL from title, returns non-empty text (VERIFY 3)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(banklessFixture);
+    const result = await banklessExtractor.extract(
+      makeCtx("MegaETH Token Launch with Co-founders Shuyao and Lei"),
+    );
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://www.bankless.com/podcast/megaeth-token-launch-with-co-founders-shuyao-and-lei",
+      expect.anything(),
+    );
+    expect(result).toBeTruthy();
+    expect(result).toContain("[0:02]");
+    expect(result).not.toContain("postSidebar");
+    expect(result).not.toContain("Post sidebar content here");
+  });
+
+  it("returns undefined when safeFetch throws (e.g. 404) (VERIFY 4)", async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error("HTTP 404"));
+    const result = await banklessExtractor.extract(
+      makeCtx("MegaETH Token Launch with Co-founders Shuyao and Lei"),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when TRANSCRIPT marker is missing (VERIFY 4)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(
+      '<div id="insideEpisode"><p>No transcript here.</p></div>',
+    );
+    const result = await banklessExtractor.extract(makeCtx("Some Episode"));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when insideEpisode container is missing (VERIFY 4)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(
+      "<div><strong>TRANSCRIPT</strong><p>Content without container.</p></div>",
+    );
+    const result = await banklessExtractor.extract(makeCtx("Some Episode"));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when episode title is empty", async () => {
+    const result = await banklessExtractor.extract(makeCtx(""));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+  });
+
+  it("ignores episode.link — derives URL from title regardless of link value", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(banklessFixture);
+    const ctx = makeCtx(
+      "MegaETH Token Launch with Co-founders Shuyao and Lei",
+      "https://some-other-host.com/episode/123",
+    );
+    const result = await banklessExtractor.extract(ctx);
+    // URL is title-derived, not link-derived
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://www.bankless.com/podcast/megaeth-token-launch-with-co-founders-shuyao-and-lei",
+      expect.anything(),
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it("truncates text exceeding MAX_TRANSCRIPT_LENGTH and appends marker", async () => {
+    const longContent =
+      '<div id="insideEpisode"><strong>TRANSCRIPT</strong><p>' +
+      "x".repeat(60000) +
+      "</p></div>";
+    vi.mocked(safeFetch).mockResolvedValue(longContent);
+    const result = await banklessExtractor.extract(makeCtx("Some Episode"));
+    expect(result).toBeDefined();
+    expect(result!.endsWith("[Transcript truncated...]")).toBe(true);
+    // 50000 chars + "\n\n[Transcript truncated...]" (26 chars) = 50026
+    expect(result!.length).toBe(50000 + "\n\n[Transcript truncated...]".length);
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/__tests__/bankless.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/bankless.test.ts
@@ -7,6 +7,10 @@ vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
 
 import { safeFetch } from "@/lib/security";
 import {
+  MAX_TRANSCRIPT_LENGTH,
+  TRUNCATED_MARKER,
+} from "@/trigger/helpers/transcript";
+import {
   banklessExtractor,
   banklessSlug,
 } from "@/trigger/helpers/transcript-extractors/bankless";
@@ -61,6 +65,10 @@ describe("banklessSlug", () => {
     expect(banklessSlug("   ")).toBe("");
   });
 
+  it("returns empty string for non-empty input that has no alphanumerics", () => {
+    expect(banklessSlug("---???---")).toBe("");
+  });
+
   it("strips apostrophes again to lock in the rule (Crypto's)", () => {
     expect(banklessSlug("Crypto's Nasdaq Problem")).toBe(
       "cryptos-nasdaq-problem",
@@ -95,12 +103,13 @@ describe("banklessExtractor.extract", () => {
     expect(result).not.toContain("Post sidebar content here");
   });
 
-  it("returns undefined when safeFetch throws (e.g. 404) (VERIFY 4)", async () => {
+  it("propagates safeFetch errors (registry is the throw-shield)", async () => {
     vi.mocked(safeFetch).mockRejectedValue(new Error("HTTP 404"));
-    const result = await banklessExtractor.extract(
-      makeCtx("MegaETH Token Launch with Co-founders Shuyao and Lei"),
-    );
-    expect(result).toBeUndefined();
+    await expect(
+      banklessExtractor.extract(
+        makeCtx("MegaETH Token Launch with Co-founders Shuyao and Lei"),
+      ),
+    ).rejects.toThrow("HTTP 404");
   });
 
   it("returns undefined when TRANSCRIPT marker is missing (VERIFY 4)", async () => {
@@ -125,6 +134,20 @@ describe("banklessExtractor.extract", () => {
     expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
   });
 
+  it("returns undefined without fetching when title slugifies to empty", async () => {
+    const result = await banklessExtractor.extract(makeCtx("---???---"));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(safeFetch)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when transcript marker has no body content (VERIFY 4)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(
+      '<div id="insideEpisode"><strong>TRANSCRIPT</strong><div class="rule"></div></div>',
+    );
+    const result = await banklessExtractor.extract(makeCtx("Some Episode"));
+    expect(result).toBeUndefined();
+  });
+
   it("ignores episode.link — derives URL from title regardless of link value", async () => {
     vi.mocked(safeFetch).mockResolvedValue(banklessFixture);
     const ctx = makeCtx(
@@ -143,13 +166,27 @@ describe("banklessExtractor.extract", () => {
   it("truncates text exceeding MAX_TRANSCRIPT_LENGTH and appends marker", async () => {
     const longContent =
       '<div id="insideEpisode"><strong>TRANSCRIPT</strong><p>' +
-      "x".repeat(60000) +
+      "x".repeat(MAX_TRANSCRIPT_LENGTH + 10000) +
       "</p></div>";
     vi.mocked(safeFetch).mockResolvedValue(longContent);
     const result = await banklessExtractor.extract(makeCtx("Some Episode"));
     expect(result).toBeDefined();
-    expect(result!.endsWith("[Transcript truncated...]")).toBe(true);
-    // 50000 chars + "\n\n[Transcript truncated...]" (26 chars) = 50026
-    expect(result!.length).toBe(50000 + "\n\n[Transcript truncated...]".length);
+    expect(result!.endsWith(TRUNCATED_MARKER.trim())).toBe(true);
+    expect(result!.length).toBe(
+      MAX_TRANSCRIPT_LENGTH + TRUNCATED_MARKER.length,
+    );
+  });
+
+  it("does not truncate text that fits exactly within MAX_TRANSCRIPT_LENGTH", async () => {
+    // Body has to land at exactly MAX after stripHtmlTranscript (which collapses
+    // whitespace and trims). Pad with `x` so the stripped body length equals MAX.
+    const body = "x".repeat(MAX_TRANSCRIPT_LENGTH);
+    vi.mocked(safeFetch).mockResolvedValue(
+      `<div id="insideEpisode"><strong>TRANSCRIPT</strong><p>${body}</p></div>`,
+    );
+    const result = await banklessExtractor.extract(makeCtx("Some Episode"));
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(MAX_TRANSCRIPT_LENGTH);
+    expect(result!.endsWith(TRUNCATED_MARKER.trim())).toBe(false);
   });
 });

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/bankless.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/bankless.html
@@ -1,40 +1,78 @@
+<!doctype html>
 <html>
-<body>
-<header><nav><a href="/">Bankless</a></nav></header>
-<main>
-<article>
-<div class="postHeader"><h1>MegaETH Token Launch with Co-founders Shuyao and Lei</h1></div>
-<div class="postContent">
-<figure class="kg-card kg-embed-card"></figure>
-<p>This episode explores the MegaETH token launch and what it means for the Ethereum ecosystem.</p>
-</div>
-<div id="insideEpisode">
-<figure class="kg-card kg-embed-card"></figure>
-<p><strong>TRANSCRIPT</strong><br>
-Host A:<br>
-[0:02] Welcome to Bankless. Today we have the co-founders of MegaETH, Shuyao Kong and Lei Yang.</p>
-<p>Shuyao:<br>
-[0:45] Thank you for having us. MegaETH is designed to be the fastest EVM chain in existence.</p>
-<p>Host A:<br>
-[1:30] Let's talk about what makes MegaETH different from other L2s.</p>
-<p>Lei:<br>
-[2:15] Most L2s optimize for cost. We optimize for speed. Real-time execution, millisecond block times.</p>
-<p>Host B:<br>
-[3:00] How do you achieve that without sacrificing decentralization?</p>
-<p>Shuyao:<br>
-[3:45] We use a heterogeneous node architecture. Not every node needs to do everything.</p>
-<p>Lei:<br>
-[4:20] The sequencer is highly optimized hardware. Validators are lightweight. It's a separation of concerns.</p>
-<p>Host A:<br>
-[5:10] What's the token for? What does it unlock in the ecosystem?</p>
-<p>Shuyao:<br>
-[5:55] Governance, staking, and eventually sequencer decentralization. It's the coordination layer.</p>
-</div>
-<div class="rule"></div>
-<div class="postSidebar">Post sidebar content here — next episode recommendations and links.</div>
-</article>
-</main>
-<script>/* tracking */</script>
-<style>/* styles */</style>
-</body>
+  <body>
+    <header>
+      <nav><a href="/">Bankless</a></nav>
+    </header>
+    <main>
+      <article>
+        <div class="postHeader">
+          <h1>MegaETH Token Launch with Co-founders Shuyao and Lei</h1>
+        </div>
+        <div class="postContent">
+          <figure class="kg-card kg-embed-card"></figure>
+          <p>
+            This episode explores the MegaETH token launch and what it means for
+            the Ethereum ecosystem.
+          </p>
+        </div>
+        <div id="insideEpisode">
+          <figure class="kg-card kg-embed-card"></figure>
+          <p>
+            <strong>TRANSCRIPT</strong><br />
+            Host A:<br />
+            [0:02] Welcome to Bankless. Today we have the co-founders of
+            MegaETH, Shuyao Kong and Lei Yang.
+          </p>
+          <p>
+            Shuyao:<br />
+            [0:45] Thank you for having us. MegaETH is designed to be the
+            fastest EVM chain in existence.
+          </p>
+          <p>
+            Host A:<br />
+            [1:30] Let's talk about what makes MegaETH different from other L2s.
+          </p>
+          <p>
+            Lei:<br />
+            [2:15] Most L2s optimize for cost. We optimize for speed. Real-time
+            execution, millisecond block times.
+          </p>
+          <p>
+            Host B:<br />
+            [3:00] How do you achieve that without sacrificing decentralization?
+          </p>
+          <p>
+            Shuyao:<br />
+            [3:45] We use a heterogeneous node architecture. Not every node
+            needs to do everything.
+          </p>
+          <p>
+            Lei:<br />
+            [4:20] The sequencer is highly optimized hardware. Validators are
+            lightweight. It's a separation of concerns.
+          </p>
+          <p>
+            Host A:<br />
+            [5:10] What's the token for? What does it unlock in the ecosystem?
+          </p>
+          <p>
+            Shuyao:<br />
+            [5:55] Governance, staking, and eventually sequencer
+            decentralization. It's the coordination layer.
+          </p>
+        </div>
+        <div class="rule"></div>
+        <div class="postSidebar">
+          Post sidebar content here — next episode recommendations and links.
+        </div>
+      </article>
+    </main>
+    <script>
+      /* tracking */
+    </script>
+    <style>
+      /* styles */
+    </style>
+  </body>
 </html>

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/bankless.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/bankless.html
@@ -1,0 +1,40 @@
+<html>
+<body>
+<header><nav><a href="/">Bankless</a></nav></header>
+<main>
+<article>
+<div class="postHeader"><h1>MegaETH Token Launch with Co-founders Shuyao and Lei</h1></div>
+<div class="postContent">
+<figure class="kg-card kg-embed-card"></figure>
+<p>This episode explores the MegaETH token launch and what it means for the Ethereum ecosystem.</p>
+</div>
+<div id="insideEpisode">
+<figure class="kg-card kg-embed-card"></figure>
+<p><strong>TRANSCRIPT</strong><br>
+Host A:<br>
+[0:02] Welcome to Bankless. Today we have the co-founders of MegaETH, Shuyao Kong and Lei Yang.</p>
+<p>Shuyao:<br>
+[0:45] Thank you for having us. MegaETH is designed to be the fastest EVM chain in existence.</p>
+<p>Host A:<br>
+[1:30] Let's talk about what makes MegaETH different from other L2s.</p>
+<p>Lei:<br>
+[2:15] Most L2s optimize for cost. We optimize for speed. Real-time execution, millisecond block times.</p>
+<p>Host B:<br>
+[3:00] How do you achieve that without sacrificing decentralization?</p>
+<p>Shuyao:<br>
+[3:45] We use a heterogeneous node architecture. Not every node needs to do everything.</p>
+<p>Lei:<br>
+[4:20] The sequencer is highly optimized hardware. Validators are lightweight. It's a separation of concerns.</p>
+<p>Host A:<br>
+[5:10] What's the token for? What does it unlock in the ecosystem?</p>
+<p>Shuyao:<br>
+[5:55] Governance, staking, and eventually sequencer decentralization. It's the coordination layer.</p>
+</div>
+<div class="rule"></div>
+<div class="postSidebar">Post sidebar content here — next episode recommendations and links.</div>
+</article>
+</main>
+<script>/* tracking */</script>
+<style>/* styles */</style>
+</body>
+</html>

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/lex-fridman.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/lex-fridman.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+<h1>Jensen Huang: Nvidia, AI, Robots, and the Future of Computing</h1>
+<div class="transcript-container">
+<p>Jensen Huang is the CEO of Nvidia. This is a conversation about AI, GPUs, robotics, and the future of computing.</p>
+<p>Lex Fridman: Jensen, thank you for being here. Let's start at the beginning.</p>
+<p>Jensen Huang: Thank you, Lex. It's great to be back.</p>
+<p>Lex Fridman: You've described Nvidia as a company that is always one step away from disaster. What do you mean by that?</p>
+<p>Jensen Huang: Every single product we've ever made, we were betting the company on it. CUDA was a bet. The GPU was a bet. GeForce was a bet.</p>
+<p>Lex Fridman: Let's talk about the moment you decided to pursue CUDA. That was a huge bet on parallel computing.</p>
+<p>Jensen Huang: Yes. The insight was that the world of computing would shift from CPU-centric to GPU-accelerated. We had to pioneer that shift ourselves.</p>
+<p>Lex Fridman: And now with AI, it feels like everything came full circle.</p>
+<p>Jensen Huang: The reason deep learning works so well on GPUs is not an accident. The same principles that make games look beautiful — massive parallelism — are what make neural networks train efficiently.</p>
+<p>Lex Fridman: What does the next decade of AI look like to you?</p>
+<p>Jensen Huang: Physical AI. Robotics. The digital world and the physical world converging. That is the next great frontier.</p>
+</div>
+<script>/* analytics placeholder */</script>
+</body>
+</html>

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/lex-fridman.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/lex-fridman.html
@@ -1,19 +1,50 @@
+<!doctype html>
 <html>
-<body>
-<h1>Jensen Huang: Nvidia, AI, Robots, and the Future of Computing</h1>
-<div class="transcript-container">
-<p>Jensen Huang is the CEO of Nvidia. This is a conversation about AI, GPUs, robotics, and the future of computing.</p>
-<p>Lex Fridman: Jensen, thank you for being here. Let's start at the beginning.</p>
-<p>Jensen Huang: Thank you, Lex. It's great to be back.</p>
-<p>Lex Fridman: You've described Nvidia as a company that is always one step away from disaster. What do you mean by that?</p>
-<p>Jensen Huang: Every single product we've ever made, we were betting the company on it. CUDA was a bet. The GPU was a bet. GeForce was a bet.</p>
-<p>Lex Fridman: Let's talk about the moment you decided to pursue CUDA. That was a huge bet on parallel computing.</p>
-<p>Jensen Huang: Yes. The insight was that the world of computing would shift from CPU-centric to GPU-accelerated. We had to pioneer that shift ourselves.</p>
-<p>Lex Fridman: And now with AI, it feels like everything came full circle.</p>
-<p>Jensen Huang: The reason deep learning works so well on GPUs is not an accident. The same principles that make games look beautiful — massive parallelism — are what make neural networks train efficiently.</p>
-<p>Lex Fridman: What does the next decade of AI look like to you?</p>
-<p>Jensen Huang: Physical AI. Robotics. The digital world and the physical world converging. That is the next great frontier.</p>
-</div>
-<script>/* analytics placeholder */</script>
-</body>
+  <body>
+    <h1>Jensen Huang: Nvidia, AI, Robots, and the Future of Computing</h1>
+    <div class="transcript-container">
+      <p>
+        Jensen Huang is the CEO of Nvidia. This is a conversation about AI,
+        GPUs, robotics, and the future of computing.
+      </p>
+      <p>
+        Lex Fridman: Jensen, thank you for being here. Let's start at the
+        beginning.
+      </p>
+      <p>Jensen Huang: Thank you, Lex. It's great to be back.</p>
+      <p>
+        Lex Fridman: You've described Nvidia as a company that is always one
+        step away from disaster. What do you mean by that?
+      </p>
+      <p>
+        Jensen Huang: Every single product we've ever made, we were betting the
+        company on it. CUDA was a bet. The GPU was a bet. GeForce was a bet.
+      </p>
+      <p>
+        Lex Fridman: Let's talk about the moment you decided to pursue CUDA.
+        That was a huge bet on parallel computing.
+      </p>
+      <p>
+        Jensen Huang: Yes. The insight was that the world of computing would
+        shift from CPU-centric to GPU-accelerated. We had to pioneer that shift
+        ourselves.
+      </p>
+      <p>
+        Lex Fridman: And now with AI, it feels like everything came full circle.
+      </p>
+      <p>
+        Jensen Huang: The reason deep learning works so well on GPUs is not an
+        accident. The same principles that make games look beautiful — massive
+        parallelism — are what make neural networks train efficiently.
+      </p>
+      <p>Lex Fridman: What does the next decade of AI look like to you?</p>
+      <p>
+        Jensen Huang: Physical AI. Robotics. The digital world and the physical
+        world converging. That is the next great frontier.
+      </p>
+    </div>
+    <script>
+      /* analytics placeholder */
+    </script>
+  </body>
 </html>

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/limitless.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/limitless.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 <body>
 <div class="episode-header">

--- a/src/trigger/helpers/transcript-extractors/__tests__/fixtures/limitless.html
+++ b/src/trigger/helpers/transcript-extractors/__tests__/fixtures/limitless.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+<div class="episode-header">
+  <h1>The Future of AI Agents: How LLMs Are Changing Everything</h1>
+  <p class="meta">Season 2 · Episode 14 · 58 min</p>
+</div>
+<div class="transcript-body">
+  <p>Welcome to Limitless, where we explore the cutting edge of artificial intelligence and its impact on how we live and work.</p>
+  <p>Host: Today we are diving deep into the world of AI agents. Our guest has spent the last decade building systems that think, reason, and act autonomously. Welcome to the show.</p>
+  <p>Guest: Thank you so much. Really excited to be here.</p>
+  <p>Host: Let's start with the basics. What exactly is an AI agent, and how does it differ from a regular language model?</p>
+  <p>Guest: Great question. A language model responds to a prompt and gives you an answer. An agent takes that one step further — it plans, uses tools, executes actions, and iterates until a goal is reached.</p>
+  <p>Host: So it's goal-directed rather than just response-directed.</p>
+  <p>Guest: Exactly. The key shift is from reactive to proactive. The agent doesn't wait for your next instruction — it decides what to do next itself.</p>
+  <p>Host: What are the biggest failure modes you see in production agent systems today?</p>
+  <p>Guest: Hallucination is still number one. Agents that are overconfident, that don't know what they don't know. The second is tool misuse — calling the wrong API, misinterpreting the output.</p>
+  <p>Host: How do you build agents that are appropriately uncertain?</p>
+  <p>Guest: You calibrate them on failure cases. You give them explicit permission to say "I don't know" or "I need more information." That's a training and prompting challenge, not just an architecture one.</p>
+</div>
+<script>/* tracking placeholder */</script>
+</body>
+</html>

--- a/src/trigger/helpers/transcript-extractors/__tests__/integration.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/integration.test.ts
@@ -3,10 +3,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
 
 import { safeFetch } from "@/lib/security";
-import { runPodcastExtractor } from "@/trigger/helpers/transcript-extractors";
-import { BANKLESS_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/bankless";
-import { LEX_FRIDMAN_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/lex-fridman";
-import { LIMITLESS_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/limitless";
+import {
+  register,
+  runPodcastExtractor,
+  __resetRegistry,
+} from "@/trigger/helpers/transcript-extractors";
+import {
+  BANKLESS_PODCAST_INDEX_ID,
+  banklessExtractor,
+} from "@/trigger/helpers/transcript-extractors/bankless";
+import {
+  LEX_FRIDMAN_PODCAST_INDEX_ID,
+  lexFridmanExtractor,
+} from "@/trigger/helpers/transcript-extractors/lex-fridman";
+import {
+  LIMITLESS_PODCAST_INDEX_ID,
+  limitlessExtractor,
+} from "@/trigger/helpers/transcript-extractors/limitless";
 import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
 
 const banklessHtml =
@@ -26,6 +39,10 @@ const makeCtx = (
 });
 
 beforeEach(() => {
+  __resetRegistry();
+  register(LEX_FRIDMAN_PODCAST_INDEX_ID, lexFridmanExtractor);
+  register(LIMITLESS_PODCAST_INDEX_ID, limitlessExtractor);
+  register(BANKLESS_PODCAST_INDEX_ID, banklessExtractor);
   vi.clearAllMocks();
   vi.mocked(safeFetch).mockResolvedValue(banklessHtml);
 });

--- a/src/trigger/helpers/transcript-extractors/__tests__/integration.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
+
+import { safeFetch } from "@/lib/security";
+import { runPodcastExtractor } from "@/trigger/helpers/transcript-extractors";
+import { BANKLESS_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/bankless";
+import { LEX_FRIDMAN_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/lex-fridman";
+import { LIMITLESS_PODCAST_INDEX_ID } from "@/trigger/helpers/transcript-extractors/limitless";
+import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
+
+const banklessHtml =
+  '<div id="insideEpisode"><strong>TRANSCRIPT</strong><p>Host: Hello world.</p></div>';
+
+const makeCtx = (
+  podcastIndexId: string,
+  link: string | null = "https://example.com/episode/",
+): ExtractorContext => ({
+  episode: {
+    podcastIndexId: "ep1",
+    title: "Some Episode Title",
+    link,
+    rssGuid: null,
+  },
+  podcast: { podcastIndexId, title: "Some Podcast" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(safeFetch).mockResolvedValue(banklessHtml);
+});
+
+describe("registry wiring (VERIFY 5: registrations against correct podcastIndexId)", () => {
+  it.each([
+    [LEX_FRIDMAN_PODCAST_INDEX_ID, "lex-fridman"],
+    [LIMITLESS_PODCAST_INDEX_ID, "limitless"],
+    [BANKLESS_PODCAST_INDEX_ID, "bankless"],
+  ])(
+    "podcastIndexId %s dispatches to extractor id %s",
+    async (id, expectedExtractorId) => {
+      const result = await runPodcastExtractor(makeCtx(id));
+      expect(result?.extractorId).toBe(expectedExtractorId);
+    },
+  );
+
+  it("returns undefined for an unregistered podcastIndexId", async () => {
+    const result = await runPodcastExtractor(makeCtx("999999999"));
+    expect(result).toBeUndefined();
+  });
+
+  it("converts extractor throws to undefined (VERIFY 4 — registry catches fetch errors)", async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error("HTTP 404"));
+    const result = await runPodcastExtractor(
+      makeCtx(BANKLESS_PODCAST_INDEX_ID),
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/__tests__/lex-fridman.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/lex-fridman.test.ts
@@ -3,20 +3,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-vi.mock("@/trigger/helpers/transcript", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/trigger/helpers/transcript")>();
-  return { ...actual, fetchTranscriptFromUrl: vi.fn() };
-});
+vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
 
-import {
-  fetchTranscriptFromUrl,
-  stripHtmlTranscript,
-} from "@/trigger/helpers/transcript";
+import { safeFetch } from "@/lib/security";
 import { lexFridmanExtractor } from "@/trigger/helpers/transcript-extractors/lex-fridman";
 import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = readFileSync(
+  join(__dirname, "fixtures", "lex-fridman.html"),
+  "utf8",
+);
 
 const makeCtx = (link: string | null): ExtractorContext => ({
   episode: {
@@ -33,51 +30,36 @@ beforeEach(() => {
 });
 
 describe("lexFridmanExtractor", () => {
-  it("builds the correct transcript URL from a trailing-slash episode link", async () => {
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(
-      "plain transcript text",
-    );
-    const result = await lexFridmanExtractor.extract(
+  it("appends -transcript and replaces the trailing slash (VERIFY 1)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("plain transcript text");
+    await lexFridmanExtractor.extract(
       makeCtx("https://lexfridman.com/jensen-huang/"),
     );
-    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
       "https://lexfridman.com/jensen-huang-transcript",
+      expect.anything(),
     );
-    expect(result).toBe("plain transcript text");
   });
 
-  it("returns undefined without fetching when link is null", async () => {
-    const result = await lexFridmanExtractor.extract(makeCtx(null));
-    expect(result).toBeUndefined();
-    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
+  it("appends -transcript when the link has no trailing slash (proves replaceTrailingSlash is wired)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("plain transcript text");
+    await lexFridmanExtractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang"),
+    );
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
+      "https://lexfridman.com/jensen-huang-transcript",
+      expect.anything(),
+    );
   });
 
-  it("returns undefined without fetching when link is empty string", async () => {
-    const result = await lexFridmanExtractor.extract(makeCtx(""));
-    expect(result).toBeUndefined();
-    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
-  });
-
-  it("returns undefined when fetchTranscriptFromUrl returns undefined", async () => {
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(undefined);
+  it("golden-HTML fixture roundtrip: real HTML strips through to clean text", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(fixture);
     const result = await lexFridmanExtractor.extract(
       makeCtx("https://lexfridman.com/jensen-huang/"),
     );
-    expect(result).toBeUndefined();
-  });
-
-  it("golden-HTML fixture roundtrip: returns stripped text from the fixture", async () => {
-    const fixture = readFileSync(
-      join(__dirname, "fixtures", "lex-fridman.html"),
-      "utf8",
-    );
-    const expectedText = stripHtmlTranscript(fixture).trim();
-    expect(expectedText).not.toBe("");
-
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(expectedText);
-    const result = await lexFridmanExtractor.extract(
-      makeCtx("https://lexfridman.com/jensen-huang/"),
-    );
-    expect(result).toBe(expectedText);
+    expect(result).toContain("Jensen Huang");
+    expect(result).toContain("Nvidia");
+    expect(result).not.toMatch(/<\/?(p|script|html|body)\b/i);
+    expect(result).not.toContain("analytics placeholder");
   });
 });

--- a/src/trigger/helpers/transcript-extractors/__tests__/lex-fridman.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/lex-fridman.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+vi.mock("@/trigger/helpers/transcript", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/trigger/helpers/transcript")>();
+  return { ...actual, fetchTranscriptFromUrl: vi.fn() };
+});
+
+import {
+  fetchTranscriptFromUrl,
+  stripHtmlTranscript,
+} from "@/trigger/helpers/transcript";
+import { lexFridmanExtractor } from "@/trigger/helpers/transcript-extractors/lex-fridman";
+import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const makeCtx = (link: string | null): ExtractorContext => ({
+  episode: {
+    podcastIndexId: "ep1",
+    title: "Jensen Huang",
+    link,
+    rssGuid: null,
+  },
+  podcast: { podcastIndexId: "lex-pod", title: "Lex Fridman" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("lexFridmanExtractor", () => {
+  it("builds the correct transcript URL from a trailing-slash episode link", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(
+      "plain transcript text",
+    );
+    const result = await lexFridmanExtractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang/"),
+    );
+    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
+      "https://lexfridman.com/jensen-huang-transcript",
+    );
+    expect(result).toBe("plain transcript text");
+  });
+
+  it("returns undefined without fetching when link is null", async () => {
+    const result = await lexFridmanExtractor.extract(makeCtx(null));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without fetching when link is empty string", async () => {
+    const result = await lexFridmanExtractor.extract(makeCtx(""));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when fetchTranscriptFromUrl returns undefined", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(undefined);
+    const result = await lexFridmanExtractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang/"),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("golden-HTML fixture roundtrip: returns stripped text from the fixture", async () => {
+    const fixture = readFileSync(
+      join(__dirname, "fixtures", "lex-fridman.html"),
+      "utf8",
+    );
+    const expectedText = stripHtmlTranscript(fixture).trim();
+    expect(expectedText).not.toBe("");
+
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(expectedText);
+    const result = await lexFridmanExtractor.extract(
+      makeCtx("https://lexfridman.com/jensen-huang/"),
+    );
+    expect(result).toBe(expectedText);
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/__tests__/limitless.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/limitless.test.ts
@@ -3,20 +3,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-vi.mock("@/trigger/helpers/transcript", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/trigger/helpers/transcript")>();
-  return { ...actual, fetchTranscriptFromUrl: vi.fn() };
-});
+vi.mock("@/lib/security", () => ({ safeFetch: vi.fn() }));
 
-import {
-  fetchTranscriptFromUrl,
-  stripHtmlTranscript,
-} from "@/trigger/helpers/transcript";
+import { safeFetch } from "@/lib/security";
 import { limitlessExtractor } from "@/trigger/helpers/transcript-extractors/limitless";
 import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = readFileSync(
+  join(__dirname, "fixtures", "limitless.html"),
+  "utf8",
+);
 
 const makeCtx = (link: string | null): ExtractorContext => ({
   episode: {
@@ -33,49 +30,25 @@ beforeEach(() => {
 });
 
 describe("limitlessExtractor", () => {
-  it("appends /transcript to the episode link", async () => {
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue("limitless transcript");
-    const result = await limitlessExtractor.extract(
+  it("appends /transcript to the episode link (VERIFY 2)", async () => {
+    vi.mocked(safeFetch).mockResolvedValue("plain transcript text");
+    await limitlessExtractor.extract(
       makeCtx("https://share.transistor.fm/s/51de038d"),
     );
-    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
+    expect(vi.mocked(safeFetch)).toHaveBeenCalledWith(
       "https://share.transistor.fm/s/51de038d/transcript",
+      expect.anything(),
     );
-    expect(result).toBe("limitless transcript");
   });
 
-  it("returns undefined without fetching when link is null", async () => {
-    const result = await limitlessExtractor.extract(makeCtx(null));
-    expect(result).toBeUndefined();
-    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
-  });
-
-  it("returns undefined without fetching when link is empty string", async () => {
-    const result = await limitlessExtractor.extract(makeCtx(""));
-    expect(result).toBeUndefined();
-    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
-  });
-
-  it("returns undefined when fetchTranscriptFromUrl returns undefined", async () => {
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(undefined);
+  it("golden-HTML fixture roundtrip: real HTML strips through to clean text", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(fixture);
     const result = await limitlessExtractor.extract(
       makeCtx("https://share.transistor.fm/s/51de038d"),
     );
-    expect(result).toBeUndefined();
-  });
-
-  it("golden-HTML fixture roundtrip: returns stripped text from the fixture", async () => {
-    const fixture = readFileSync(
-      join(__dirname, "fixtures", "limitless.html"),
-      "utf8",
-    );
-    const expectedText = stripHtmlTranscript(fixture).trim();
-    expect(expectedText).not.toBe("");
-
-    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(expectedText);
-    const result = await limitlessExtractor.extract(
-      makeCtx("https://share.transistor.fm/s/51de038d"),
-    );
-    expect(result).toBe(expectedText);
+    expect(result).toContain("AI agents");
+    expect(result).toContain("Hallucination");
+    expect(result).not.toMatch(/<\/?(p|script|html|body|div)\b/i);
+    expect(result).not.toContain("tracking placeholder");
   });
 });

--- a/src/trigger/helpers/transcript-extractors/__tests__/limitless.test.ts
+++ b/src/trigger/helpers/transcript-extractors/__tests__/limitless.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+vi.mock("@/trigger/helpers/transcript", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/trigger/helpers/transcript")>();
+  return { ...actual, fetchTranscriptFromUrl: vi.fn() };
+});
+
+import {
+  fetchTranscriptFromUrl,
+  stripHtmlTranscript,
+} from "@/trigger/helpers/transcript";
+import { limitlessExtractor } from "@/trigger/helpers/transcript-extractors/limitless";
+import type { ExtractorContext } from "@/trigger/helpers/transcript-extractors/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const makeCtx = (link: string | null): ExtractorContext => ({
+  episode: {
+    podcastIndexId: "ep1",
+    title: "The Future of AI Agents",
+    link,
+    rssGuid: null,
+  },
+  podcast: { podcastIndexId: "limitless-pod", title: "Limitless" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("limitlessExtractor", () => {
+  it("appends /transcript to the episode link", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue("limitless transcript");
+    const result = await limitlessExtractor.extract(
+      makeCtx("https://share.transistor.fm/s/51de038d"),
+    );
+    expect(vi.mocked(fetchTranscriptFromUrl)).toHaveBeenCalledWith(
+      "https://share.transistor.fm/s/51de038d/transcript",
+    );
+    expect(result).toBe("limitless transcript");
+  });
+
+  it("returns undefined without fetching when link is null", async () => {
+    const result = await limitlessExtractor.extract(makeCtx(null));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without fetching when link is empty string", async () => {
+    const result = await limitlessExtractor.extract(makeCtx(""));
+    expect(result).toBeUndefined();
+    expect(vi.mocked(fetchTranscriptFromUrl)).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when fetchTranscriptFromUrl returns undefined", async () => {
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(undefined);
+    const result = await limitlessExtractor.extract(
+      makeCtx("https://share.transistor.fm/s/51de038d"),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("golden-HTML fixture roundtrip: returns stripped text from the fixture", async () => {
+    const fixture = readFileSync(
+      join(__dirname, "fixtures", "limitless.html"),
+      "utf8",
+    );
+    const expectedText = stripHtmlTranscript(fixture).trim();
+    expect(expectedText).not.toBe("");
+
+    vi.mocked(fetchTranscriptFromUrl).mockResolvedValue(expectedText);
+    const result = await limitlessExtractor.extract(
+      makeCtx("https://share.transistor.fm/s/51de038d"),
+    );
+    expect(result).toBe(expectedText);
+  });
+});

--- a/src/trigger/helpers/transcript-extractors/bankless.ts
+++ b/src/trigger/helpers/transcript-extractors/bankless.ts
@@ -28,10 +28,10 @@ export function banklessSlug(title: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-const CONTAINER_RE = /<div\b[^>]*?\bid=["']?insideEpisode\b/i;
-const MARKER_RE = /<strong>\s*TRANSCRIPT\s*<\/strong>/i;
+const CONTAINER_RE = /<div\b[^>]*?\sid=["']?insideEpisode(?=["'\s>])/i;
+const MARKER_RE = /<strong\b[^>]*>\s*TRANSCRIPT\s*<\/strong>/i;
 const END_ANCHOR_RE =
-  /<\w+\s+[^>]*?class=["']?[^"'>]*?\b(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i;
+  /<\w+\b[^>]*?\sclass=["']?[^"'>]*?(?<=\s|["'])(?:postSidebar|rule)(?=["'\s>])|<\/article>|<aside\b|<footer\b/i;
 
 /**
  * Bankless extractor — fetches the episode page, narrows to the transcript

--- a/src/trigger/helpers/transcript-extractors/bankless.ts
+++ b/src/trigger/helpers/transcript-extractors/bankless.ts
@@ -1,0 +1,104 @@
+import { safeFetch } from "@/lib/security";
+import {
+  FETCH_TIMEOUT_MS,
+  MAX_TRANSCRIPT_LENGTH,
+  stripHtmlTranscript,
+} from "@/trigger/helpers/transcript";
+import type {
+  Extractor,
+  ExtractorContext,
+} from "@/trigger/helpers/transcript-extractors/types";
+
+// Bankless Podcast — PodcastIndex feed:
+// https://podcastindex.org/podcast/357756
+export const BANKLESS_PODCAST_INDEX_ID = "357756";
+
+/**
+ * Convert a Bankless episode title into the URL slug used by bankless.com/podcast/.
+ *
+ * Verified empirically against five live episode URLs (2026-05-10): apostrophes
+ * are dropped (NOT hyphenated) — `Bitcoin's` → `bitcoins`, NOT `bitcoin-s`. This
+ * differs from `src/lib/utils.ts` `slugify`, which is why we keep a site-specific
+ * rule here rather than reusing the generic helper.
+ *
+ * Rule:
+ *   1. NFKD normalize + strip combining marks.
+ *   2. Lowercase.
+ *   3. Strip apostrophes / curly quotes / straight double quotes.
+ *   4. Replace runs of any non-`[a-z0-9]` characters with a single hyphen.
+ *   5. Trim leading/trailing hyphens.
+ */
+export function banklessSlug(title: string): string {
+  return title
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/['‘’"“”]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Bankless extractor — fetches the episode page, narrows to the transcript
+ * section by the verified anchor pair, and returns clean text.
+ *
+ * Anchors (verified verbatim 2026-05-10 against
+ * https://www.bankless.com/podcast/megaeth-token-launch-with-co-founders-shuyao-and-lei):
+ *   - Container: `<div id="insideEpisode">`
+ *   - Marker:    `<strong>TRANSCRIPT</strong>`
+ * Both must be present, in order. Either missing → returns undefined.
+ *
+ * The end of the transcript is bounded by the next post-content sibling
+ * (`postSidebar`, `rule`, `</article>`, `<aside`, `<footer`) to avoid bleeding
+ * into "next episode" / sidebar markup.
+ */
+export const banklessExtractor: Extractor = {
+  id: "bankless",
+  extract: async (ctx: ExtractorContext): Promise<string | undefined> => {
+    const title = ctx.episode.title?.trim();
+    if (!title) return undefined;
+
+    const slug = banklessSlug(title);
+    if (!slug) return undefined;
+
+    const url = `https://www.bankless.com/podcast/${slug}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let html: string;
+    try {
+      html = await safeFetch(url, { signal: controller.signal });
+    } catch {
+      // safeFetch throws on non-2xx (security.ts:263–265) and on abort/network errors.
+      // Issue #428 requires undefined-on-error rather than throwing.
+      return undefined;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const containerStart = html.search(
+      /<div\s+id=["']?insideEpisode["']?[^>]*>/i,
+    );
+    if (containerStart === -1) return undefined;
+
+    const inside = html.slice(containerStart);
+    const markerStart = inside.search(/<strong>\s*TRANSCRIPT\s*<\/strong>/i);
+    if (markerStart === -1) return undefined;
+
+    const fromMarker = inside.slice(markerStart);
+    const endIdx = fromMarker.search(
+      /class=["']?(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i,
+    );
+    const scoped = endIdx === -1 ? fromMarker : fromMarker.slice(0, endIdx);
+
+    const text = stripHtmlTranscript(scoped).trim();
+    // Defensive: the <strong>TRANSCRIPT</strong> marker always contributes its
+    // text node, so `text` is never empty in practice with the current anchor
+    // design. Guard retained for future anchor changes.
+    if (!text) return undefined;
+
+    return text.length > MAX_TRANSCRIPT_LENGTH
+      ? text.slice(0, MAX_TRANSCRIPT_LENGTH) + "\n\n[Transcript truncated...]"
+      : text;
+  },
+};

--- a/src/trigger/helpers/transcript-extractors/bankless.ts
+++ b/src/trigger/helpers/transcript-extractors/bankless.ts
@@ -28,7 +28,7 @@ export function banklessSlug(title: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-const CONTAINER_RE = /<div\s+id=["']?insideEpisode\b["']?[^>]*>/i;
+const CONTAINER_RE = /<div\b[^>]*?\bid=["']?insideEpisode\b/i;
 const MARKER_RE = /<strong>\s*TRANSCRIPT\s*<\/strong>/i;
 const END_ANCHOR_RE =
   /<\w+\s+[^>]*?class=["']?(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i;
@@ -69,7 +69,10 @@ export const banklessExtractor: Extractor = {
     const containerStart = html.search(CONTAINER_RE);
     if (containerStart === -1) return undefined;
 
-    const inside = html.slice(containerStart);
+    const rawInside = html.slice(containerStart);
+    const containerEnd = rawInside.search(END_ANCHOR_RE);
+    const inside =
+      containerEnd === -1 ? rawInside : rawInside.slice(0, containerEnd);
     const markerMatch = MARKER_RE.exec(inside);
     if (!markerMatch) return undefined;
 

--- a/src/trigger/helpers/transcript-extractors/bankless.ts
+++ b/src/trigger/helpers/transcript-extractors/bankless.ts
@@ -21,7 +21,7 @@ export const BANKLESS_PODCAST_INDEX_ID = "357756";
 export function banklessSlug(title: string): string {
   return title
     .normalize("NFKD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\u0300-\u036F]/g, "")
     .toLowerCase()
     .replace(/['‘’"“”]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
@@ -31,7 +31,7 @@ export function banklessSlug(title: string): string {
 const CONTAINER_RE = /<div\b[^>]*?\bid=["']?insideEpisode\b/i;
 const MARKER_RE = /<strong>\s*TRANSCRIPT\s*<\/strong>/i;
 const END_ANCHOR_RE =
-  /<\w+\s+[^>]*?class=["']?(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i;
+  /<\w+\s+[^>]*?class=["']?[^"'>]*?\b(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i;
 
 /**
  * Bankless extractor — fetches the episode page, narrows to the transcript

--- a/src/trigger/helpers/transcript-extractors/bankless.ts
+++ b/src/trigger/helpers/transcript-extractors/bankless.ts
@@ -1,16 +1,13 @@
-import { safeFetch } from "@/lib/security";
 import {
-  FETCH_TIMEOUT_MS,
-  MAX_TRANSCRIPT_LENGTH,
+  safeFetchWithTimeout,
   stripHtmlTranscript,
+  truncateTranscript,
 } from "@/trigger/helpers/transcript";
 import type {
   Extractor,
   ExtractorContext,
 } from "@/trigger/helpers/transcript-extractors/types";
 
-// Bankless Podcast — PodcastIndex feed:
-// https://podcastindex.org/podcast/357756
 export const BANKLESS_PODCAST_INDEX_ID = "357756";
 
 /**
@@ -20,13 +17,6 @@ export const BANKLESS_PODCAST_INDEX_ID = "357756";
  * are dropped (NOT hyphenated) — `Bitcoin's` → `bitcoins`, NOT `bitcoin-s`. This
  * differs from `src/lib/utils.ts` `slugify`, which is why we keep a site-specific
  * rule here rather than reusing the generic helper.
- *
- * Rule:
- *   1. NFKD normalize + strip combining marks.
- *   2. Lowercase.
- *   3. Strip apostrophes / curly quotes / straight double quotes.
- *   4. Replace runs of any non-`[a-z0-9]` characters with a single hyphen.
- *   5. Trim leading/trailing hyphens.
  */
 export function banklessSlug(title: string): string {
   return title
@@ -38,6 +28,11 @@ export function banklessSlug(title: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+const CONTAINER_RE = /<div\s+id=["']?insideEpisode\b["']?[^>]*>/i;
+const MARKER_RE = /<strong>\s*TRANSCRIPT\s*<\/strong>/i;
+const END_ANCHOR_RE =
+  /<\w+\s+[^>]*?class=["']?(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i;
+
 /**
  * Bankless extractor — fetches the episode page, narrows to the transcript
  * section by the verified anchor pair, and returns clean text.
@@ -48,9 +43,16 @@ export function banklessSlug(title: string): string {
  *   - Marker:    `<strong>TRANSCRIPT</strong>`
  * Both must be present, in order. Either missing → returns undefined.
  *
+ * The body is sliced from immediately *after* the marker, so a heading-only
+ * section returns undefined rather than the literal word "TRANSCRIPT" (which
+ * would mask fallback to other transcript sources).
+ *
  * The end of the transcript is bounded by the next post-content sibling
  * (`postSidebar`, `rule`, `</article>`, `<aside`, `<footer`) to avoid bleeding
  * into "next episode" / sidebar markup.
+ *
+ * Fetch errors propagate; the registry (`runPodcastExtractor`) catches them
+ * and converts to `undefined` per the scaffolding contract from #459.
  */
 export const banklessExtractor: Extractor = {
   id: "bankless",
@@ -62,43 +64,22 @@ export const banklessExtractor: Extractor = {
     if (!slug) return undefined;
 
     const url = `https://www.bankless.com/podcast/${slug}`;
+    const html = await safeFetchWithTimeout(url);
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    let html: string;
-    try {
-      html = await safeFetch(url, { signal: controller.signal });
-    } catch {
-      // safeFetch throws on non-2xx (security.ts:263–265) and on abort/network errors.
-      // Issue #428 requires undefined-on-error rather than throwing.
-      return undefined;
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    const containerStart = html.search(
-      /<div\s+id=["']?insideEpisode["']?[^>]*>/i,
-    );
+    const containerStart = html.search(CONTAINER_RE);
     if (containerStart === -1) return undefined;
 
     const inside = html.slice(containerStart);
-    const markerStart = inside.search(/<strong>\s*TRANSCRIPT\s*<\/strong>/i);
-    if (markerStart === -1) return undefined;
+    const markerMatch = MARKER_RE.exec(inside);
+    if (!markerMatch) return undefined;
 
-    const fromMarker = inside.slice(markerStart);
-    const endIdx = fromMarker.search(
-      /class=["']?(?:postSidebar|rule)\b|<\/article>|<aside\b|<footer\b/i,
-    );
-    const scoped = endIdx === -1 ? fromMarker : fromMarker.slice(0, endIdx);
+    const fromBody = inside.slice(markerMatch.index + markerMatch[0].length);
+    const endIdx = fromBody.search(END_ANCHOR_RE);
+    const scoped = endIdx === -1 ? fromBody : fromBody.slice(0, endIdx);
 
     const text = stripHtmlTranscript(scoped).trim();
-    // Defensive: the <strong>TRANSCRIPT</strong> marker always contributes its
-    // text node, so `text` is never empty in practice with the current anchor
-    // design. Guard retained for future anchor changes.
     if (!text) return undefined;
 
-    return text.length > MAX_TRANSCRIPT_LENGTH
-      ? text.slice(0, MAX_TRANSCRIPT_LENGTH) + "\n\n[Transcript truncated...]"
-      : text;
+    return truncateTranscript(text);
   },
 };

--- a/src/trigger/helpers/transcript-extractors/index.ts
+++ b/src/trigger/helpers/transcript-extractors/index.ts
@@ -47,3 +47,23 @@ export async function runPodcastExtractor(
     return undefined;
   }
 }
+
+// Concrete extractor registrations (issue #428).
+// Order is irrelevant — the registry keys off podcastIndexId.
+import {
+  LEX_FRIDMAN_PODCAST_INDEX_ID,
+  lexFridmanExtractor,
+} from "@/trigger/helpers/transcript-extractors/lex-fridman";
+register(LEX_FRIDMAN_PODCAST_INDEX_ID, lexFridmanExtractor);
+
+import {
+  LIMITLESS_PODCAST_INDEX_ID,
+  limitlessExtractor,
+} from "@/trigger/helpers/transcript-extractors/limitless";
+register(LIMITLESS_PODCAST_INDEX_ID, limitlessExtractor);
+
+import {
+  BANKLESS_PODCAST_INDEX_ID,
+  banklessExtractor,
+} from "@/trigger/helpers/transcript-extractors/bankless";
+register(BANKLESS_PODCAST_INDEX_ID, banklessExtractor);

--- a/src/trigger/helpers/transcript-extractors/index.ts
+++ b/src/trigger/helpers/transcript-extractors/index.ts
@@ -1,4 +1,16 @@
 import { logger } from "@trigger.dev/sdk";
+import {
+  BANKLESS_PODCAST_INDEX_ID,
+  banklessExtractor,
+} from "@/trigger/helpers/transcript-extractors/bankless";
+import {
+  LEX_FRIDMAN_PODCAST_INDEX_ID,
+  lexFridmanExtractor,
+} from "@/trigger/helpers/transcript-extractors/lex-fridman";
+import {
+  LIMITLESS_PODCAST_INDEX_ID,
+  limitlessExtractor,
+} from "@/trigger/helpers/transcript-extractors/limitless";
 import type {
   Extractor,
   ExtractorContext,
@@ -48,22 +60,7 @@ export async function runPodcastExtractor(
   }
 }
 
-// Concrete extractor registrations (issue #428).
 // Order is irrelevant — the registry keys off podcastIndexId.
-import {
-  LEX_FRIDMAN_PODCAST_INDEX_ID,
-  lexFridmanExtractor,
-} from "@/trigger/helpers/transcript-extractors/lex-fridman";
 register(LEX_FRIDMAN_PODCAST_INDEX_ID, lexFridmanExtractor);
-
-import {
-  LIMITLESS_PODCAST_INDEX_ID,
-  limitlessExtractor,
-} from "@/trigger/helpers/transcript-extractors/limitless";
 register(LIMITLESS_PODCAST_INDEX_ID, limitlessExtractor);
-
-import {
-  BANKLESS_PODCAST_INDEX_ID,
-  banklessExtractor,
-} from "@/trigger/helpers/transcript-extractors/bankless";
 register(BANKLESS_PODCAST_INDEX_ID, banklessExtractor);

--- a/src/trigger/helpers/transcript-extractors/lex-fridman.ts
+++ b/src/trigger/helpers/transcript-extractors/lex-fridman.ts
@@ -1,8 +1,6 @@
 import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
 import type { Extractor } from "@/trigger/helpers/transcript-extractors/types";
 
-// Lex Fridman Podcast — PodcastIndex feed:
-// https://podcastindex.org/podcast/745287
 export const LEX_FRIDMAN_PODCAST_INDEX_ID = "745287";
 
 export const lexFridmanExtractor: Extractor = linkSuffixExtractor({

--- a/src/trigger/helpers/transcript-extractors/lex-fridman.ts
+++ b/src/trigger/helpers/transcript-extractors/lex-fridman.ts
@@ -1,0 +1,12 @@
+import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
+import type { Extractor } from "@/trigger/helpers/transcript-extractors/types";
+
+// Lex Fridman Podcast — PodcastIndex feed:
+// https://podcastindex.org/podcast/745287
+export const LEX_FRIDMAN_PODCAST_INDEX_ID = "745287";
+
+export const lexFridmanExtractor: Extractor = linkSuffixExtractor({
+  id: "lex-fridman",
+  suffix: "-transcript",
+  replaceTrailingSlash: true,
+});

--- a/src/trigger/helpers/transcript-extractors/limitless.ts
+++ b/src/trigger/helpers/transcript-extractors/limitless.ts
@@ -6,4 +6,5 @@ export const LIMITLESS_PODCAST_INDEX_ID = "7326914";
 export const limitlessExtractor: Extractor = linkSuffixExtractor({
   id: "limitless",
   suffix: "/transcript",
+  replaceTrailingSlash: true,
 });

--- a/src/trigger/helpers/transcript-extractors/limitless.ts
+++ b/src/trigger/helpers/transcript-extractors/limitless.ts
@@ -1,8 +1,6 @@
 import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
 import type { Extractor } from "@/trigger/helpers/transcript-extractors/types";
 
-// Limitless Podcast — PodcastIndex feed:
-// https://podcastindex.org/podcast/7326914
 export const LIMITLESS_PODCAST_INDEX_ID = "7326914";
 
 export const limitlessExtractor: Extractor = linkSuffixExtractor({

--- a/src/trigger/helpers/transcript-extractors/limitless.ts
+++ b/src/trigger/helpers/transcript-extractors/limitless.ts
@@ -1,0 +1,11 @@
+import { linkSuffixExtractor } from "@/trigger/helpers/transcript-extractors/link-suffix";
+import type { Extractor } from "@/trigger/helpers/transcript-extractors/types";
+
+// Limitless Podcast — PodcastIndex feed:
+// https://podcastindex.org/podcast/7326914
+export const LIMITLESS_PODCAST_INDEX_ID = "7326914";
+
+export const limitlessExtractor: Extractor = linkSuffixExtractor({
+  id: "limitless",
+  suffix: "/transcript",
+});

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -4,6 +4,26 @@ import { safeFetch } from "@/lib/security";
 
 export const MAX_TRANSCRIPT_LENGTH = 50000;
 export const FETCH_TIMEOUT_MS = 30000;
+export const TRUNCATED_MARKER = "\n\n[Transcript truncated...]";
+
+export async function safeFetchWithTimeout(
+  url: string,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await safeFetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function truncateTranscript(text: string): string {
+  return text.length > MAX_TRANSCRIPT_LENGTH
+    ? text.slice(0, MAX_TRANSCRIPT_LENGTH) + TRUNCATED_MARKER
+    : text;
+}
 
 const SUPPORTED_TRANSCRIPT_TYPES = [
   "text/plain",
@@ -94,17 +114,7 @@ export async function fetchTranscript(
     return undefined;
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  let transcript: string;
-  try {
-    transcript = await safeFetch(transcriptEntry.url, {
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timeout);
-  }
+  let transcript = await safeFetchWithTimeout(transcriptEntry.url);
 
   const rawLength = transcript.length;
   transcript = normalizeTranscriptContent(transcript, transcriptEntry.type);
@@ -119,13 +129,7 @@ export async function fetchTranscript(
     }
     return undefined;
   }
-  if (transcript.length > MAX_TRANSCRIPT_LENGTH) {
-    transcript =
-      transcript.slice(0, MAX_TRANSCRIPT_LENGTH) +
-      "\n\n[Transcript truncated...]";
-  }
-
-  return transcript;
+  return truncateTranscript(transcript);
 }
 
 /**
@@ -162,26 +166,14 @@ export function extractTranscriptUrl(description: string): string | null {
 export async function fetchTranscriptFromUrl(
   url: string,
 ): Promise<string | undefined> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    let content = await safeFetch(url, { signal: controller.signal });
+  let content = await safeFetchWithTimeout(url);
 
-    if (/<html[\s>]/i.test(content) || /<!doctype\s+html/i.test(content)) {
-      content = stripHtmlTranscript(content);
-    }
-
-    content = content.trim();
-    if (!content) return undefined;
-
-    if (content.length > MAX_TRANSCRIPT_LENGTH) {
-      content =
-        content.slice(0, MAX_TRANSCRIPT_LENGTH) +
-        "\n\n[Transcript truncated...]";
-    }
-
-    return content;
-  } finally {
-    clearTimeout(timeout);
+  if (/<html[\s>]/i.test(content) || /<!doctype\s+html/i.test(content)) {
+    content = stripHtmlTranscript(content);
   }
+
+  content = content.trim();
+  if (!content) return undefined;
+
+  return truncateTranscript(content);
 }

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -2,8 +2,8 @@ import he from "he";
 import type { PodcastIndexEpisode } from "@/lib/podcastindex";
 import { safeFetch } from "@/lib/security";
 
-const MAX_TRANSCRIPT_LENGTH = 50000;
-const FETCH_TIMEOUT_MS = 30000;
+export const MAX_TRANSCRIPT_LENGTH = 50000;
+export const FETCH_TIMEOUT_MS = 30000;
 
 const SUPPORTED_TRANSCRIPT_TYPES = [
   "text/plain",

--- a/src/trigger/helpers/transcript.ts
+++ b/src/trigger/helpers/transcript.ts
@@ -20,9 +20,12 @@ export async function safeFetchWithTimeout(
 }
 
 export function truncateTranscript(text: string): string {
-  return text.length > MAX_TRANSCRIPT_LENGTH
-    ? text.slice(0, MAX_TRANSCRIPT_LENGTH) + TRUNCATED_MARKER
-    : text;
+  if (text.length <= MAX_TRANSCRIPT_LENGTH) return text;
+  let truncated = text.slice(0, MAX_TRANSCRIPT_LENGTH);
+  if (/[\uD800-\uDBFF]$/.test(truncated)) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated + TRUNCATED_MARKER;
 }
 
 const SUPPORTED_TRANSCRIPT_TYPES = [
@@ -161,7 +164,7 @@ export function extractTranscriptUrl(description: string): string | null {
 
 /**
  * Fetches transcript content from a URL using SSRF-safe fetching.
- * Returns undefined on any error (non-fatal fallback).
+ * Throws on fetch errors; returns undefined only for empty or whitespace-only content.
  */
 export async function fetchTranscriptFromUrl(
   url: string,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
     css: false,
+    testTimeout: 30000,
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next", "storybook-static"],
     coverage: {


### PR DESCRIPTION
## Summary

- Three concrete transcript extractors registered against the scaffolding from #459. **Lex Fridman** (`linkSuffixExtractor` with `-transcript`) and **Limitless** (`linkSuffixExtractor` with `/transcript`) are one-line registrations; **Bankless** is bespoke (title-derived URL via `banklessSlug` → `safeFetchWithTimeout` → narrow on the verified anchor pair `<div id="insideEpisode">` + `<strong>TRANSCRIPT</strong>` → `stripHtmlTranscript`).
- Per the #459 scaffolding contract, extractors propagate fetch errors and the registry's outer `try/catch` (`runPodcastExtractor`) is the throw-shield — it converts throws to `undefined` so the transcript-acquisition waterfall stays non-fatal.
- Each ships with a ≤5KB golden-HTML fixture test (`__tests__/fixtures/*.html`); the Lex/Limitless tests now mock at the `safeFetch` boundary so the real strip pipeline runs end-to-end (was tautological in the first cut). New `__tests__/integration.test.ts` verifies registry → extractor wiring by `podcastIndexId` and the registry's throw-to-undefined contract.
- Promoted `MAX_TRANSCRIPT_LENGTH`, `FETCH_TIMEOUT_MS`, `TRUNCATED_MARKER`, `safeFetchWithTimeout`, and `truncateTranscript` to module exports in `transcript.ts`; `fetchTranscript`, `fetchTranscriptFromUrl`, and Bankless now share the abort-timeout + truncation patterns instead of duplicating them three times.
- Real PodcastIndex feed IDs in place: Lex Fridman `745287`, Limitless `7326914`, Bankless `357756`.
- Pipeline integration in `fetch-transcript.ts` is **out of scope** here; that lands in #429.

## Test plan

- [x] `bun run test` — full repo: 3278 passed, 54 skipped, 0 failures
- [x] `bun run test src/trigger/helpers/transcript-extractors/` — 60 tests pass (added integration suite + boundary cases + slug-empty + marker-no-body)
- [x] `bun run test src/trigger/helpers/__tests__/transcript.test.ts` — 51 pass, no regression from helper extraction
- [x] `bun run test:coverage` — extractor submodule lines ≥80% threshold
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run build` — production build compiles
- [x] `bun run build-storybook` — Storybook build compiles
- [x] `rg PLACEHOLDER_ src/trigger/helpers/transcript-extractors/` — no matches
- [x] All three fixture files ≤5KB: lex-fridman 1501B, limitless 1801B, bankless 1652B

Closes #428

## Agent Notes

### Open Questions

- The Bankless container regex `<div\s+id=["']?insideEpisode\b["']?[^>]*>` now uses a `\b` after `insideEpisode` to reject prefix-matches like `id="insideEpisodeFoo"`. The end-anchor regex was tightened to anchor on the `<tag` boundary so the scoped slice doesn't end mid-tag. Both changes are validated by the new boundary tests; if Bankless ever switches to multi-attribute markup (e.g., `class="foo postSidebar"`), the end-anchor would miss and we'd fall through to `<\/article>` / `<aside`. Worth re-validating against 2–3 more live episodes before #429 wires the pipeline.
- `bankless.ts` empty-body branch: the original "defensive guard" was unreachable (the marker text "TRANSCRIPT" always survived stripping). After slicing past the marker (Codex P2 fix), the guard is now meaningful — it catches genuinely empty post-marker sections. No log added; the registry's outer `logger.warn` covers diagnostic visibility for any throw, and an empty-body return is a normal "no transcript" signal.

### Context for Next Session

- #429 integrates this registry into `src/trigger/fetch-transcript.ts`. The dispatcher is `runPodcastExtractor(ctx)` from `src/trigger/helpers/transcript-extractors/index.ts`; it returns `{ transcript, extractorId } | undefined`. Keys off `ctx.podcast.podcastIndexId`. Per the #459 scaffolding contract, the dispatcher catches extractor throws and converts them to `undefined`, so `fetch-transcript.ts` only needs to handle the success/fallthrough cases.
- Bankless uses `episode.title` (not `episode.link`) to derive the URL, unlike Lex/Limitless which use `episode.link + suffix`. The integration in #429 needs to pass full `ExtractorContext` including `title` — see `src/trigger/helpers/transcript-extractors/types.ts:1-9`.
- `safeFetchWithTimeout` and `truncateTranscript` are now exported from `src/trigger/helpers/transcript.ts` and reused across `fetchTranscript`, `fetchTranscriptFromUrl`, and `banklessExtractor`. Future extractors should use these helpers rather than recreating the abort/timeout/truncation pattern.
- PodcastIndex feed IDs are hard-coded as string consts (`*_PODCAST_INDEX_ID`) in each extractor file. If a podcast is re-imported with a different feed source, the registry key won't match — IDs may need updating in those files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic transcript extraction added for Bankless, Lex Fridman, and Limitless podcasts.

* **Reliability & Behavior**
  * Centralized fetch timeout and truncation handling to improve extraction robustness and predictable transcript length.

* **Tests**
  * Comprehensive unit and integration tests added to validate extractor behavior and registry wiring.

* **Documentation**
  * Changelog and developer notes updated with extractor details and development tips.

* **Chores**
  * Test runner timeout adjusted; minor configuration updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/461)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->