### PR TITLE
[codex] test: cover notifications helper gaps

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  NOTIFICATIONS_CHANGED_EVENT,
+  dispatchNotificationsChanged,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("no-ops during SSR when window is unavailable", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(() => dispatchNotificationsChanged([12], "mark-all")).not.toThrow();
+  });
+
+  it("dispatches an event with episode ids when no action is provided", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([12, 34]);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(event?.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect((event as CustomEvent).detail).toEqual({
+      episodeDbIds: [12, 34],
+    });
+  });
+
+  it("includes the action discriminator when provided", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    const event = dispatchSpy.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).toEqual({
+      episodeDbIds: [],
+      action: "mark-all",
+    });
+  });
+});

--- a/src/lib/__tests__/notifications-query.test.ts
+++ b/src/lib/__tests__/notifications-query.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCount = vi.fn();
+const mockEq = vi.fn((...args: unknown[]) => args);
+const mockAnd = vi.fn((...args: unknown[]) => args);
+
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "notifications.userId",
+    isRead: "notifications.isRead",
+    isDismissed: "notifications.isDismissed",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => mockAnd(...args),
+  eq: (...args: unknown[]) => mockEq(...args),
+}));
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("counts only unread and undismissed notifications for the user", async () => {
+    mockCount.mockResolvedValue(7);
+
+    const { countUnreadNotifications } =
+      await import("@/lib/notifications-query");
+    const total = await countUnreadNotifications("user-123");
+
+    expect(total).toBe(7);
+    expect(mockEq).toHaveBeenCalledWith("notifications.userId", "user-123");
+    expect(mockEq).toHaveBeenCalledWith("notifications.isRead", false);
+    expect(mockEq).toHaveBeenCalledWith("notifications.isDismissed", false);
+    expect(mockAnd).toHaveBeenCalledWith(
+      ["notifications.userId", "user-123"],
+      ["notifications.isRead", false],
+      ["notifications.isDismissed", false],
+    );
+    expect(mockCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "notifications.userId",
+        isRead: "notifications.isRead",
+        isDismissed: "notifications.isDismissed",
+      }),
+      [
+        ["notifications.userId", "user-123"],
+        ["notifications.isRead", false],
+        ["notifications.isDismissed", false],
+      ],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add direct unit coverage for `dispatchNotificationsChanged` payload shaping and SSR no-op behavior
- add direct unit coverage for `countUnreadNotifications` so the shared unread predicate stays pinned to `isRead=false && isDismissed=false`
- keep scope limited to the helper files introduced in the recent inbox/notifications change set

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked locally: Doppler project/secrets not configured in this worktree)*
