### PR TITLE
[codex] test: cover inbox notification helpers

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  NOTIFICATIONS_CHANGED_EVENT,
+  dispatchNotificationsChanged,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches a counts-only notifications event when no action is provided", () => {
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([10, 20]);
+
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    const event = dispatchEvent.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(event?.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect((event as CustomEvent).detail).toEqual({ episodeDbIds: [10, 20] });
+  });
+
+  it("includes the action in the dispatched event detail when provided", () => {
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    const event = dispatchEvent.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+});

--- a/src/lib/__tests__/notifications-query.test.ts
+++ b/src/lib/__tests__/notifications-query.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEq = vi.fn((...args: unknown[]) => ({ kind: "eq", args }));
+const mockAnd = vi.fn((...args: unknown[]) => ({ kind: "and", args }));
+const mockCount = vi.fn();
+
+vi.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => mockEq(...args),
+  and: (...args: unknown[]) => mockAnd(...args),
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "notifications.userId",
+    isRead: "notifications.isRead",
+    isDismissed: "notifications.isDismissed",
+  },
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts only unread and undismissed notifications for the given user", async () => {
+    mockCount.mockResolvedValue(7);
+
+    const { countUnreadNotifications } =
+      await import("@/lib/notifications-query");
+
+    await expect(countUnreadNotifications("user-123")).resolves.toBe(7);
+
+    expect(mockEq).toHaveBeenNthCalledWith(
+      1,
+      "notifications.userId",
+      "user-123",
+    );
+    expect(mockEq).toHaveBeenNthCalledWith(2, "notifications.isRead", false);
+    expect(mockEq).toHaveBeenNthCalledWith(
+      3,
+      "notifications.isDismissed",
+      false,
+    );
+    expect(mockAnd).toHaveBeenCalledWith(
+      { kind: "eq", args: ["notifications.userId", "user-123"] },
+      { kind: "eq", args: ["notifications.isRead", false] },
+      { kind: "eq", args: ["notifications.isDismissed", false] },
+    );
+    expect(mockCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "notifications.userId",
+        isRead: "notifications.isRead",
+        isDismissed: "notifications.isDismissed",
+      }),
+      {
+        kind: "and",
+        args: [
+          { kind: "eq", args: ["notifications.userId", "user-123"] },
+          { kind: "eq", args: ["notifications.isRead", false] },
+          { kind: "eq", args: ["notifications.isDismissed", false] },
+        ],
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for `dispatchNotificationsChanged` so counts-only and `mark-all` payloads stay pinned to the inbox event contract
- add a focused unread-query test to lock the shared `isRead=false && isDismissed=false` predicate introduced by the inbox rename refactor

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` *(blocked locally: Doppler project/config is not set in this worktree, so `doppler run -- next build` fails before Next.js starts)*
