### PR TITLE
test: cover inbox notification helper contracts

### DIFF
--- a/src/lib/__tests__/events.test.ts
+++ b/src/lib/__tests__/events.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("dispatchNotificationsChanged", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatches the base event payload without an action", async () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const { NOTIFICATIONS_CHANGED_EVENT, dispatchNotificationsChanged } =
+      await import("@/lib/events");
+
+    dispatchNotificationsChanged([11, 22]);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]?.[0];
+    expect(event).toBeInstanceOf(CustomEvent);
+    expect(event?.type).toBe(NOTIFICATIONS_CHANGED_EVENT);
+    expect((event as CustomEvent).detail).toEqual({ episodeDbIds: [11, 22] });
+  });
+
+  it("includes the mark-all action when provided", async () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const { dispatchNotificationsChanged } = await import("@/lib/events");
+
+    dispatchNotificationsChanged([], "mark-all");
+
+    const event = dispatchSpy.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).toEqual({ episodeDbIds: [], action: "mark-all" });
+  });
+
+  it("is a no-op during server-side execution", async () => {
+    vi.stubGlobal("window", undefined);
+    const { dispatchNotificationsChanged } = await import("@/lib/events");
+
+    expect(() => dispatchNotificationsChanged([5], "mark-all")).not.toThrow();
+  });
+});

--- a/src/lib/__tests__/notifications-query.test.ts
+++ b/src/lib/__tests__/notifications-query.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCount = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    $count: (...args: unknown[]) => mockCount(...args),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  notifications: {
+    userId: "notifications.userId",
+    isRead: "notifications.isRead",
+    isDismissed: "notifications.isDismissed",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args: unknown[]) => ({ _op: "and", args })),
+  eq: vi.fn((...args: unknown[]) => ({ _op: "eq", args })),
+}));
+
+describe("countUnreadNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts only unread and non-dismissed rows for the given user", async () => {
+    mockCount.mockResolvedValue(6);
+
+    const { and, eq } = await import("drizzle-orm");
+    const { notifications } = await import("@/db/schema");
+    const { countUnreadNotifications } =
+      await import("@/lib/notifications-query");
+
+    await expect(countUnreadNotifications("user_123")).resolves.toBe(6);
+
+    expect(eq).toHaveBeenCalledWith(notifications.userId, "user_123");
+    expect(eq).toHaveBeenCalledWith(notifications.isRead, false);
+    expect(eq).toHaveBeenCalledWith(notifications.isDismissed, false);
+    expect(and).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _op: "eq",
+        args: [notifications.userId, "user_123"],
+      }),
+      expect.objectContaining({
+        _op: "eq",
+        args: [notifications.isRead, false],
+      }),
+      expect.objectContaining({
+        _op: "eq",
+        args: [notifications.isDismissed, false],
+      }),
+    );
+    expect(mockCount).toHaveBeenCalledWith(
+      notifications,
+      expect.objectContaining({ _op: "and" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add direct coverage for the shared unread notifications count helper
- add direct coverage for notifications-changed event payload dispatch, including mark-all
- keep scope limited to the recent inbox/notifications rename follow-up helper contracts

## Test plan
- [x] bun run test src/lib/__tests__/notifications-query.test.ts src/lib/__tests__/events.test.ts
- [x] bun run format:check
- [x] bun run lint
- [x] bun run test
- [ ] bun run build (blocked: Doppler project/secrets unavailable in this worktree)
