### PR TITLE
[codex] test: cover batch summarize terminal runs

### DIFF
--- a/src/components/podcasts/__tests__/batch-summarize-button.test.tsx
+++ b/src/components/podcasts/__tests__/batch-summarize-button.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { realtimeRunFixture } from "@/test/realtime-run";
+
+const mocks = vi.hoisted(() => ({
+  useRealtimeRun: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@trigger.dev/react-hooks", () => ({
+  useRealtimeRun: (...args: unknown[]) => mocks.useRealtimeRun(...args),
+}));
+
+vi.mock("sonner", () => ({ toast: mocks.toast }));
+
+const mockFetch = vi.fn();
+
+import { BatchSummarizeButton } from "@/components/podcasts/batch-summarize-button";
+
+describe("BatchSummarizeButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+    mocks.useRealtimeRun.mockImplementation((_runId: string, options) => ({
+      run: options?.enabled ? null : null,
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows completed progress and success toast when the realtime run succeeds", async () => {
+    const user = userEvent.setup();
+    mocks.useRealtimeRun.mockImplementation((_runId: string, options) => ({
+      run: options?.enabled
+        ? realtimeRunFixture("COMPLETED", {
+            metadata: {
+              progress: {
+                total: 3,
+                succeeded: 2,
+                failed: 0,
+                skipped: 1,
+                completed: 3,
+              },
+            },
+          })
+        : null,
+    }));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: () =>
+        Promise.resolve({
+          runId: "run_123",
+          publicAccessToken: "tok_abc",
+          total: 3,
+          skipped: 1,
+        }),
+    });
+
+    render(<BatchSummarizeButton episodeIds={[11, "12", 13]} />);
+
+    await user.click(screen.getByRole("button", { name: /summarize recent/i }));
+    await user.click(
+      screen.getByRole("button", { name: /confirm summarizing 3 episodes/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("2 summarized, 1 skipped")).toBeInTheDocument();
+    });
+
+    expect(mocks.toast.success).toHaveBeenCalledWith(
+      "Batch summarization complete",
+    );
+    expect(mocks.useRealtimeRun).toHaveBeenCalledWith("run_123", {
+      accessToken: "tok_abc",
+      enabled: true,
+    });
+  });
+
+  it("surfaces timed-out runs as terminal failures via the SDK boolean helpers", async () => {
+    const user = userEvent.setup();
+    mocks.useRealtimeRun.mockImplementation((_runId: string, options) => ({
+      run: options?.enabled ? realtimeRunFixture("TIMED_OUT") : null,
+    }));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: () =>
+        Promise.resolve({
+          runId: "run_timeout",
+          publicAccessToken: "tok_timeout",
+          total: 2,
+          skipped: 0,
+        }),
+    });
+
+    render(<BatchSummarizeButton episodeIds={[21, 22]} />);
+
+    await user.click(screen.getByRole("button", { name: /summarize recent/i }));
+    await user.click(
+      screen.getByRole("button", { name: /confirm summarizing 2 episodes/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Batch run timed out")).toBeInTheDocument();
+    });
+
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "Batch summarization failed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add focused component coverage for `BatchSummarizeButton` terminal Trigger.dev run states
- verify successful completed runs show final progress and success toast
- verify timed-out runs surface as terminal failures through the SDK boolean helpers

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked: `doppler run -- next build` fails in this workspace because no Doppler project/fallback file is configured)*
