### PR TITLE
refactor: extract triggerTopicDigestGenerationCore to drop double-auth (#452)

### DIFF
--- a/src/app/actions/__tests__/topics-detail.test.ts
+++ b/src/app/actions/__tests__/topics-detail.test.ts
@@ -562,6 +562,7 @@ describe("triggerTopicDigestRefresh", () => {
     expect(result).toEqual({ success: false, error: "Unauthorized" });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
     expect(mockCreatePublicToken).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it.each([0, -1, 1.5])("rejects invalid canonicalTopicId %s", async (id) => {
@@ -569,6 +570,7 @@ describe("triggerTopicDigestRefresh", () => {
     expect(result).toMatchObject({ success: false });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
     expect(mockCreatePublicToken).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it("ineligible: passes through without calling createPublicToken", async () => {
@@ -750,6 +752,7 @@ describe("triggerTopicDigestRefresh", () => {
       data: { status: "cached", digestId: 22 },
     });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it("queues at exactly staleness threshold (boundary = STALENESS_GROWTH_THRESHOLD)", async () => {
@@ -781,5 +784,6 @@ describe("triggerTopicDigestRefresh", () => {
       data: { status: "queued", runId: "run_stale" },
     });
     expect(mockTasksTrigger).toHaveBeenCalledOnce();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/actions/__tests__/topics-detail.test.ts
+++ b/src/app/actions/__tests__/topics-detail.test.ts
@@ -553,6 +553,9 @@ describe("getTopicDetailData", () => {
 // ============================================================================
 
 describe("triggerTopicDigestRefresh", () => {
+  // Auth-call-count assertions across these tests guard the single-`auth()`
+  // contract from issue #452 — refresh previously delegated through the
+  // public `triggerTopicDigestGeneration`, double-wrapping `withAuthAction`.
   it("returns Unauthorized without a session", async () => {
     mockAuth.mockResolvedValue(makeAnonAuth());
     const result = await triggerTopicDigestRefresh({ canonicalTopicId: 1 });
@@ -590,6 +593,7 @@ describe("triggerTopicDigestRefresh", () => {
       data: { status: "ineligible" },
     });
     expect(mockCreatePublicToken).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it("cached: passes through without calling createPublicToken", async () => {
@@ -622,6 +626,7 @@ describe("triggerTopicDigestRefresh", () => {
     });
     expect(mockCreatePublicToken).not.toHaveBeenCalled();
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it("queued: bundles publicAccessToken from auth.createPublicToken with 15m TTL", async () => {
@@ -656,6 +661,7 @@ describe("triggerTopicDigestRefresh", () => {
       scopes: { read: { runs: ["run_abc"] } },
       expirationTime: "15m",
     });
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   it("returns success: false with the underlying error when tasks.trigger rejects", async () => {
@@ -682,9 +688,9 @@ describe("triggerTopicDigestRefresh", () => {
 
     expect(result).toMatchObject({ success: false });
     if (result.success) throw new Error("expected failure");
-    // The underlying error message is propagated through triggerTopicDigestGeneration.
     expect(result.error).toBe("trigger sdk down");
     expect(mockCreatePublicToken).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
     consoleErrorSpy.mockRestore();
   });
 
@@ -713,6 +719,7 @@ describe("triggerTopicDigestRefresh", () => {
 
     expect(result).toEqual({ success: false, error: "token-failed" });
     expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
     consoleErrorSpy.mockRestore();
   });
 

--- a/src/app/actions/__tests__/topics-digest.test.ts
+++ b/src/app/actions/__tests__/topics-digest.test.ts
@@ -146,6 +146,7 @@ describe("triggerTopicDigestGeneration", () => {
     expect(result).toEqual(expect.objectContaining({ success: false }));
     expect(mockDbSelect).not.toHaveBeenCalled();
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 2b: Unknown extra key (.strict) ────────────────────────────────────
@@ -160,6 +161,7 @@ describe("triggerTopicDigestGeneration", () => {
     expect(typeof (result as { error: string }).error).toBe("string");
     expect(mockDbSelect).not.toHaveBeenCalled();
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 3: Canonical not found ──────────────────────────────────────────────
@@ -169,6 +171,7 @@ describe("triggerTopicDigestGeneration", () => {
     const result = await triggerTopicDigestGeneration({ canonicalTopicId: 99 });
     expect(result).toEqual({ success: false, error: "not-found" });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 4: Canonical non-active (status !== active) ─────────────────────────
@@ -189,6 +192,7 @@ describe("triggerTopicDigestGeneration", () => {
     const result = await triggerTopicDigestGeneration({ canonicalTopicId: 5 });
     expect(result).toEqual({ success: false, error: "not-found" });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 5: Ineligible (episode count < MIN_DERIVED_COUNT_FOR_DIGEST) ───────
@@ -212,6 +216,7 @@ describe("triggerTopicDigestGeneration", () => {
       data: { status: "ineligible", digestId: undefined },
     });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 6: Cached (existing fresh, growth < STALENESS_GROWTH_THRESHOLD) ────
@@ -236,6 +241,7 @@ describe("triggerTopicDigestGeneration", () => {
       data: { status: "cached", digestId: 22 },
     });
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 7: Queued first-time (no existing digest) ───────────────────────────

--- a/src/app/actions/__tests__/topics-digest.test.ts
+++ b/src/app/actions/__tests__/topics-digest.test.ts
@@ -134,6 +134,7 @@ describe("triggerTopicDigestGeneration", () => {
     expect(result).toEqual({ success: false, error: "Unauthorized" });
     expect(mockDbSelect).not.toHaveBeenCalled();
     expect(mockTasksTrigger).not.toHaveBeenCalled();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 2: Invalid input (Zod rejection) ────────────────────────────────────
@@ -268,6 +269,7 @@ describe("triggerTopicDigestGeneration", () => {
         idempotencyKeyTTL: "10m",
       }),
     );
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 8: Queued stale (growth >= STALENESS_GROWTH_THRESHOLD) ─────────────
@@ -301,6 +303,7 @@ describe("triggerTopicDigestGeneration", () => {
         idempotencyKey: "generate-topic-digest-5",
       }),
     );
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 
   // ── Case 9: tasks.trigger outage ─────────────────────────────────────────────
@@ -328,5 +331,6 @@ describe("triggerTopicDigestGeneration", () => {
       error: "Trigger.dev unavailable",
     });
     expect(mockTasksTrigger).toHaveBeenCalledOnce();
+    expect(mockAuth).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/actions/topics.ts
+++ b/src/app/actions/topics.ts
@@ -575,9 +575,12 @@ async function triggerTopicDigestGenerationCore(
       };
     }
     // Above the minimum but not stale enough — serve the cached digest.
+    if (!existing) {
+      throw new Error("invariant violated: cached status but no digest row");
+    }
     return {
       success: true,
-      data: { status: "cached", digestId: existing!.id },
+      data: { status: "cached", digestId: existing.id },
     };
   }
 

--- a/src/app/actions/topics.ts
+++ b/src/app/actions/topics.ts
@@ -517,15 +517,98 @@ const topicDigestSchema = z
   .object({ canonicalTopicId: z.number().int().positive() })
   .strict();
 
+type TopicDigestGenerationResult = ActionResult<{
+  status: "queued" | "cached" | "ineligible";
+  digestId?: number;
+  runId?: string;
+}>;
+
+// Unwrapped helper (no `withAuthAction`) so callers run the Clerk lookup
+// exactly once per public action invocation — see issue #452.
+async function triggerTopicDigestGenerationCore(
+  input: z.infer<typeof topicDigestSchema>,
+): Promise<TopicDigestGenerationResult> {
+  const { canonicalTopicId } = input;
+
+  const [canonicalRows, digestRows] = await Promise.all([
+    db
+      .select({
+        id: canonicalTopics.id,
+        status: canonicalTopics.status,
+        completedSummaryCount: canonicalTopicCompletedSummaryCount(),
+      })
+      .from(canonicalTopics)
+      .where(eq(canonicalTopics.id, canonicalTopicId)),
+    db
+      .select({
+        id: canonicalTopicDigests.id,
+        episodeCountAtGeneration:
+          canonicalTopicDigests.episodeCountAtGeneration,
+      })
+      .from(canonicalTopicDigests)
+      .where(eq(canonicalTopicDigests.canonicalTopicId, canonicalTopicId)),
+  ]);
+
+  const canonical = canonicalRows[0];
+  if (!canonical || canonical.status !== "active") {
+    return { success: false, error: "not-found" };
+  }
+
+  // Both eligibility and staleness operate on completed-summary count to
+  // align with the task's `summaryStatus = 'completed'` predicate (ADR-051).
+  // The `isDigestSynthesizable` predicate is the canonical implementation;
+  // the action just maps its boolean result back to our three-state
+  // {ineligible, cached, queued} response by inspecting the inputs once
+  // more to disambiguate which negative branch fired.
+  const completedSummaryCount = Number(canonical.completedSummaryCount ?? 0);
+  const existing = digestRows[0] ?? null;
+  const synthesizable = isDigestSynthesizable({
+    completedSummaryCount,
+    digestEpisodeCountAtGeneration: existing?.episodeCountAtGeneration ?? null,
+  });
+
+  if (!synthesizable) {
+    if (completedSummaryCount < MIN_DERIVED_COUNT_FOR_DIGEST) {
+      return {
+        success: true,
+        data: { status: "ineligible", digestId: existing?.id },
+      };
+    }
+    // Above the minimum but not stale enough — serve the cached digest.
+    return {
+      success: true,
+      data: { status: "cached", digestId: existing!.id },
+    };
+  }
+
+  try {
+    const handle = await tasks.trigger<typeof generateTopicDigest>(
+      "generate-topic-digest",
+      { canonicalTopicId },
+      {
+        idempotencyKey: `generate-topic-digest-${canonicalTopicId}`,
+        idempotencyKeyTTL: "10m",
+      },
+    );
+    return {
+      success: true,
+      data: { status: "queued", digestId: existing?.id, runId: handle.id },
+    };
+  } catch (e) {
+    console.error("[triggerTopicDigestGenerationCore] trigger failed:", {
+      canonicalTopicId,
+      error: e,
+    });
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "trigger-failed",
+    };
+  }
+}
+
 export async function triggerTopicDigestGeneration(input: {
   canonicalTopicId: number;
-}): Promise<
-  ActionResult<{
-    status: "queued" | "cached" | "ineligible";
-    digestId?: number;
-    runId?: string;
-  }>
-> {
+}): Promise<TopicDigestGenerationResult> {
   return withAuthAction(async () => {
     const parsed = topicDigestSchema.safeParse(input);
     if (!parsed.success) {
@@ -534,83 +617,7 @@ export async function triggerTopicDigestGeneration(input: {
         error: parsed.error.issues[0]?.message ?? "Invalid input",
       };
     }
-    const { canonicalTopicId } = parsed.data;
-
-    const [canonicalRows, digestRows] = await Promise.all([
-      db
-        .select({
-          id: canonicalTopics.id,
-          status: canonicalTopics.status,
-          completedSummaryCount: canonicalTopicCompletedSummaryCount(),
-        })
-        .from(canonicalTopics)
-        .where(eq(canonicalTopics.id, canonicalTopicId)),
-      db
-        .select({
-          id: canonicalTopicDigests.id,
-          episodeCountAtGeneration:
-            canonicalTopicDigests.episodeCountAtGeneration,
-        })
-        .from(canonicalTopicDigests)
-        .where(eq(canonicalTopicDigests.canonicalTopicId, canonicalTopicId)),
-    ]);
-
-    const canonical = canonicalRows[0];
-    if (!canonical || canonical.status !== "active") {
-      return { success: false, error: "not-found" };
-    }
-
-    // Both eligibility and staleness operate on completed-summary count to
-    // align with the task's `summaryStatus = 'completed'` predicate (ADR-051).
-    // The `isDigestSynthesizable` predicate is the canonical implementation;
-    // the action just maps its boolean result back to our three-state
-    // {ineligible, cached, queued} response by inspecting the inputs once
-    // more to disambiguate which negative branch fired.
-    const completedSummaryCount = Number(canonical.completedSummaryCount ?? 0);
-    const existing = digestRows[0] ?? null;
-    const synthesizable = isDigestSynthesizable({
-      completedSummaryCount,
-      digestEpisodeCountAtGeneration:
-        existing?.episodeCountAtGeneration ?? null,
-    });
-
-    if (!synthesizable) {
-      if (completedSummaryCount < MIN_DERIVED_COUNT_FOR_DIGEST) {
-        return {
-          success: true,
-          data: { status: "ineligible", digestId: existing?.id },
-        };
-      }
-      // Above the minimum but not stale enough — serve the cached digest.
-      return {
-        success: true,
-        data: { status: "cached", digestId: existing!.id },
-      };
-    }
-
-    try {
-      const handle = await tasks.trigger<typeof generateTopicDigest>(
-        "generate-topic-digest",
-        { canonicalTopicId },
-        {
-          idempotencyKey: `generate-topic-digest-${canonicalTopicId}`,
-          idempotencyKeyTTL: "10m",
-        },
-      );
-      return {
-        success: true,
-        data: { status: "queued", digestId: existing?.id, runId: handle.id },
-      };
-    } catch (e) {
-      console.error("[triggerTopicDigestGeneration] trigger failed:", {
-        canonicalTopicId,
-        error: e,
-      });
-      return {
-        success: false,
-        error: e instanceof Error ? e.message : "trigger-failed",
-      };
-    }
+    return triggerTopicDigestGenerationCore(parsed.data);
   });
 }
 
@@ -846,7 +853,7 @@ export async function triggerTopicDigestRefresh(input: {
       };
     }
 
-    const gateResult = await triggerTopicDigestGeneration(parsed.data);
+    const gateResult = await triggerTopicDigestGenerationCore(parsed.data);
     if (!gateResult.success) return gateResult;
 
     const { status, digestId, runId } = gateResult.data;


### PR DESCRIPTION
## Summary

- `triggerTopicDigestRefresh` previously delegated to the public `triggerTopicDigestGeneration`, so each refresh request ran `withAuthAction` (Clerk `auth()`) twice and `topicDigestSchema.safeParse` twice. Cosmetic perf issue today, but a footgun: any future divergence between the two outer wrappers would silently leak into one path and not the other.
- Extract a private `triggerTopicDigestGenerationCore(input)` containing the shared body (canonical lookup, eligibility/staleness check, `tasks.trigger` call). Both public actions now wrap the core with a single `withAuthAction` + single `safeParse`. No wire-shape changes; no signature changes.
- Add `expect(mockAuth).toHaveBeenCalledTimes(1)` across every branch of `triggerTopicDigestGeneration` (5 tests) and `triggerTopicDigestRefresh` (5 tests) to lock in the single-auth contract as a regression guard. Hoist the rationale into one suite-level comment per `describe` block instead of repeating it inline.

## Test plan

- [x] `bun run test -- src/app/actions/__tests__/topics-digest.test.ts src/app/actions/__tests__/topics-detail.test.ts` — 36 / 36 pass
- [x] `bun run test` — full suite (3335 / 3335 pass, 56 integration tests skipped without `DATABASE_URL`; none exercise the refactored functions)
- [x] `bun run format:check` clean
- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [x] `bun run build-storybook` succeeds
- [x] Multi-tool review (Codex + pr-review-toolkit + /simplify lanes) applied: rename underscore-prefixed helper, fix misleading log tag, drop stale propagation comment, extend single-auth assertion to remaining error/edge tests

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage to enforce a single authentication call across topic digest generation and refresh scenarios.

* **Refactor**
  * Internal extraction and reorganization of digest gating/trigger logic with no changes to user-facing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/465)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chalet-Labs/contentgenie/pull/465)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->