### PR TITLE
[codex] test: cover notifications change event helper

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const globalWithWindow = globalThis as unknown as { window?: Window };
+const originalWindow = globalWithWindow.window;
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalWindow === undefined) {
+      globalWithWindow.window = undefined;
+    } else {
+      globalWithWindow.window = originalWindow;
+    }
+  });
+
+  it("dispatches the mark-all payload shape for inbox-wide read sync", async () => {
+    const dispatchEvent = vi.fn();
+    globalWithWindow.window = { dispatchEvent } as unknown as Window;
+
+    const { dispatchNotificationsChanged, NOTIFICATIONS_CHANGED_EVENT } =
+      await import("@/lib/events");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0][0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: "mark-all";
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+
+  it("no-ops when window is unavailable", async () => {
+    globalWithWindow.window = undefined;
+
+    const { dispatchNotificationsChanged } = await import("@/lib/events");
+
+    expect(() => dispatchNotificationsChanged([42])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add direct regression coverage for `dispatchNotificationsChanged`
- pin the new inbox `mark-all` payload shape used by notification sync
- verify the helper safely no-ops when `window` is unavailable

## Test plan
- [x] `bun test src/lib/__tests__/events.test.ts`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `doppler run --project contentgenie --config dev -- bunx next build`
