### PR TITLE
feat: integrate podcast-site extractor into fetch-transcript pipeline

### DIFF
--- a/.agentnotes/cdt/feat-fetch-transcript-podcast-site.md
+++ b/.agentnotes/cdt/feat-fetch-transcript-podcast-site.md
@@ -12,11 +12,11 @@
 
 ### What's Done
 
-PR #464 opened. Step 3 inserted in fetch-transcript.ts gated on Step 2 miss; lazy `db.query.episodes.findFirst({ with: { podcast: true } })` loads the `ExtractorContext` payload without widening `FetchTranscriptPayload`. `persistTranscript` gained optional 4th `extractorId?: string` with conditional spread. Tests: hit / miss / throw / orphaned-FK in fetch-transcript.test.ts plus two unit tests for the conditional spread in database.test.ts.
+PR #464 opened. Step 3 inserted in fetch-transcript.ts gated on Step 2 miss; lazy `db.query.episodes.findFirst({ with: { podcast: true } })` loads the `ExtractorContext` payload without widening `FetchTranscriptPayload`. `persistTranscript` gained optional 4th `extractorId?: string` and always writes `transcript_extractor` (set when `source === "podcast-site"`, cleared to `null` otherwise) so the column never carries stale provenance across a `force=true` re-fetch. Tests: hit / miss / throw / orphaned-FK in fetch-transcript.test.ts plus four unit tests in database.test.ts covering the always-clear behavior (podcast-site with/without extractorId, non-podcast-site source, and stale-clearing on re-fetch).
 
 ### Open Questions
 
-- Conditional spread vs unconditional `extractorId ?? null` write in `persistTranscript` was a deliberate plan-time choice (plan L32) — Codex and one internal reviewer both proposed flipping it. Mitigation: documented the rationale inline (`src/trigger/helpers/database.ts:161-165`) so future readers see the constraint before changing it. If a "force re-fetch UX" lands later that needs to clear the column on supersession, that's the moment to revisit.
+- Initial plan-time decision (plan L32) used a conditional spread to defer column clearing to a future "force re-fetch UX". Three reviewers (Codex P2, internal code-reviewer, then gemini-code-assist on PR) flagged the stale-provenance bug on `force=true` re-fetch by a different source. Reversed in commit 9c9a1d5 — now `transcript_extractor` always reflects the current source's provenance via an unconditional ternary.
 - Type-design reviewer suggested branding `extractorId` as `TranscriptExtractorId` (closed union derived from the registry). Deferred per checklist §7 — touches 5 files in `src/trigger/helpers/transcript-extractors/` (#428's scope) and the bug isn't introduced by this PR.
 
 ### Context for Next Session

--- a/.agentnotes/cdt/feat-fetch-transcript-podcast-site.md
+++ b/.agentnotes/cdt/feat-fetch-transcript-podcast-site.md
@@ -1,0 +1,30 @@
+# Branch: feat/fetch-transcript-podcast-site
+
+**Created**: 2026-05-11
+**First plan**: .dev/cdt/plans/plan-20260511-1433.md
+
+---
+
+## Session 20260511-1452
+
+**Task**: Integrate the podcast-site extractor registry into `src/trigger/fetch-transcript.ts` as a new Step 3 between PodcastIndex and description-URL; thread `transcript_extractor` through `persistTranscript`; cover with three Vitest cases (hit / miss / extractor-throw). Closes #429.
+**Plan**: .dev/cdt/plans/plan-20260511-1433.md
+
+### What's Done
+
+PR #464 opened. Step 3 inserted in fetch-transcript.ts gated on Step 2 miss; lazy `db.query.episodes.findFirst({ with: { podcast: true } })` loads the `ExtractorContext` payload without widening `FetchTranscriptPayload`. `persistTranscript` gained optional 4th `extractorId?: string` with conditional spread. Tests: hit / miss / throw / orphaned-FK in fetch-transcript.test.ts plus two unit tests for the conditional spread in database.test.ts.
+
+### Open Questions
+
+- Conditional spread vs unconditional `extractorId ?? null` write in `persistTranscript` was a deliberate plan-time choice (plan L32) — Codex and one internal reviewer both proposed flipping it. Mitigation: documented the rationale inline (`src/trigger/helpers/database.ts:161-165`) so future readers see the constraint before changing it. If a "force re-fetch UX" lands later that needs to clear the column on supersession, that's the moment to revisit.
+- Type-design reviewer suggested branding `extractorId` as `TranscriptExtractorId` (closed union derived from the registry). Deferred per checklist §7 — touches 5 files in `src/trigger/helpers/transcript-extractors/` (#428's scope) and the bug isn't introduced by this PR.
+
+### Context for Next Session
+
+- Pipeline order is now `cached → podcastindex → podcast-site → description-url → assemblyai` (5 steps). Inline `// Step N:` comments at `src/trigger/fetch-transcript.ts:65, 89, 114, 163, 189` are the source of truth — keep them renumbered if more steps are inserted.
+- The Step 3 DB lookup is a **separate** `findFirst` from the Step 1 cache check by design — Step 1 stays a single-column lookup so the cache-hit fast path doesn't pay the podcast join cost. Reviewers consistently flag this as duplication; it's intentional.
+- Test-side `stubStep3Lookup(row)` helper in `src/trigger/__tests__/fetch-transcript.test.ts` is the canonical way to stub the relational query; future Step-3-touching tests should reuse it instead of inlining `mockFindFirst.mockImplementation` branches.
+- Pre-PR validation flagged 7 actionable findings across 9 reviewers; the second commit (`39b1290`) addresses all of them — see PR #464 commit history.
+
+### References
+- PR: https://github.com/Chalet-Labs/contentgenie/pull/464

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Bankless, Lex Fridman, and Limitless transcript extractors (`src/trigger/helpers/transcript-extractors/`). Each podcast's episode page is parsed (Bankless via bespoke HTML anchor pair; Lex Fridman + Limitless via the shared `linkSuffixExtractor`) to surface a transcript when PodcastIndex / RSS feeds don't carry one. Pipeline wiring in `fetch-transcript.ts` follows in #429. (#428)
+- Wired podcast-site extractor registry into the fetch-transcript waterfall as Step 3 (between PodcastIndex and description-URL); on hit, persists the extractor id in `episodes.transcript_extractor`. (#429)
+- Bankless, Lex Fridman, and Limitless transcript extractors (`src/trigger/helpers/transcript-extractors/`). Each podcast's episode page is parsed (Bankless via bespoke HTML anchor pair; Lex Fridman + Limitless via the shared `linkSuffixExtractor`) to surface a transcript when PodcastIndex / RSS feeds don't carry one. (#428)
 - Regression tests + Storybook story for podcast-site transcript source value (#430)
 - Internal `transcript-extractors` registry scaffolding (`src/trigger/helpers/transcript-extractors/`) with the shared `linkSuffixExtractor` factory. Empty registry — specific extractors and pipeline wiring follow in #428/#429. (#427)
 - `episode_link` and `transcript_extractor` columns on `episodes`, plus `'podcast-site'` accepted by `transcript_source_enum`. Persists PodcastIndex `link` on episode insert across poll/processing/summary paths. (#426)

--- a/src/trigger/__tests__/fetch-transcript.test.ts
+++ b/src/trigger/__tests__/fetch-transcript.test.ts
@@ -13,20 +13,38 @@ vi.mock("@trigger.dev/sdk", () =>
   }),
 );
 
-// Branches on query shape: Step 1 uses columns:{transcription}, Step 3 uses with:{podcast}
-const mockFindFirst = vi
-  .fn()
-  .mockImplementation(
-    (opts: {
-      columns?: Record<string, unknown>;
-      with?: Record<string, unknown>;
-    }) => {
+const mockFindFirst = vi.fn().mockResolvedValue(null);
+
+type EpisodeWithPodcastRow = {
+  podcastIndexId: string;
+  title: string;
+  episodeLink: string | null;
+  rssGuid: string | null;
+  podcast: { podcastIndexId: string; title: string } | null;
+};
+
+const defaultStep3EpisodeRow: EpisodeWithPodcastRow = {
+  podcastIndexId: "12345",
+  title: "Ep title",
+  episodeLink: "https://example.com/ep",
+  rssGuid: "guid-1",
+  podcast: { podcastIndexId: "357756", title: "Bankless" },
+};
+
+// Step 1 uses columns:{transcription} (no `with`), Step 3 uses with:{podcast}.
+// Stubs the Step 3 lookup to return `row` and leaves the Step 1 lookup at the
+// caller-provided default (set on `mockFindFirst` via `.mockResolvedValue`).
+function stubStep3Lookup(row: EpisodeWithPodcastRow | null) {
+  const step1Default = mockFindFirst.getMockImplementation();
+  mockFindFirst.mockImplementation(
+    (opts: { with?: Record<string, unknown> }) => {
       if (opts?.with?.podcast !== undefined) {
-        return Promise.resolve(null);
+        return Promise.resolve(row);
       }
-      return Promise.resolve(null);
+      return step1Default ? step1Default(opts) : Promise.resolve(null);
     },
   );
+}
 
 vi.mock("@/db", () => ({
   db: {
@@ -115,17 +133,7 @@ const mockTranscripts = [
 describe("fetch-transcript task", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindFirst.mockImplementation(
-      (opts: {
-        columns?: Record<string, unknown>;
-        with?: Record<string, unknown>;
-      }) => {
-        if (opts?.with?.podcast !== undefined) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
-      },
-    );
+    mockFindFirst.mockResolvedValue(null);
     mockRunPodcastExtractor.mockResolvedValue(undefined);
     mockPersistTranscript.mockResolvedValue(undefined);
     mockSummarizeTrigger.mockResolvedValue({ id: "run_summarize" });
@@ -153,6 +161,7 @@ describe("fetch-transcript task", () => {
       source: undefined,
     });
     expect(mockFetchTranscript).not.toHaveBeenCalled();
+    expect(mockRunPodcastExtractor).not.toHaveBeenCalled();
     expect(vi.mocked(submitTranscriptionAsync)).not.toHaveBeenCalled();
     expect(mockPersistTranscript).not.toHaveBeenCalled();
   });
@@ -194,6 +203,7 @@ describe("fetch-transcript task", () => {
       transcript: "PodcastIndex transcript text",
       source: "podcastindex",
     });
+    expect(mockRunPodcastExtractor).not.toHaveBeenCalled();
     expect(mockPersistTranscript).toHaveBeenCalledWith(
       123,
       "PodcastIndex transcript text",
@@ -432,23 +442,7 @@ describe("fetch-transcript task", () => {
 
   it("podcast-site extractor hit: returns transcript, skips description-URL and AssemblyAI", async () => {
     mockFetchTranscript.mockResolvedValue(undefined);
-    mockFindFirst.mockImplementation(
-      (opts: {
-        columns?: Record<string, unknown>;
-        with?: Record<string, unknown>;
-      }) => {
-        if (opts?.with?.podcast !== undefined) {
-          return Promise.resolve({
-            podcastIndexId: "12345",
-            title: "Ep title",
-            episodeLink: "https://example.com/ep",
-            rssGuid: "guid-1",
-            podcast: { podcastIndexId: "357756", title: "Bankless" },
-          });
-        }
-        return Promise.resolve(null);
-      },
-    );
+    stubStep3Lookup(defaultStep3EpisodeRow);
     mockRunPodcastExtractor.mockResolvedValue({
       transcript: "Site transcript",
       extractorId: "bankless",
@@ -472,23 +466,7 @@ describe("fetch-transcript task", () => {
 
   it("podcast-site extractor miss: falls through to description-URL step", async () => {
     mockFetchTranscript.mockResolvedValue(undefined);
-    mockFindFirst.mockImplementation(
-      (opts: {
-        columns?: Record<string, unknown>;
-        with?: Record<string, unknown>;
-      }) => {
-        if (opts?.with?.podcast !== undefined) {
-          return Promise.resolve({
-            podcastIndexId: "12345",
-            title: "Ep title",
-            episodeLink: "https://example.com/ep",
-            rssGuid: "guid-1",
-            podcast: { podcastIndexId: "357756", title: "Bankless" },
-          });
-        }
-        return Promise.resolve(null);
-      },
-    );
+    stubStep3Lookup(defaultStep3EpisodeRow);
     mockRunPodcastExtractor.mockResolvedValue(undefined);
     mockExtractTranscriptUrl.mockReturnValue(
       "https://example.com/transcript.txt",
@@ -516,23 +494,7 @@ describe("fetch-transcript task", () => {
 
   it("podcast-site extractor throws: pipeline continues non-fatally, falls through to AssemblyAI", async () => {
     mockFetchTranscript.mockResolvedValue(undefined);
-    mockFindFirst.mockImplementation(
-      (opts: {
-        columns?: Record<string, unknown>;
-        with?: Record<string, unknown>;
-      }) => {
-        if (opts?.with?.podcast !== undefined) {
-          return Promise.resolve({
-            podcastIndexId: "12345",
-            title: "Ep title",
-            episodeLink: "https://example.com/ep",
-            rssGuid: "guid-1",
-            podcast: { podcastIndexId: "357756", title: "Bankless" },
-          });
-        }
-        return Promise.resolve(null);
-      },
-    );
+    stubStep3Lookup(defaultStep3EpisodeRow);
     mockRunPodcastExtractor.mockRejectedValue(new Error("registry exploded"));
     mockExtractTranscriptUrl.mockReturnValue(null);
     const mockToken = {
@@ -569,22 +531,33 @@ describe("fetch-transcript task", () => {
       undefined,
     );
   });
+
+  it("podcast-site skipped when episode row has no joined podcast (unregistered FK)", async () => {
+    mockFetchTranscript.mockResolvedValue(undefined);
+    stubStep3Lookup({ ...defaultStep3EpisodeRow, podcast: null });
+    mockExtractTranscriptUrl.mockReturnValue(
+      "https://example.com/transcript.txt",
+    );
+    mockFetchTranscriptFromUrl.mockResolvedValue("Description URL transcript");
+
+    const result = await taskConfig.run({
+      episodeId: 123,
+      transcripts: [],
+      description: "See transcript at https://example.com/transcript.txt",
+    });
+
+    expect(mockRunPodcastExtractor).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      transcript: "Description URL transcript",
+      source: "description-url",
+    });
+  });
 });
 
 describe("fetch-transcript triggerSummarize chaining", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindFirst.mockImplementation(
-      (opts: {
-        columns?: Record<string, unknown>;
-        with?: Record<string, unknown>;
-      }) => {
-        if (opts?.with?.podcast !== undefined) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
-      },
-    );
+    mockFindFirst.mockResolvedValue(null);
     mockRunPodcastExtractor.mockResolvedValue(undefined);
     mockPersistTranscript.mockResolvedValue(undefined);
     mockSummarizeTrigger.mockResolvedValue({ id: "run_summarize" });

--- a/src/trigger/__tests__/fetch-transcript.test.ts
+++ b/src/trigger/__tests__/fetch-transcript.test.ts
@@ -13,7 +13,20 @@ vi.mock("@trigger.dev/sdk", () =>
   }),
 );
 
-const mockFindFirst = vi.fn().mockResolvedValue(null);
+// Branches on query shape: Step 1 uses columns:{transcription}, Step 3 uses with:{podcast}
+const mockFindFirst = vi
+  .fn()
+  .mockImplementation(
+    (opts: {
+      columns?: Record<string, unknown>;
+      with?: Record<string, unknown>;
+    }) => {
+      if (opts?.with?.podcast !== undefined) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    },
+  );
 
 vi.mock("@/db", () => ({
   db: {
@@ -32,10 +45,16 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/db/schema", () => ({
   episodes: { podcastIndexId: "podcastIndexId" },
+  podcasts: { podcastIndexId: "podcastIndexId" },
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
+}));
+
+const mockRunPodcastExtractor = vi.fn();
+vi.mock("@/trigger/helpers/transcript-extractors", () => ({
+  runPodcastExtractor: (...args: unknown[]) => mockRunPodcastExtractor(...args),
 }));
 
 const mockFetchTranscript = vi.fn();
@@ -96,7 +115,18 @@ const mockTranscripts = [
 describe("fetch-transcript task", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindFirst.mockResolvedValue(null);
+    mockFindFirst.mockImplementation(
+      (opts: {
+        columns?: Record<string, unknown>;
+        with?: Record<string, unknown>;
+      }) => {
+        if (opts?.with?.podcast !== undefined) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      },
+    );
+    mockRunPodcastExtractor.mockResolvedValue(undefined);
     mockPersistTranscript.mockResolvedValue(undefined);
     mockSummarizeTrigger.mockResolvedValue({ id: "run_summarize" });
   });
@@ -148,6 +178,7 @@ describe("fetch-transcript task", () => {
       123,
       "PodcastIndex transcript",
       "podcastindex",
+      undefined,
     );
   });
 
@@ -167,6 +198,7 @@ describe("fetch-transcript task", () => {
       123,
       "PodcastIndex transcript text",
       "podcastindex",
+      undefined,
     );
   });
 
@@ -191,6 +223,7 @@ describe("fetch-transcript task", () => {
       123,
       "Description URL transcript",
       "description-url",
+      undefined,
     );
     expect(vi.mocked(submitTranscriptionAsync)).not.toHaveBeenCalled();
   });
@@ -229,6 +262,7 @@ describe("fetch-transcript task", () => {
       123,
       "AssemblyAI transcript",
       "assemblyai",
+      undefined,
     );
   });
 
@@ -395,12 +429,163 @@ describe("fetch-transcript task", () => {
     const result = await taskConfig.run({ episodeId: 123, transcripts: [] });
     expect(result).toEqual({ transcript: undefined, source: null });
   });
+
+  it("podcast-site extractor hit: returns transcript, skips description-URL and AssemblyAI", async () => {
+    mockFetchTranscript.mockResolvedValue(undefined);
+    mockFindFirst.mockImplementation(
+      (opts: {
+        columns?: Record<string, unknown>;
+        with?: Record<string, unknown>;
+      }) => {
+        if (opts?.with?.podcast !== undefined) {
+          return Promise.resolve({
+            podcastIndexId: "12345",
+            title: "Ep title",
+            episodeLink: "https://example.com/ep",
+            rssGuid: "guid-1",
+            podcast: { podcastIndexId: "357756", title: "Bankless" },
+          });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    mockRunPodcastExtractor.mockResolvedValue({
+      transcript: "Site transcript",
+      extractorId: "bankless",
+    });
+
+    const result = await taskConfig.run({ episodeId: 123, transcripts: [] });
+
+    expect(result).toEqual({
+      transcript: "Site transcript",
+      source: "podcast-site",
+    });
+    expect(mockPersistTranscript).toHaveBeenCalledWith(
+      123,
+      "Site transcript",
+      "podcast-site",
+      "bankless",
+    );
+    expect(mockExtractTranscriptUrl).not.toHaveBeenCalled();
+    expect(vi.mocked(submitTranscriptionAsync)).not.toHaveBeenCalled();
+  });
+
+  it("podcast-site extractor miss: falls through to description-URL step", async () => {
+    mockFetchTranscript.mockResolvedValue(undefined);
+    mockFindFirst.mockImplementation(
+      (opts: {
+        columns?: Record<string, unknown>;
+        with?: Record<string, unknown>;
+      }) => {
+        if (opts?.with?.podcast !== undefined) {
+          return Promise.resolve({
+            podcastIndexId: "12345",
+            title: "Ep title",
+            episodeLink: "https://example.com/ep",
+            rssGuid: "guid-1",
+            podcast: { podcastIndexId: "357756", title: "Bankless" },
+          });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    mockRunPodcastExtractor.mockResolvedValue(undefined);
+    mockExtractTranscriptUrl.mockReturnValue(
+      "https://example.com/transcript.txt",
+    );
+    mockFetchTranscriptFromUrl.mockResolvedValue("Description URL transcript");
+
+    const result = await taskConfig.run({
+      episodeId: 123,
+      transcripts: [],
+      description: "See transcript at https://example.com/transcript.txt",
+    });
+
+    expect(mockRunPodcastExtractor).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      transcript: "Description URL transcript",
+      source: "description-url",
+    });
+    expect(mockPersistTranscript).toHaveBeenCalledWith(
+      123,
+      "Description URL transcript",
+      "description-url",
+      undefined,
+    );
+  });
+
+  it("podcast-site extractor throws: pipeline continues non-fatally, falls through to AssemblyAI", async () => {
+    mockFetchTranscript.mockResolvedValue(undefined);
+    mockFindFirst.mockImplementation(
+      (opts: {
+        columns?: Record<string, unknown>;
+        with?: Record<string, unknown>;
+      }) => {
+        if (opts?.with?.podcast !== undefined) {
+          return Promise.resolve({
+            podcastIndexId: "12345",
+            title: "Ep title",
+            episodeLink: "https://example.com/ep",
+            rssGuid: "guid-1",
+            podcast: { podcastIndexId: "357756", title: "Bankless" },
+          });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    mockRunPodcastExtractor.mockRejectedValue(new Error("registry exploded"));
+    mockExtractTranscriptUrl.mockReturnValue(null);
+    const mockToken = {
+      id: "token-1",
+      url: "https://hooks.trigger.dev/token/1",
+    };
+    mockCreateToken.mockResolvedValue(mockToken);
+    vi.mocked(submitTranscriptionAsync).mockResolvedValue("transcript-abc");
+    mockForToken.mockResolvedValue({
+      ok: true,
+      output: { transcript_id: "transcript-abc", status: "completed" },
+    });
+    vi.mocked(getTranscriptionStatus).mockResolvedValue({
+      id: "transcript-abc",
+      status: "completed",
+      text: "AssemblyAI transcript",
+      error: null,
+    });
+
+    const result = await taskConfig.run({
+      episodeId: 123,
+      transcripts: [],
+      enclosureUrl: "https://example.com/audio.mp3",
+    });
+
+    expect(result).toEqual({
+      transcript: "AssemblyAI transcript",
+      source: "assemblyai",
+    });
+    expect(mockPersistTranscript).toHaveBeenCalledWith(
+      123,
+      "AssemblyAI transcript",
+      "assemblyai",
+      undefined,
+    );
+  });
 });
 
 describe("fetch-transcript triggerSummarize chaining", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindFirst.mockResolvedValue(null);
+    mockFindFirst.mockImplementation(
+      (opts: {
+        columns?: Record<string, unknown>;
+        with?: Record<string, unknown>;
+      }) => {
+        if (opts?.with?.podcast !== undefined) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      },
+    );
+    mockRunPodcastExtractor.mockResolvedValue(undefined);
     mockPersistTranscript.mockResolvedValue(undefined);
     mockSummarizeTrigger.mockResolvedValue({ id: "run_summarize" });
   });

--- a/src/trigger/fetch-transcript.ts
+++ b/src/trigger/fetch-transcript.ts
@@ -146,7 +146,9 @@ export const fetchTranscriptTask = task({
               length: transcript.length,
             });
           } else {
-            logger.info("No transcript from podcast-site extractor");
+            logger.debug("No transcript from podcast-site extractor", {
+              episodeId,
+            });
           }
         }
       } catch (error) {

--- a/src/trigger/fetch-transcript.ts
+++ b/src/trigger/fetch-transcript.ts
@@ -111,7 +111,7 @@ export const fetchTranscriptTask = task({
       }
     }
 
-    // Step 3: Podcast-site extractor (registered podcasts only — bankless, lex-fridman, limitless)
+    // Step 3: Podcast-site extractor (registry-gated, see helpers/transcript-extractors/index.ts)
     if (!transcript) {
       try {
         const episodeRow = await db.query.episodes.findFirst({

--- a/src/trigger/fetch-transcript.ts
+++ b/src/trigger/fetch-transcript.ts
@@ -13,6 +13,7 @@ import {
   getTranscriptionStatus,
 } from "@/lib/assemblyai";
 import { persistTranscript } from "@/trigger/helpers/database";
+import { runPodcastExtractor } from "@/trigger/helpers/transcript-extractors";
 import { summarizeEpisode } from "@/trigger/summarize-episode";
 
 export type FetchTranscriptPayload = {
@@ -59,6 +60,7 @@ export const fetchTranscriptTask = task({
 
     let transcript: string | undefined;
     let transcriptSource: TranscriptSource | "cached" | "none" = "none";
+    let transcriptExtractor: string | undefined;
 
     // Step 1: Check cached transcription in database (cheapest source), unless force=true
     if (!force) {
@@ -109,7 +111,56 @@ export const fetchTranscriptTask = task({
       }
     }
 
-    // Step 3: Extract transcript URL from description
+    // Step 3: Podcast-site extractor (registered podcasts only — bankless, lex-fridman, limitless)
+    if (!transcript) {
+      try {
+        const episodeRow = await db.query.episodes.findFirst({
+          where: eq(episodes.podcastIndexId, piId),
+          columns: {
+            podcastIndexId: true,
+            title: true,
+            episodeLink: true,
+            rssGuid: true,
+          },
+          with: { podcast: { columns: { podcastIndexId: true, title: true } } },
+        });
+        if (episodeRow?.podcast) {
+          const extractorResult = await runPodcastExtractor({
+            episode: {
+              podcastIndexId: episodeRow.podcastIndexId,
+              title: episodeRow.title,
+              link: episodeRow.episodeLink,
+              rssGuid: episodeRow.rssGuid,
+            },
+            podcast: {
+              podcastIndexId: episodeRow.podcast.podcastIndexId,
+              title: episodeRow.podcast.title,
+            },
+          });
+          if (extractorResult) {
+            transcript = extractorResult.transcript;
+            transcriptSource = "podcast-site";
+            transcriptExtractor = extractorResult.extractorId;
+            logger.info("Transcript fetched from podcast-site extractor", {
+              extractorId: extractorResult.extractorId,
+              length: transcript.length,
+            });
+          } else {
+            logger.info("No transcript from podcast-site extractor");
+          }
+        }
+      } catch (error) {
+        logger.warn(
+          "Podcast-site extractor step failed, proceeding without it",
+          {
+            episodeId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
+    // Step 4: Extract transcript URL from description
     if (!transcript && description) {
       const transcriptUrl = extractTranscriptUrl(description);
       if (transcriptUrl) {
@@ -135,7 +186,7 @@ export const fetchTranscriptTask = task({
       }
     }
 
-    // Step 4: AssemblyAI async transcription via Trigger.dev token
+    // Step 5: AssemblyAI async transcription via Trigger.dev token
     if (!transcript && enclosureUrl) {
       metadata.set("step", "transcribing-audio");
 
@@ -238,6 +289,7 @@ export const fetchTranscriptTask = task({
       });
       transcript = undefined;
       transcriptSource = "none";
+      transcriptExtractor = undefined;
     }
 
     // Map internal sentinels to DB-safe values:
@@ -259,7 +311,12 @@ export const fetchTranscriptTask = task({
     // Only persist when we fetched from an external source (not cache — DB is already correct).
     // This is the sole writer of transcript columns (ADR-027).
     if (transcript && dbSource !== undefined && dbSource !== null) {
-      await persistTranscript(episodeId, transcript, dbSource);
+      await persistTranscript(
+        episodeId,
+        transcript,
+        dbSource,
+        transcriptExtractor,
+      );
     }
 
     // Clear run ID unconditionally — run has terminated (success or no-transcript).

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -158,7 +158,7 @@ describe("persistTranscript", () => {
     ).rejects.toThrow("Episode 999 not found for transcript persistence");
   });
 
-  it("writes transcriptExtractor when extractorId is provided", async () => {
+  it("writes transcriptExtractor when source is podcast-site and extractorId is provided", async () => {
     const chain = makeUpdateChain([{ id: 4 }]);
     mockUpdate.mockReturnValue(chain);
 
@@ -170,15 +170,40 @@ describe("persistTranscript", () => {
     );
   });
 
-  it("omits transcriptExtractor from the set payload when extractorId is undefined", async () => {
+  it("clears transcriptExtractor to null when source is podcast-site but extractorId is undefined", async () => {
     const chain = makeUpdateChain([{ id: 5 }]);
+    mockUpdate.mockReturnValue(chain);
+
+    const { persistTranscript } = await import("@/trigger/helpers/database");
+    await persistTranscript(123, "Site transcript", "podcast-site");
+
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ transcriptExtractor: null }),
+    );
+  });
+
+  it("clears transcriptExtractor to null when source is not podcast-site", async () => {
+    const chain = makeUpdateChain([{ id: 6 }]);
     mockUpdate.mockReturnValue(chain);
 
     const { persistTranscript } = await import("@/trigger/helpers/database");
     await persistTranscript(123, "transcript", "podcastindex");
 
-    const setArg = chain.set.mock.calls[0]?.[0];
-    expect(setArg).not.toHaveProperty("transcriptExtractor");
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ transcriptExtractor: null }),
+    );
+  });
+
+  it("clears stale transcriptExtractor when re-fetched from a different source even if extractorId is passed", async () => {
+    const chain = makeUpdateChain([{ id: 7 }]);
+    mockUpdate.mockReturnValue(chain);
+
+    const { persistTranscript } = await import("@/trigger/helpers/database");
+    await persistTranscript(123, "AAI transcript", "assemblyai", "bankless");
+
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ transcriptExtractor: null }),
+    );
   });
 });
 

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -157,6 +157,29 @@ describe("persistTranscript", () => {
       persistTranscript(999, "text", "description-url"),
     ).rejects.toThrow("Episode 999 not found for transcript persistence");
   });
+
+  it("writes transcriptExtractor when extractorId is provided", async () => {
+    const chain = makeUpdateChain([{ id: 4 }]);
+    mockUpdate.mockReturnValue(chain);
+
+    const { persistTranscript } = await import("@/trigger/helpers/database");
+    await persistTranscript(123, "Site transcript", "podcast-site", "bankless");
+
+    expect(chain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ transcriptExtractor: "bankless" }),
+    );
+  });
+
+  it("omits transcriptExtractor from the set payload when extractorId is undefined", async () => {
+    const chain = makeUpdateChain([{ id: 5 }]);
+    mockUpdate.mockReturnValue(chain);
+
+    const { persistTranscript } = await import("@/trigger/helpers/database");
+    await persistTranscript(123, "transcript", "podcastindex");
+
+    const setArg = chain.set.mock.calls[0]?.[0];
+    expect(setArg).not.toHaveProperty("transcriptExtractor");
+  });
 });
 
 describe("persistEpisodeSummary", () => {

--- a/src/trigger/helpers/__tests__/database.test.ts
+++ b/src/trigger/helpers/__tests__/database.test.ts
@@ -141,7 +141,7 @@ describe("persistTranscript", () => {
     mockUpdate.mockReturnValue(chain);
 
     const { persistTranscript } = await import("@/trigger/helpers/database");
-    await persistTranscript(123, "extracted text", "podcast-site");
+    await persistTranscript(123, "extracted text", "podcast-site", "bankless");
 
     expect(chain.set).toHaveBeenCalledWith(
       expect.objectContaining({ transcriptSource: "podcast-site" }),
@@ -170,16 +170,17 @@ describe("persistTranscript", () => {
     );
   });
 
-  it("clears transcriptExtractor to null when source is podcast-site but extractorId is undefined", async () => {
+  it("throws when source is podcast-site but extractorId is undefined", async () => {
     const chain = makeUpdateChain([{ id: 5 }]);
     mockUpdate.mockReturnValue(chain);
 
     const { persistTranscript } = await import("@/trigger/helpers/database");
-    await persistTranscript(123, "Site transcript", "podcast-site");
-
-    expect(chain.set).toHaveBeenCalledWith(
-      expect.objectContaining({ transcriptExtractor: null }),
+    await expect(
+      persistTranscript(123, "Site transcript", "podcast-site"),
+    ).rejects.toThrow(
+      "persistTranscript: extractorId required when source is podcast-site",
     );
+    expect(chain.set).not.toHaveBeenCalled();
   });
 
   it("clears transcriptExtractor to null when source is not podcast-site", async () => {

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -164,10 +164,10 @@ export async function updateEpisodeStatus(
 // See ADR-026 for column ownership and ADR-027 for the refactor that removed
 // transcript writes from persistEpisodeSummary.
 //
-// extractorId is the registry id (e.g. "bankless") populated only when
-// source === "podcast-site". Other sources pass undefined and the conditional
-// spread leaves any existing transcript_extractor value in place — clearing
-// is the future "force re-fetch" UX's concern, not this function's.
+// transcript_extractor is the registry id (e.g. "bankless"), tied 1:1 to the
+// "podcast-site" source. Any other source clears it to null so the column
+// always reflects the current transcript's provenance — preventing a stale
+// extractor id from surviving a force=true re-fetch by a different source.
 export async function persistTranscript(
   episodeId: number,
   transcript: string,
@@ -187,7 +187,8 @@ export async function persistTranscript(
       transcriptError: null,
       transcriptRunId: null,
       updatedAt: now,
-      ...(extractorId !== undefined && { transcriptExtractor: extractorId }),
+      transcriptExtractor:
+        source === "podcast-site" ? (extractorId ?? null) : null,
     })
     .where(eq(episodes.podcastIndexId, piId))
     .returning({ id: episodes.id });

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -167,6 +167,7 @@ export async function persistTranscript(
   episodeId: number,
   transcript: string,
   source: TranscriptSource,
+  extractorId?: string,
 ): Promise<void> {
   const now = new Date();
   // Trigger payload uses numeric form; brand for DB lookup.
@@ -181,6 +182,7 @@ export async function persistTranscript(
       transcriptError: null,
       transcriptRunId: null,
       updatedAt: now,
+      ...(extractorId !== undefined && { transcriptExtractor: extractorId }),
     })
     .where(eq(episodes.podcastIndexId, piId))
     .returning({ id: episodes.id });

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -163,6 +163,11 @@ export async function updateEpisodeStatus(
 // from an external source (not on cache-hit paths where source is undefined).
 // See ADR-026 for column ownership and ADR-027 for the refactor that removed
 // transcript writes from persistEpisodeSummary.
+//
+// extractorId is the registry id (e.g. "bankless") populated only when
+// source === "podcast-site". Other sources pass undefined and the conditional
+// spread leaves any existing transcript_extractor value in place — clearing
+// is the future "force re-fetch" UX's concern, not this function's.
 export async function persistTranscript(
   episodeId: number,
   transcript: string,

--- a/src/trigger/helpers/database.ts
+++ b/src/trigger/helpers/database.ts
@@ -174,6 +174,11 @@ export async function persistTranscript(
   source: TranscriptSource,
   extractorId?: string,
 ): Promise<void> {
+  if (source === "podcast-site" && !extractorId) {
+    throw new Error(
+      "persistTranscript: extractorId required when source is podcast-site",
+    );
+  }
   const now = new Date();
   // Trigger payload uses numeric form; brand for DB lookup.
   const piId = asPodcastIndexEpisodeId(String(episodeId));


### PR DESCRIPTION
## Summary

- Insert a new **Step 3** in `src/trigger/fetch-transcript.ts` calling `runPodcastExtractor({ episode, podcast })` between the PodcastIndex step (now Step 2) and the description-URL step (now Step 4). On hit, the transcript is persisted with `transcript_source='podcast-site'` and the new `transcript_extractor=<id>` column.
- Extend `persistTranscript(episodeId, transcript, source, extractorId?)` with an optional positional 4th arg. The `.set()` clause uses a **conditional spread** so `transcript_extractor` is written only when `extractorId !== undefined` — prior column values are preserved on non-extractor source paths.
- Lazy-fetch `episode + podcast` rows inside the new step via a single Drizzle relational query (`with: { podcast: true }`), gated behind `if (!transcript)` — zero DB cost on cache-hit and PodcastIndex-hit paths.
- New Vitest cases cover hit / miss / throw integration boundaries plus the orphaned-FK (`episodeRow.podcast === null`) skip, and dedicated unit tests in `database.test.ts` cover the new conditional-spread branch.

Closes #429

## Pipeline order

```
cached → podcastindex → podcast-site (new) → description-url → assemblyai
```

## Test plan

- [x] `bun run lint` clean
- [x] `bun run test` — 3333 passed, 56 skipped (244 files)
- [x] `bun run build` clean
- [x] `bun run build-storybook` clean
- [x] `bun run format:check` clean
- [x] Cache-hit path explicitly asserts `mockRunPodcastExtractor` is **not** called
- [x] PodcastIndex-hit path explicitly asserts `mockRunPodcastExtractor` is **not** called
- [x] Orphaned-FK case (episode row exists, `podcast` join is null) skips Step 3 and falls through to description-URL
- [x] `persistTranscript` unit tests cover both branches of the conditional spread (extractor-id present → column written; undefined → column omitted)
- [x] Extractor throw verified to fall through to AssemblyAI without crashing
- [x] CHANGELOG `[Unreleased]` entry added; "follows in #429" deferral removed from prior entry

## Agent Notes

### Context for Next Session

- The conditional spread `...(extractorId !== undefined && { transcriptExtractor: extractorId })` in `persistTranscript` (`src/trigger/helpers/database.ts`) is intentional — non-extractor source paths must leave any prior `transcript_extractor` value untouched. The function-level comment documents this; the dedicated unit test covers both branches. Future work that wants to clear the column on supersession needs explicit semantics, not an unconditional `extractorId ?? null` write.
- `FetchTranscriptPayload` was deliberately NOT widened with `title`/`link`/`rssGuid`/podcast fields (would have rippled across all callers). Instead, the new Step lazy-fetches the rows it needs via a single Drizzle relational query gated on Step 2 miss. See plan `.dev/cdt/plans/plan-20260511-1433.md` §Overview for the A/B/C decision trade-offs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transcript extraction support for Bankless, Lex Fridman, and Limitless podcasts, extracting transcripts from episode pages when not available through standard RSS or PodcastIndex feeds.
  * Enhanced transcript source tracking to ensure accurate provenance management across re-fetches.

* **Documentation**
  * Updated documentation to reflect the new transcript extraction workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->