### PR TITLE
test: cover notification helper contracts

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchNotificationsChanged,
+  NOTIFICATIONS_CHANGED_EVENT,
+} from "@/lib/events";
+
+describe("dispatchNotificationsChanged", () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.window = originalWindow;
+  });
+
+  it("dispatches the counts-only payload when no action is provided", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([10, 11]);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: "mark-all";
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [10, 11] });
+  });
+
+  it("dispatches the mark-all payload when action is provided", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0] as CustomEvent<{
+      episodeDbIds: number[];
+      action?: "mark-all";
+    }>;
+    expect(event.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+
+  it("is a no-op when window is unavailable", () => {
+    // @ts-expect-error test-only override for the runtime guard
+    globalThis.window = undefined;
+
+    expect(() => dispatchNotificationsChanged([42], "mark-all")).not.toThrow();
+  });
+});

--- a/src/lib/__tests__/notifications-query.test.ts
+++ b/src/lib/__tests__/notifications-query.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { notifications } from "@/db/schema";
+
+const mockCount = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "notifications.userId",
+    isRead: "notifications.isRead",
+    isDismissed: "notifications.isDismissed",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args: unknown[]) => ({ kind: "and", args })),
+  eq: vi.fn((...args: unknown[]) => ({ kind: "eq", args })),
+}));
+
+import { countUnreadNotifications } from "@/lib/notifications-query";
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts only rows that match the unread-and-not-dismissed predicate", async () => {
+    mockCount.mockResolvedValue(6);
+
+    const result = await countUnreadNotifications("user-123");
+
+    expect(result).toBe(6);
+    expect(mockCount).toHaveBeenCalledWith(notifications, {
+      kind: "and",
+      args: [
+        { kind: "eq", args: ["notifications.userId", "user-123"] },
+        { kind: "eq", args: ["notifications.isRead", false] },
+        { kind: "eq", args: ["notifications.isDismissed", false] },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add direct unit coverage for `dispatchNotificationsChanged` payload variants and its no-window guard
- add direct unit coverage for `countUnreadNotifications` so the shared unread predicate stays pinned to `isRead=false && isDismissed=false`
- keep scope limited to recent inbox/notification helper paths introduced by the `/inbox` work

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [ ] `bun run build` _(blocked locally: Doppler is not configured in this worktree; `doppler run -- next build` failed with "You must specify a project" and no fallback file)_
