### PR TITLE
test: cover inbox notification event paths

### DIFF
--- a/src/contexts/__tests__/sidebar-counts-context.test.tsx
+++ b/src/contexts/__tests__/sidebar-counts-context.test.tsx
@@ -441,7 +441,7 @@ describe("SidebarCountsProvider — unreadNotificationCount", () => {
     });
 
     await act(async () => {
-      resolveRefresh?.({
+      resolveRefresh!({
         subscriptionCount: 0,
         savedCount: 0,
         unreadNotificationCount: 9,
@@ -455,7 +455,7 @@ describe("SidebarCountsProvider — unreadNotificationCount", () => {
     });
 
     await act(async () => {
-      resolveInitial?.({
+      resolveInitial!({
         subscriptionCount: 0,
         savedCount: 0,
         unreadNotificationCount: 2,

--- a/src/contexts/__tests__/sidebar-counts-context.test.tsx
+++ b/src/contexts/__tests__/sidebar-counts-context.test.tsx
@@ -411,4 +411,58 @@ describe("SidebarCountsProvider — unreadNotificationCount", () => {
 
     expect(screen.getByTestId("unread-count").textContent).toBe("7");
   });
+
+  it("ignores stale refresh responses when a newer notification refresh resolves first", async () => {
+    let resolveInitial: ((value: unknown) => void) | undefined;
+    let resolveRefresh: ((value: unknown) => void) | undefined;
+
+    mockGetDashboardStats
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveInitial = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+    render(
+      <SidebarCountsProvider>
+        <TestConsumer />
+      </SidebarCountsProvider>,
+    );
+
+    expect(screen.getByTestId("loading").textContent).toBe("loading");
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(NOTIFICATIONS_CHANGED_EVENT));
+    });
+
+    await act(async () => {
+      resolveRefresh?.({
+        subscriptionCount: 0,
+        savedCount: 0,
+        unreadNotificationCount: 9,
+        error: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unread-count").textContent).toBe("9");
+      expect(screen.getByTestId("loading").textContent).toBe("done");
+    });
+
+    await act(async () => {
+      resolveInitial?.({
+        subscriptionCount: 0,
+        savedCount: 0,
+        unreadNotificationCount: 2,
+        error: null,
+      });
+    });
+
+    expect(screen.getByTestId("unread-count").textContent).toBe("9");
+  });
 });

--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  NOTIFICATIONS_CHANGED_EVENT,
+  dispatchNotificationsChanged,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches a counts-only payload when no action is provided", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([10, 20]);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect((event as CustomEvent).type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect((event as CustomEvent).detail).toEqual({ episodeDbIds: [10, 20] });
+  });
+
+  it("dispatches mark-all payloads with the action included", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect((event as CustomEvent).detail).toEqual({
+      episodeDbIds: [],
+      action: "mark-all",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test that proves `SidebarCountsProvider` ignores stale notification-count refresh responses when a newer refresh wins the race
- add direct coverage for `dispatchNotificationsChanged` payload shapes used by the inbox/bell synchronization flow

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked in this worktree: Doppler project/secrets are not configured, so `doppler run -- next build` cannot fetch secrets)*
