### PR TITLE
refactor: Consolidate notification mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Notification mutations now share one user-scoped update helper and explicitly use the canonical `ActionResult` envelope, keeping ownership checks and client-facing action contracts aligned.
 - Trending topics trigger task: `MAX_EPISODES` lowered from 500 to 200, input field switched from `keyTakeaways` to `summary` for richer clustering context, and the LLM call now passes `maxTokens: 16000` so reasoning models (e.g. GLM-5.1) have headroom after chain-of-thought.
 - Podcast detail page now loads up to 200 episodes (raised from 20 for PodcastIndex-sourced and 50 for RSS-sourced) and supports client-side title search within the loaded window (#291)
 - Dashboard Trending Topics card redesigned as a vertical list with topic name, AI description (2-line clamp), episode count, and per-row link to `/trending/<slug>` (#281)

--- a/src/app/actions/__tests__/notifications.test.ts
+++ b/src/app/actions/__tests__/notifications.test.ts
@@ -113,8 +113,10 @@ describe("notification server actions", () => {
       const { markNotificationRead } =
         await import("@/app/actions/notifications");
       const result = await markNotificationRead(1);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("You must be signed in");
+      expect(result).toEqual({
+        success: false,
+        error: "You must be signed in",
+      });
     });
 
     it("marks notification as read for the owning user", async () => {
@@ -138,8 +140,10 @@ describe("notification server actions", () => {
       const { markNotificationRead } =
         await import("@/app/actions/notifications");
       const result = await markNotificationRead(999);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Notification not found");
+      expect(result).toEqual({
+        success: false,
+        error: "Notification not found",
+      });
     });
   });
 
@@ -372,24 +376,30 @@ describe("notification server actions", () => {
       const { dismissNotification } =
         await import("@/app/actions/notifications");
       const result = await dismissNotification(1);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("You must be signed in");
+      expect(result).toEqual({
+        success: false,
+        error: "You must be signed in",
+      });
     });
 
     it("returns error for non-integer id", async () => {
       const { dismissNotification } =
         await import("@/app/actions/notifications");
       const result = await dismissNotification(1.5);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Invalid notification id");
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid notification id",
+      });
     });
 
     it("returns error for id <= 0", async () => {
       const { dismissNotification } =
         await import("@/app/actions/notifications");
       const result = await dismissNotification(0);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Invalid notification id");
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid notification id",
+      });
     });
 
     it("dismisses notification and returns success", async () => {
@@ -414,8 +424,10 @@ describe("notification server actions", () => {
       const { dismissNotification } =
         await import("@/app/actions/notifications");
       const result = await dismissNotification(999);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Notification not found");
+      expect(result).toEqual({
+        success: false,
+        error: "Notification not found",
+      });
     });
 
     it("scopes update to userId (and() called with userId condition)", async () => {

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema";
 import { countUnreadNotifications } from "@/lib/notifications-query";
 import { POSTGRES_MAX_INT as MAX_SERIAL_ID } from "@/lib/postgres-limits";
+import type { ActionResult } from "@/types/action-result";
 
 export type NotificationGroup =
   | { kind: "episodes_since_last_seen"; count: number; sinceIso: string }
@@ -33,6 +34,27 @@ type PodcastGroupRow = {
   podcastTitle: string;
   count: number;
 };
+
+type NotificationStateUpdate = { isRead: true } | { isDismissed: true };
+
+async function updateOwnedNotification(
+  userId: string,
+  notificationId: number,
+  update: NotificationStateUpdate,
+): Promise<boolean> {
+  const result = await db
+    .update(notifications)
+    .set(update)
+    .where(
+      and(
+        eq(notifications.id, notificationId),
+        eq(notifications.userId, userId),
+      ),
+    )
+    .returning({ id: notifications.id });
+
+  return result.length > 0;
+}
 
 export async function getNotificationSummary(): Promise<NotificationSummary> {
   const { userId } = await auth();
@@ -238,7 +260,9 @@ export async function getUnreadCount(): Promise<number> {
   return countUnreadNotifications(userId);
 }
 
-export async function markNotificationRead(notificationId: number) {
+export async function markNotificationRead(
+  notificationId: number,
+): Promise<ActionResult> {
   const { userId } = await auth();
   if (!userId) {
     return { success: false, error: "You must be signed in" };
@@ -248,18 +272,10 @@ export async function markNotificationRead(notificationId: number) {
   }
 
   try {
-    const result = await db
-      .update(notifications)
-      .set({ isRead: true })
-      .where(
-        and(
-          eq(notifications.id, notificationId),
-          eq(notifications.userId, userId),
-        ),
-      )
-      .returning({ id: notifications.id });
-
-    if (result.length === 0) {
+    const wasUpdated = await updateOwnedNotification(userId, notificationId, {
+      isRead: true,
+    });
+    if (!wasUpdated) {
       return { success: false, error: "Notification not found" };
     }
 
@@ -270,7 +286,7 @@ export async function markNotificationRead(notificationId: number) {
   }
 }
 
-export async function markAllNotificationsRead() {
+export async function markAllNotificationsRead(): Promise<ActionResult> {
   const { userId } = await auth();
   if (!userId) {
     return { success: false, error: "You must be signed in" };
@@ -294,7 +310,9 @@ export async function markAllNotificationsRead() {
   }
 }
 
-export async function dismissNotification(notificationId: number) {
+export async function dismissNotification(
+  notificationId: number,
+): Promise<ActionResult> {
   const { userId } = await auth();
   if (!userId) {
     return { success: false, error: "You must be signed in" };
@@ -304,18 +322,10 @@ export async function dismissNotification(notificationId: number) {
   }
 
   try {
-    const result = await db
-      .update(notifications)
-      .set({ isDismissed: true })
-      .where(
-        and(
-          eq(notifications.id, notificationId),
-          eq(notifications.userId, userId),
-        ),
-      )
-      .returning({ id: notifications.id });
-
-    if (result.length === 0) {
+    const wasUpdated = await updateOwnedNotification(userId, notificationId, {
+      isDismissed: true,
+    });
+    if (!wasUpdated) {
       return { success: false, error: "Notification not found" };
     }
 
@@ -391,7 +401,7 @@ export async function getEpisodeTopics(
 export async function updateNotificationPreferences(prefs: {
   digestFrequency?: "realtime" | "daily" | "weekly";
   pushEnabled?: boolean;
-}) {
+}): Promise<ActionResult> {
   const { userId } = await auth();
   if (!userId) {
     return { success: false, error: "You must be signed in" };


### PR DESCRIPTION
## Summary

- consolidate the duplicated user-scoped notification update query behind one typed helper
- make notification mutation contracts explicit with the shared `ActionResult` envelope
- tighten error-path tests to assert the complete action response and document the maintainability change

This keeps the ownership/IDOR predicate in one place while preserving authentication, validation, database behavior, and client-visible error messages. The smaller mutation surface is easier for future agents to inspect and modify safely.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test` (3,363 passed, 56 skipped)
- [x] `bunx tsc --noEmit`
- [ ] `bun run build` — blocked before compilation because this fresh worktree has no Doppler project/fallback configuration
- [x] `bunx next build` compiled successfully and passed Next.js type validation; static prerender then stopped on the expected missing Clerk/Neon environment variables

No UI behavior changed, so browser verification is not applicable.