### PR TITLE
[codex] test: cover notification helper contracts

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  dispatchNotificationsChanged,
+  NOTIFICATIONS_CHANGED_EVENT,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches the ids-only payload for row-level reconcile events", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([11, 22]);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(event?.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect((event as CustomEvent).detail).toEqual({ episodeDbIds: [11, 22] });
+  });
+
+  it("dispatches the mark-all action for aggregate read transitions", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect((event as CustomEvent).detail).toEqual({
+      episodeDbIds: [],
+      action: "mark-all",
+    });
+  });
+});

--- a/src/lib/__tests__/notifications-query.test.ts
+++ b/src/lib/__tests__/notifications-query.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCount = vi.fn();
+const mockEq = vi.fn((...args: unknown[]) => ({ op: "eq", args }));
+const mockAnd = vi.fn((...args: unknown[]) => ({ op: "and", args }));
+
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "notifications.userId",
+    isRead: "notifications.isRead",
+    isDismissed: "notifications.isDismissed",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => mockEq(...args),
+  and: (...args: unknown[]) => mockAnd(...args),
+}));
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("counts only rows that match the shared unread predicate", async () => {
+    mockCount.mockResolvedValueOnce(7);
+
+    const { countUnreadNotifications } =
+      await import("@/lib/notifications-query");
+
+    await expect(countUnreadNotifications("user-123")).resolves.toBe(7);
+
+    expect(mockEq).toHaveBeenNthCalledWith(
+      1,
+      "notifications.userId",
+      "user-123",
+    );
+    expect(mockEq).toHaveBeenNthCalledWith(2, "notifications.isRead", false);
+    expect(mockEq).toHaveBeenNthCalledWith(
+      3,
+      "notifications.isDismissed",
+      false,
+    );
+    expect(mockAnd).toHaveBeenCalledWith(
+      { op: "eq", args: ["notifications.userId", "user-123"] },
+      { op: "eq", args: ["notifications.isRead", false] },
+      { op: "eq", args: ["notifications.isDismissed", false] },
+    );
+    expect(mockCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "notifications.userId",
+        isRead: "notifications.isRead",
+        isDismissed: "notifications.isDismissed",
+      }),
+      {
+        op: "and",
+        args: [
+          { op: "eq", args: ["notifications.userId", "user-123"] },
+          { op: "eq", args: ["notifications.isRead", false] },
+          { op: "eq", args: ["notifications.isDismissed", false] },
+        ],
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add direct unit coverage for `dispatchNotificationsChanged` so the notifications event payload contract is pinned in one place
- add direct unit coverage for `countUnreadNotifications` so the shared unread predicate stays aligned across inbox, bell, and sidebar callers
- keep scope limited to recent inbox/notification helper changes; no production code changes

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked: Doppler not configured in this worktree; `doppler run -- next build` failed with "You must specify a project" and no fallback file)*
