### PR TITLE
[codex] test: cover notifications event helper

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  dispatchNotificationsChanged,
+  NOTIFICATIONS_CHANGED_EVENT,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does nothing during server-side execution when window is unavailable", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(() => dispatchNotificationsChanged([10, 11])).not.toThrow();
+  });
+
+  it("dispatches the base payload without an action discriminator", () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+
+    dispatchNotificationsChanged([10, 11]);
+
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    const event = dispatchEvent.mock.calls[0][0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: string;
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [10, 11] });
+  });
+
+  it("dispatches mark-all events with the action discriminator", () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    const event = dispatchEvent.mock.calls[0][0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: string;
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+});


### PR DESCRIPTION
## Summary
- add direct unit coverage for `dispatchNotificationsChanged`
- pin the server-side no-op guard when `window` is unavailable
- assert both payload shapes used by inbox notification listeners

## Test plan
- [x] `bun run vitest run src/lib/__tests__/events.test.ts --coverage --coverage.include=src/lib/events.ts`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked locally: Doppler project/fallback secrets not configured in this worktree)*