### PR TITLE
[codex] test: cover notification helper contracts

### DIFF
--- a/src/lib/__tests__/notification-helpers.test.ts
+++ b/src/lib/__tests__/notification-helpers.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { countUnreadNotifications } from "@/lib/notifications-query";
+import { notifications } from "@/db/schema";
+import {
+  dispatchNotificationsChanged,
+  NOTIFICATIONS_CHANGED_EVENT,
+} from "@/lib/events";
 
 const mockCount = vi.fn();
 vi.mock("@/db", () => ({
@@ -30,10 +36,6 @@ describe("countUnreadNotifications", () => {
   it("counts only unread and non-dismissed notifications for the user", async () => {
     mockCount.mockResolvedValue(7);
 
-    const { countUnreadNotifications } =
-      await import("@/lib/notifications-query");
-    const { notifications } = await import("@/db/schema");
-
     await expect(countUnreadNotifications("user_123")).resolves.toBe(7);
 
     expect(mockEq).toHaveBeenCalledWith(notifications.userId, "user_123");
@@ -57,12 +59,10 @@ describe("dispatchNotificationsChanged", () => {
     vi.restoreAllMocks();
   });
 
-  it("dispatches the default payload shape without an action", async () => {
-    const dispatchEvent = vi.fn();
-    vi.stubGlobal("window", { dispatchEvent } as unknown as Window);
-
-    const { dispatchNotificationsChanged, NOTIFICATIONS_CHANGED_EVENT } =
-      await import("@/lib/events");
+  it("dispatches the default payload shape without an action", () => {
+    const dispatchEvent = vi
+      .spyOn(window, "dispatchEvent")
+      .mockReturnValue(true);
 
     dispatchNotificationsChanged([10, 20]);
 
@@ -75,11 +75,10 @@ describe("dispatchNotificationsChanged", () => {
     expect(event.detail).toEqual({ episodeDbIds: [10, 20] });
   });
 
-  it("dispatches the mark-all payload shape when an action is provided", async () => {
-    const dispatchEvent = vi.fn();
-    vi.stubGlobal("window", { dispatchEvent } as unknown as Window);
-
-    const { dispatchNotificationsChanged } = await import("@/lib/events");
+  it("dispatches the mark-all payload shape when an action is provided", () => {
+    const dispatchEvent = vi
+      .spyOn(window, "dispatchEvent")
+      .mockReturnValue(true);
 
     dispatchNotificationsChanged([], "mark-all");
 
@@ -90,10 +89,8 @@ describe("dispatchNotificationsChanged", () => {
     expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
   });
 
-  it("is a no-op when called without a window", async () => {
+  it("is a no-op when called without a window", () => {
     vi.stubGlobal("window", undefined);
-
-    const { dispatchNotificationsChanged } = await import("@/lib/events");
 
     expect(() => dispatchNotificationsChanged([10])).not.toThrow();
   });

--- a/src/lib/__tests__/notification-helpers.test.ts
+++ b/src/lib/__tests__/notification-helpers.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCount = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "user_id",
+    isRead: "is_read",
+    isDismissed: "is_dismissed",
+  },
+}));
+
+const mockEq = vi.fn((...args: unknown[]) => ({ kind: "eq", args }));
+const mockAnd = vi.fn((...args: unknown[]) => ({ kind: "and", args }));
+vi.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => mockEq(...args),
+  and: (...args: unknown[]) => mockAnd(...args),
+}));
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts only unread and non-dismissed notifications for the user", async () => {
+    mockCount.mockResolvedValue(7);
+
+    const { countUnreadNotifications } =
+      await import("@/lib/notifications-query");
+    const { notifications } = await import("@/db/schema");
+
+    await expect(countUnreadNotifications("user_123")).resolves.toBe(7);
+
+    expect(mockEq).toHaveBeenCalledWith(notifications.userId, "user_123");
+    expect(mockEq).toHaveBeenCalledWith(notifications.isRead, false);
+    expect(mockEq).toHaveBeenCalledWith(notifications.isDismissed, false);
+    expect(mockAnd).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "eq" }),
+      expect.objectContaining({ kind: "eq" }),
+      expect.objectContaining({ kind: "eq" }),
+    );
+    expect(mockCount).toHaveBeenCalledWith(
+      notifications,
+      expect.objectContaining({ kind: "and" }),
+    );
+  });
+});
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches the default payload shape without an action", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent } as unknown as Window);
+
+    const { dispatchNotificationsChanged, NOTIFICATIONS_CHANGED_EVENT } =
+      await import("@/lib/events");
+
+    dispatchNotificationsChanged([10, 20]);
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0]?.[0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: string;
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [10, 20] });
+  });
+
+  it("dispatches the mark-all payload shape when an action is provided", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent } as unknown as Window);
+
+    const { dispatchNotificationsChanged } = await import("@/lib/events");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    const event = dispatchEvent.mock.calls[0]?.[0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: string;
+    }>;
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+
+  it("is a no-op when called without a window", async () => {
+    vi.stubGlobal("window", undefined);
+
+    const { dispatchNotificationsChanged } = await import("@/lib/events");
+
+    expect(() => dispatchNotificationsChanged([10])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add direct unit coverage for `countUnreadNotifications` so the shared unread predicate stays pinned to `userId && isRead=false && isDismissed=false`
- add direct unit coverage for `dispatchNotificationsChanged` payload shaping, including the `mark-all` variant and the server-side no-op branch
- keep scope limited to the recent notifications helper extraction without changing production code

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked in this worktree: Doppler project/secrets are not configured, so `doppler run -- next build` fails before Next.js starts)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains no user-facing changes. Internal improvements have been made to strengthen test coverage for notification handling.

* **Tests**
  * Enhanced test coverage for notification system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->